### PR TITLE
Properly flush pending params

### DIFF
--- a/src/core1/audio/n_synthesizer.c
+++ b/src/core1/audio/n_synthesizer.c
@@ -248,8 +248,18 @@ void _n_collectPVoices()
     }
 }
 
-void _n_freePVoice(N_PVoice *pvoice) 
+void _n_freePVoice(N_PVoice *pvoice)
 {
+    // [port] Flush pending params to prevent pool exhaustion cascade.
+    ALParam *p = pvoice->em_ctrlList;
+    while (p) {
+        ALParam *next = p->next;
+        __n_freeParam(p);
+        p = next;
+    }
+    pvoice->em_ctrlList = NULL;
+    pvoice->em_ctrlTail = NULL;
+
     /*
      * move the voice from the allocated list to the lame list
      */


### PR DESCRIPTION
When the param pool runs low, `n_alSynStopVoice`/`n_alSynFreeVoice` fail silently (`ALFailIf` returns early)
- Physical voices never get freed back to pFreeList
- All future voice allocs must steal, which allocates 2 more params each
- This snowballs until the pool is completely exhausted

This fixes the cascade failure affecting long play sessions.