### PR TITLE
Widescreen culling fix and enhancement draw distance

### DIFF
--- a/src/core1/viewport.c
+++ b/src/core1/viewport.c
@@ -271,7 +271,7 @@ void viewport_setFrustumPlanes(f32 arg0[4], f32 arg1[4], f32 arg2[4], f32 arg3[4
 }
 
 bool viewport_isBoundingBoxInFrustum(f32 min[3], f32 max[3]) {
-    
+
     if (((sViewportFrustumPlanes[0][0] * min[0] + sViewportFrustumPlanes[0][1] * min[1] + sViewportFrustumPlanes[0][2] * min[2] + sViewportFrustumPlanes[0][3]) >= 0.0f) &&
         ((sViewportFrustumPlanes[0][0] * min[0] + sViewportFrustumPlanes[0][1] * min[1] + sViewportFrustumPlanes[0][2] * max[2] + sViewportFrustumPlanes[0][3]) >= 0.0f) &&
         ((sViewportFrustumPlanes[0][0] * min[0] + sViewportFrustumPlanes[0][1] * max[1] + sViewportFrustumPlanes[0][2] * min[2] + sViewportFrustumPlanes[0][3]) >= 0.0f) &&
@@ -343,9 +343,8 @@ bool viewport_cube_isInFrustum2(Cube *cube) {
     rel_pos[1] = (f32) ((cube->y * 1000) + 500) - sViewportPosition[1];
     rel_pos[2] = (f32) ((cube->z * 1000) + 500) - sViewportPosition[2];
 
-    // [port] Draw distance cutoff — skip when extended draw distance is enabled
 #ifdef ENHANCEMENT
-    // TODO: replace with CVar-driven multiplier
+    // Extended draw distance: bypass cube distance check
 #else
     if (LENGTH_SQ_VEC3F(rel_pos) > 1.6e7f) {
         return false;
@@ -365,6 +364,9 @@ bool viewport_cube_isInFrustum2(Cube *cube) {
 
 // viewport_distanceFromPlane ?
 bool viewport_func_8024DB50(f32 pos[3], f32 distance) {
+#ifdef ENHANCEMENT
+    return true; // Extended draw distance: bypass frustum distance check
+#endif
     f32 delta[3];
     s32 i;
 

--- a/src/core2/actor_array.c
+++ b/src/core2/actor_array.c
@@ -6,6 +6,9 @@
 
 #include "prop.h"
 
+extern s32 D_80370990; // [port] original frustum result from modelRender_draw
+extern s32 port_getViewportWidth(void);
+
 #define DIST_SQ_VEC3F(v1, v2) ((v1[0] - v2[0])*(v1[0] - v2[0]) + (v1[1] - v2[1])*(v1[1] - v2[1]) + (v1[2] - v2[2])*(v1[2] - v2[2]))
 
 extern void func_802D7124(Actor *, f32);
@@ -145,7 +148,9 @@ void actor_predrawMethod(Actor *this){
         this->unkF4_29 = NOT(this->unkF4_29);
     }//L80325594
 
-    if(this->unk130){
+    // [port] In widescreen, only run the predraw callback if the actor would
+    // have been visible in the original 4:3 frustum, preserving game logic.
+    if(this->unk130 && (port_getViewportWidth() <= 320 || D_80370990)){
         this->unk130(this);
     }
 
@@ -192,8 +197,12 @@ void func_80325760(Actor *this) {
     func_8033A45C(2, 4);
 }
 
+// [port] In widescreen, actors outside the 4:3 frustum are still drawn but
+// should not be marked as visible for game logic purposes.
 void actor_postdrawMethod(ActorMarker *marker){
-    marker->unk14_21 = true;
+    if (port_getViewportWidth() <= 320 || D_80370990) {
+        marker->unk14_21 = true;
+    }
 }
 
 void func_803257A4(ActorMarker *marker){

--- a/src/core2/actor_cubebounds.c
+++ b/src/core2/actor_cubebounds.c
@@ -437,11 +437,16 @@ void func_80302C94(Gfx **gfx, Mtx **mtx, Vtx **vtx) {
     }
 
     for(i = 0; i < 3; i++){
-        if(vp_cube_indices[i] - sp44[i] >= 5){
-            sp44[i] = vp_cube_indices[i] - 4;
+#ifdef ENHANCEMENT
+        int width = sCubeList.width[i]; // Extended draw distance: full map
+#else
+        int width = 4;
+#endif
+        if(vp_cube_indices[i] - sp44[i] > width){
+            sp44[i] = vp_cube_indices[i] - width;
         }
-        if(sp38[i] - vp_cube_indices[i] >= 5){
-            sp38[i] = vp_cube_indices[i] + 4;
+        if(sp38[i] - vp_cube_indices[i] > width){
+            sp38[i] = vp_cube_indices[i] + width;
         }
     }
     if (sCubeList.unk3C != NULL) {

--- a/src/core2/model/render.c
+++ b/src/core2/model/render.c
@@ -925,6 +925,7 @@ void func_80338CD0(Gfx **gfx, Mtx **mtx, void *arg2){
 }
 
 //CmdD_DRAW_DISTANCE
+extern s32 port_getViewportWidth(void); // [port]
 void func_80338DCC(Gfx ** gfx, Mtx ** mtx, void *arg2){
     f32 sp2C[3];
     f32 sp20[3];
@@ -933,11 +934,10 @@ void func_80338DCC(Gfx ** gfx, Mtx ** mtx, void *arg2){
         sp2C[0] = (f32)cmd->unk8[0] * modelRenderScale;
         sp2C[1] = (f32)cmd->unk8[1] * modelRenderScale;
         sp2C[2] = (f32)cmd->unk8[2] * modelRenderScale;
-
         sp20[0] = (f32)cmd->unkE[0] * modelRenderScale;
         sp20[1] = (f32)cmd->unkE[1] * modelRenderScale;
         sp20[2] = (f32)cmd->unkE[2] * modelRenderScale;
-        if(viewport_isBoundingBoxInFrustum(sp2C, sp20)){
+        if(port_getViewportWidth() > 320 || viewport_isBoundingBoxInFrustum(sp2C, sp20)){
             func_80339124(gfx, mtx, (BKGeoList*)((u8*)cmd + cmd->unk14));
         }
     }
@@ -1035,6 +1035,13 @@ BKModelBin *modelRender_draw(Gfx **gfx, Mtx **mtx, f32 position[3], f32 rotation
         modelRender_reset();
         return 0;
     }
+
+#ifdef ENHANCEMENT
+    // Extended draw distance: disable clipping, set huge distance thresholds
+    D_80383710 = false;
+    D_8038370C = 1e30f;
+    D_80383708 = 1e30f;
+#endif
 
     D_80370990 = 0;
     viewport_getPosition_vec3f(modelRenderCameraPosition);

--- a/src/core2/sprite/render.c
+++ b/src/core2/sprite/render.c
@@ -38,6 +38,9 @@ void func_80344124(void){
 }
 
 void func_80344138(BKSpriteDisplayData *self, s32 frame, s32 mirrored, f32 position[3], f32 scale[3], Gfx **gfx, Mtx **mtx) {
+#ifdef ENHANCEMENT
+    D_803858B0 = true; // Extended draw distance: disable sprite distance cull
+#endif
     f32 sp6C[3];
     f32 sp60[3];
     f32 temp_f14;


### PR DESCRIPTION
### Without ENHANCEMENT (default):

- Widescreen frustum fix in `func_80338DCC (CmdD)` — prevents edge pop-in at wide aspect ratios
- Everything else is original N64 behavior

### With ENHANCEMENT:

`viewport_func_8024DB50` returns true — bypass distance frustum check
`viewport_cube_isInFrustum2` skips the 1.6e7 distance cutoff — all cubes visible
`func_80302C94` expands cube range from 4 to full map width — all cubes processed
`modelRender_draw` sets `D_80383708=1e30`, `D_8038370C=1e30`, `D_80383710=false` — no model distance clipping
`func_80344138` sets `D_803858B0=true` — sprites visible at any distance

What it does NOT change (preserves game logic):

- Actor AI/behavior distance (`func_80329530`, `func_803296D8`) — actors still activate at original range
- Actor spawn/despawn — controlled by the cube system which now shows them, but their behavior only runs when close
- `D_80370990` still records the original frustum result — actor callbacks (unk130, unk14_21) use this for game logic

Thanks ProxySaw: https://github.com/garrettjoecox/ProxyBK_RecompMods/blob/master/packages/ExtendedDrawDistance/src/extended_draw_distance.c