### PR TITLE
Fix jiggy dance camera, frustum culling, and linux compile errors

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -470,6 +470,7 @@ option(USE_STANDALONE "Build as a standalone executable" OFF)
 option(BUILD_STORMLIB "Build with StormLib support" OFF)
 
 option(BUILD_BK64 "Build with Banjo-Kazooie support" ON)
+option(BUILD_PM64 "Build with Paper Mario support" OFF)
 option(BUILD_SM64 "Build with Super Mario 64 support" OFF)
 option(BUILD_MK64 "Build with Mario Kart 64 support" OFF)
 option(BUILD_SF64 "Build with Star Fox 64 support" OFF)

--- a/include/bsint.h
+++ b/include/bsint.h
@@ -2,7 +2,8 @@
 #define __BS_INT_H__
 
 #include <ultra64.h>
-#include "functions.h"
+// [port] This shouldn't be here
+// #include "functions.h"
 #include "variables.h"
 
 typedef void (*bsStateMethod)(void);  

--- a/src/core1/viewport.c
+++ b/src/core1/viewport.c
@@ -222,19 +222,20 @@ void viewport_unused_pushVpScaleAndTranslation(f32 scale_x, f32 scale_y, f32 tra
 }
 
 void viewport_update(void) {
-    // [port] Widen the left/right frustum planes for widescreen so objects
-    // at the horizontal edges aren't culled prematurely.
-    f32 frustumX = 89.21774f;
-    f32 frustumZ = 45.168514251708984f;
-    if (port_getViewportWidth() > 320) {
-        static const f32 vanillaAspect = 1.35185182f;
-        f32 aspectScale = sViewportAspect / vanillaAspect;
-        frustumX *= aspectScale * 1.1f;
-    }
+    // [port] Compute frustum plane normals from the actual FOV and aspect ratio.
+    f32 halfFovYRad = (sViewportFOVy * 0.5f) * (M_PI / 180.0f);
+    f32 halfFovXRad = atanf(tanf(halfFovYRad) * sViewportAspect);
+    // Scale to match the vanilla magnitude (100.0 unnormalized length)
+    f32 mag = sqrtf(89.21774f * 89.21774f + 45.168514f * 45.168514f);
+    f32 frustumX = sinf(halfFovXRad) * mag;
+    f32 frustumZ = cosf(halfFovXRad) * mag;
     func_80256E24(sViewportFrustumPlanes[0], sViewportRotation[0], sViewportRotation[1], -frustumX, 0.0f, frustumZ);
     func_80256E24(sViewportFrustumPlanes[1], sViewportRotation[0], sViewportRotation[1], frustumX, 0.0f, frustumZ);
-    func_80256E24(sViewportFrustumPlanes[2], sViewportRotation[0], sViewportRotation[1], 0.0f, 93.9692611694336f, 34.20201110839844f);
-    func_80256E24(sViewportFrustumPlanes[3], sViewportRotation[0], sViewportRotation[1], 0.0f, -93.9692611694336f, 34.20201110839844f);
+    // [port] Pad top/bottom planes slightly to reduce pop-in during vertical cam movement.
+    f32 frustumY = 93.9692611694336f * 1.15f;
+    f32 frustumZv = 34.20201110839844f;
+    func_80256E24(sViewportFrustumPlanes[2], sViewportRotation[0], sViewportRotation[1], 0.0f, frustumY, frustumZv);
+    func_80256E24(sViewportFrustumPlanes[3], sViewportRotation[0], sViewportRotation[1], 0.0f, -frustumY, frustumZv);
 
     ml_vec3f_normalize(sViewportFrustumPlanes[0]);
     ml_vec3f_normalize(sViewportFrustumPlanes[1]);

--- a/src/core2/bs/player_spawn.c
+++ b/src/core2/bs/player_spawn.c
@@ -951,6 +951,16 @@ void func_8029CCC4(void){
     if(jiggyscore_total() == 100 && fileProgressFlag_get(FILEPROG_FC_DEFEAT_GRUNTY)){
         func_8028F918(2);
     }
+    // [port] When skipping the jiggy dance:
+    // - Restore camera type (set to 0xC by __baMarker_8028B848 for first/10th jiggy dialog)
+    // - Don't touch the ambience counter or music fade — the jinjo or other spawner
+    //   may have already decremented the counter, and the timed restore would cause
+    //   a double-increment. Just play the jingle and let the spawner handle cleanup.
+    if (CVarGetInteger(CVAR_ENHANCEMENT("Cutscenes.SkipJiggyDance"), 0)) {
+        func_80291548();
+        coMusicPlayer_playMusic(COMUSIC_D_JINGLE_JIGGY_COLLECTED, -1);
+        return;
+    }
     core1_ce60_incOrDecCounter(false);
     func_8025A55C(0, 4000, 0xC);
     coMusicPlayer_playMusic(COMUSIC_D_JINGLE_JIGGY_COLLECTED, -1);

--- a/src/core2/model/render.c
+++ b/src/core2/model/render.c
@@ -925,7 +925,7 @@ void func_80338CD0(Gfx **gfx, Mtx **mtx, void *arg2){
 }
 
 //CmdD_DRAW_DISTANCE
-extern s32 port_getViewportWidth(void);
+extern f32 GameEngine_GetAspectRatio(void);
 void func_80338DCC(Gfx ** gfx, Mtx ** mtx, void *arg2){
     f32 sp2C[3];
     f32 sp20[3];
@@ -937,9 +937,10 @@ void func_80338DCC(Gfx ** gfx, Mtx ** mtx, void *arg2){
         sp20[0] = (f32)cmd->unkE[0] * modelRenderScale;
         sp20[1] = (f32)cmd->unkE[1] * modelRenderScale;
         sp20[2] = (f32)cmd->unkE[2] * modelRenderScale;
-        if(port_getViewportWidth() > 320 || viewport_isBoundingBoxInFrustum(sp2C, sp20)){
-            func_80339124(gfx, mtx, (BKGeoList*)((u8*)cmd + cmd->unk14));
-        }
+        // [port] The N64 bounding boxes in CmdD_DRAW_DISTANCE are too conservative
+        // for the port's viewport (292x216 -> 320x240 at 4:3). Extend to all aspect
+        //ratios since the port always renders at a higher effective resolution.
+        func_80339124(gfx, mtx, (BKGeoList*)((u8*)cmd + cmd->unk14));
     }
 }
 


### PR DESCRIPTION
- Fix skip jiggy dance getting camera stuck by restoring camera type and playing jingle without touching ambience counter
- Compute frustum plane normals from actual FOV and aspect ratio instead of hardcoded widescreen hack; bypass CmdD_DRAW_DISTANCE bounding box check since the port always renders at higher effective resolution
- Add missing BUILD_PM64 CMake option and remove problematic functions.h include from bsint.h for linux builds