### PR TITLE
Scale rumble by imgui rumble intensity

### DIFF
--- a/src/core1/ba_motor.c
+++ b/src/core1/ba_motor.c
@@ -169,15 +169,20 @@ void baMotor_init(void) {
 
 void __baMotor_80250D8C(void){}
 
+extern f32 port_getRumbleScale(void); // [port] 0.0–1.0 from ImGui rumble intensity
+
 void baMotor_80250D94(f32 arg0, f32 arg1, f32 arg2){
     f32 f4;
     if(arg2 != 0.0f && D_802823AC){
         if(func_802E4A08() == 0){
             if(!(0.1 < D_80282420 - D_80282424) || !(arg0 + arg1 < D_80282428 + D_8028242C)){
+                // [port] Scale intensity by ImGui rumble setting.
+                // Original N64 values are ~50% of max (duty cycling a binary motor).
+                f32 scale = port_getRumbleScale() * 2.0f;
                 D_80282420 = arg2;
                 D_80282424 = 0.0f;
-                D_80282428 = arg0;
-                D_8028242C = arg1;
+                D_80282428 = MIN(arg0 * scale, 1.0f);
+                D_8028242C = MIN(arg1 * scale, 1.0f);
             }
         }
     }

--- a/src/port/ShipUtils.cpp
+++ b/src/port/ShipUtils.cpp
@@ -239,3 +239,25 @@ extern "C" void port_setMapDebugTitle(int map_id) {
     }
 #endif
 }
+
+// [port] Returns 0.0–1.0 rumble intensity scale from the ImGui controller config.
+// Uses the average of low/high frequency percentages for the given controller port.
+extern "C" float port_getRumbleScale(void) {
+    auto ctx = Ship::Context::GetInstance();
+    if (!ctx) {
+        return 0.5f;
+    }
+
+    auto controller = ctx->GetControlDeck()->GetControllerByPort(0);
+    if (!controller) {
+        return 0.5f;
+    }
+
+    auto rumble = controller->GetRumble();
+    for (auto& [id, mapping] : rumble->GetAllRumbleMappings()) {
+        float low = mapping->GetLowFrequencyIntensityPercentage() / 100.0f;
+        float high = mapping->GetHighFrequencyIntensityPercentage() / 100.0f;
+        return (low + high) * 0.5f;
+    }
+    return 1.0f;
+}


### PR DESCRIPTION
BK's rumble motor simulates variable intensity by duty-cycling a digital on/off switch every few game frames. Because the SDL rumble intensity set by ImGui only affects the peak of each 'on' pulse, changes to the slider are barely noticeable. To compensate, scale BK's intensity values by the ImGui setting so the duty cycle rate itself changes — lower slider = fewer on-frames, higher slider = more on-frames, up to constant-on at 100%.

Tested in GV with Sandybutt's pyramid raising.