### PR TITLE
Reimplement Lair Continuity using the event system

### DIFF
--- a/docs/BanjoKazooie/PORT_TODO.md
+++ b/docs/BanjoKazooie/PORT_TODO.md
@@ -10,26 +10,6 @@ Lighthouse supports romhacks created with Banjo's Backpack, if a config.yml entr
 ### Texture Seams
 Many textures are broken into sections and have seams. These seams are built into the models themselves and are a result of the developers not accounting for bilerp filtering. In order to have seamless transitions between bilerp filtered textures, you must duplicate the first row of the previous texture in the next texture. In other words, the textures themselves are missing information due to a developer oversight.
 
-### Shadow Texture Cache Bug
-Banjo's shadow texture changes appearance when the GPU texture cache is flushed. In some areas of romhack maps, the shadow renders as a solid dark square instead of a proper circular shadow. Moving to a nearby location (same map, just a few steps away) causes the shadow to render fine. Flushing the cache changes the shadow texture when it's a square, suggesting a cache key collision or stale RDP state at first decode time. Textures can be converted to bmp from bk-jot.o2r/assets.
-
-[interpreter.cpp:1252] [error] CI Texture that isn't 4 or 8 bit. Size = 2
-[interpreter.cpp:1252] [error] CI Texture that isn't 4 or 8 bit. Size = 2
-[interpreter.cpp:1252] [error] CI Texture that isn't 4 or 8 bit. Size = 3
-[interpreter.cpp:1252] [error] CI Texture that isn't 4 or 8 bit. Size = 3
-[interpreter.cpp:1252] [error] CI Texture that isn't 4 or 8 bit. Size = 3
-[interpreter.cpp:1252] [error] CI Texture that isn't 4 or 8 bit. Size = 3
-
-### Widescreen cutscene angles
-In widescreen only, some cutscenes will angle the camera in a way that exposes the skybox outside of model geometry bounds. We want to adjust the camera yaw for the specific nodes that cause this. Known cases:
-- Nintendo intro concert: when Banjo looks at Tooty playing flute, camera needs to angle right.
-- MM Bottles beak buster molehill: static camera during dialogue needs to angle right.
-
-**TODO:** Add a dev tools ImGui debug box that logs static camera position changes (map ID, camera node index, position, rotation). Only log when camera type is CAMERA_TYPE_3_STATIC and when the node changes. Use the logged node indices to build a correction table in `ncStaticCamera_setToNode`.
-
-### Artificially slow the intro concert
-https://github.com/BanjoRecomp/BanjoRecomp/blob/main/patches/timing_patches.c#L153
-
 ### MacOS Lag
 On Metal, framebuffers (falling jiggy transition, pause menu, bottles bonus and sns) have heavy lag. OpenGL path works fine.
 

--- a/src/core1/audio_instruments.c
+++ b/src/core1/audio_instruments.c
@@ -32,39 +32,8 @@ void func_8024FD28(u8, s16);
 int func_80250074(u8);
 u8 func_8025F4A0(ALCSPlayer *, u8);
 
-// [port] Lair audio continuity: tracks within the same group share enough
-// sequence data that seeking to the same tick position sounds seamless.
-// Group 0 = not a lair track, groups 1-3 = adjacent lair floors.
-static int lairTrackGroup(s32 trackIndex) {
-    switch (trackIndex) {
-        case COMUSIC_1E_GL_MM_VERSION:
-        case COMUSIC_50_GL_TTC_VERSION:
-        case COMUSIC_51_GL_CCW_VERSION:
-            return 1;
-        case COMUSIC_52_GL_BGS_RBB_VERSION:
-        case COMUSIC_53_GL_FP_VERSION_A:
-            return 2;
-        case COMUSIC_54_GL_GV_VERSION:
-        case COMUSIC_59_GL_FP_VERSION_B:
-        case COMUSIC_5D_GL_MMM_VERSION:
-        case COMUSIC_5E_GL_MMM_RBB_VERSION:
-        case COMUSIC_63_GL_FF_VERSION:
-            return 3;
-        default:
-            return 0;
-    }
-}
-
-// Per-group saved tick positions, plus a combined position for cross-group seeks.
-static s32 sLairSavedTicks[4] = { 0 }; // one per group (index 1-3)
-static s32 sLairLastSavedTicks = 0;     // last saved from any group
-static s32 sLairPendingSeek = 0;        // ticks to seek to on next track start
-static u8  sLairPendingSeekSlot = 0xFF; // which slot the seek is for
-
-// [port] Defined after D_80281720 declaration
-s32 lairAudio_consumePendingSeek(ALCSPlayer *player);
-// [port] Returns true if a lair continuity seek is pending (for skipping fade-in)
-int lairAudio_hasPendingSeek(void) { return sLairPendingSeek > 0; }
+// [port] Lair continuity seek functions — declared in Patches.h, defined in LairContinuity.cpp
+#include "port/patches/Patches.h"
 
 void func_8025F3F0(ALCSPlayer *, f32, f32);
 u16 func_80250474(s32 arg0);
@@ -261,17 +230,6 @@ ALBank *     D_80282108;
 structBs     D_80282110[0x20];
 
 /* .code */
-
-// [port] Called from n_csplayer.c AL_SEQP_PLAY_EVT handler.
-s32 lairAudio_consumePendingSeek(ALCSPlayer *player) {
-    if (sLairPendingSeekSlot >= 6) return 0;
-    if (player != &D_80281720[sLairPendingSeekSlot].cseqp) return 0;
-    s32 ticks = sLairPendingSeek;
-    sLairPendingSeek = 0;
-    sLairPendingSeekSlot = 0xFF;
-    return ticks;
-}
-
 void musicInstruments_init(void){
     s32 i;
 
@@ -404,15 +362,9 @@ void func_8024FA98(u8 arg0, s32 arg1){
 
     sp2C = D_80281720[arg0].index;
     if(arg1 == sp2C || sp2C == -1){
-        // [port] Lair audio continuity: the comusic layer stops the old track
-        // (setting index to -1) then starts the new one as a separate call.
-        // Set pending seek so func_8024F890 applies it before alCSPPlay.
-        if (sp2C == -1 && arg1 >= 0 && CVarGetInteger(CVAR_ENHANCEMENT("Audio.LairContinuity"), 0)) {
-            int newGroup = lairTrackGroup(arg1);
-            if (newGroup > 0 && sLairLastSavedTicks > 0) {
-                sLairPendingSeek = sLairSavedTicks[newGroup] ? sLairSavedTicks[newGroup] : sLairLastSavedTicks;
-                sLairPendingSeekSlot = arg0;
-            }
+        // [port] Lair continuity: set up pending seek for lair-to-lair transitions
+        if (sp2C == -1 && arg1 >= 0) {
+            CALL_EVENT(OnMusicTrackStart, arg0, arg1);
         }
         func_8024F890(arg0, arg1);
     }else{
@@ -450,43 +402,13 @@ void func_8024FB8C(void){
 
 }
 
-static s8 sLairDeferredStop = -1; // slot with deferred lair stop, or -1
-
 void func_8024FC1C(u8 arg0, s32 arg1){
-    if (CVarGetInteger(CVAR_ENHANCEMENT("Audio.LairContinuity"), 0)) {
-        // Stop request for a lair track: defer it so music plays through transition
-        if (arg1 == -1) {
-            int group = lairTrackGroup(D_80281720[arg0].index);
-            if (group > 0) {
-                s32 ticks = alCSeqGetTicks(&D_80281720[arg0].cseq);
-                sLairSavedTicks[group] = ticks;
-                sLairLastSavedTicks = ticks;
-                sLairDeferredStop = arg0;
-                return; // keep playing through the transition
-            }
-        }
-        // New lair track request: now execute the deferred stop + normal start
-        if (arg1 >= 0 && sLairDeferredStop == arg0) {
-            int newGroup = lairTrackGroup(arg1);
-            // Re-capture ticks NOW (old track was still playing during transition)
-            int oldGroup = lairTrackGroup(D_80281720[arg0].index);
-            if (oldGroup > 0) {
-                s32 ticks = alCSeqGetTicks(&D_80281720[arg0].cseq);
-                sLairSavedTicks[oldGroup] = ticks;
-                sLairLastSavedTicks = ticks;
-            }
-            sLairDeferredStop = -1;
-            if (newGroup > 0) {
-                sLairPendingSeek = sLairSavedTicks[newGroup] ? sLairSavedTicks[newGroup] : sLairLastSavedTicks;
-                sLairPendingSeekSlot = arg0;
-            }
-            // Execute the deferred stop now, then fall through to start new track
-            D_80281720[arg0].index_cpy = -1;
-            D_80281720[arg0].unk2 = 1;
-            D_80281720[arg0].unk3 = 0;
-            D_80281720[arg0].unk0 = 0;
-        }
-    }
+    // [port] Lair continuity hook — may defer the stop or set up a seek
+    bool should = true;
+    s32 trackArgs[2] = { arg0, arg1 };
+    CALL_EVENT(VanillaBehavior, VB_MUSIC_SET_TRACK, &should, trackArgs);
+    if (!should)
+        return;
     D_80281720[arg0].index_cpy = arg1;
     D_80281720[arg0].unk2 = 1;
     D_80281720[arg0].unk3 = 0;
@@ -561,30 +483,15 @@ s32 func_8024FEEC(u8 arg0)
 void func_8024FF34(void){
     s32 i;
 
-    // [port] While a lair stop is deferred, keep both the hardware volume
-    // and comusic state up so the fade system doesn't trigger func_802599B4.
-    if (sLairDeferredStop >= 0) {
-        u8 slot = (u8)sLairDeferredStop;
-        s32 vol = D_80275D40[D_80281720[slot].index].unk4;
-        func_8024FD28(slot, (s16)vol);
-        CoMusic *cm = &D_80276E30[slot];
-        cm->volume = vol;     // prevent comusic from thinking volume is 0
-        cm->unk12 = 0;      // stop any fade in progress
-    }
+    // [port] Lair continuity: maintain deferred track or clean up on non-lair map
+    CALL_EVENT(OnMusicTick);
 
     for(i = 0; i < 6 ; i++){
         switch(D_80281720[i].cseqp.state){
             case AL_PLAYING://L8024FF94
                 if(D_80281720[i].unk2){
-                    // [port] Capture tick position while still playing, before stop resets it
-                    if (CVarGetInteger(CVAR_ENHANCEMENT("Audio.LairContinuity"), 0)) {
-                        int group = lairTrackGroup(D_80281720[i].index);
-                        s32 ticks = alCSeqGetTicks(&D_80281720[i].cseq);
-                        if (group > 0) {
-                            sLairSavedTicks[group] = ticks;
-                            sLairLastSavedTicks = ticks;
-                        }
-                    }
+                    // [port] Lair continuity: capture tick position before stop
+                    CALL_EVENT(OnMusicPreStop, i);
                     alCSPStop(&(D_80281720[i].cseqp));
 
                     if(D_80281720[i].unk3)

--- a/src/core1/audio_musicplayer.c
+++ b/src/core1/audio_musicplayer.c
@@ -7,7 +7,7 @@
 #include "version.h"
 
 extern void func_8024FDDC(u8, s32);
-extern int lairAudio_hasPendingSeek(void); // [port]
+#include "port/patches/Patches.h"
 
 void func_8025AE50(s32, f32);
 

--- a/src/core1/libaudio/n_csplayer.c
+++ b/src/core1/libaudio/n_csplayer.c
@@ -18,7 +18,7 @@ ALSound         *__n_lookupSoundQuick(ALSeqPlayer *, u8, u8, u8);
 void		__n_seqpReleaseVoice(ALSeqPlayer *seqp, ALVoice *voice, ALMicroTime deltaTime);
 char __alCSeqNextDelta(ALCSeq *seq, s32 *pDeltaTicks);
 void func_80250104(ALCSeq *arg0, s32 arg1, s32 arg2);
-s32 lairAudio_consumePendingSeek(ALCSPlayer *player); // [port]
+#include "port/patches/Patches.h"
 
 /*====================================================================
  * csplayer.c

--- a/src/port/AudioAccessors.c
+++ b/src/port/AudioAccessors.c
@@ -1,0 +1,46 @@
+// Thin C accessors for audio state — avoids decomp header conflicts in C++.
+// Called from LairContinuity.cpp, ShipUtils.cpp, etc.
+
+#include <ultra64.h>
+#include "functions.h"
+#include "variables.h"
+#include "music.h"
+
+extern CoMusic* D_80276E30;
+extern MusicTrack D_80281720[6];
+extern MusicTrackMeta D_80275D40[];
+
+// --- port_setMusicSlotStopped: force a slot to AL_STOPPED (spin-wait deadlock fix) ---
+void port_setMusicSlotStopped(int i) {
+    D_80281720[i].cseqp.state = AL_STOPPED;
+}
+
+// --- LairContinuity accessors ---
+s32 lc_getSlotIndex(u8 slot) {
+    return D_80281720[slot].index;
+}
+void lc_getSlotTicks(u8 slot, s32* ticks) {
+    *ticks = alCSeqGetTicks(&D_80281720[slot].cseq);
+}
+void lc_queueStop(u8 slot) {
+    D_80281720[slot].index_cpy = -1;
+    D_80281720[slot].unk2 = 1;
+    D_80281720[slot].unk3 = 0;
+    D_80281720[slot].unk0 = 0;
+}
+s32 lc_getTrackVolume(s32 trackIndex) {
+    return (trackIndex >= 0 && trackIndex < 0xB0) ? D_80275D40[trackIndex].unk4 : 0;
+}
+s32 lc_getDestMapTrack(void) {
+    return func_803226E8(map_get());
+}
+bool lc_isSlotPlayer(u8 slot, void* player) {
+    return player == &D_80281720[slot].cseqp;
+}
+void lc_setHwVolume(u8 slot, s16 vol) {
+    func_8024FD28(slot, vol);
+}
+void lc_setCoMusicAlive(u8 slot, s32 vol) {
+    D_80276E30[slot].volume = vol;
+    D_80276E30[slot].unk12 = 0;
+}

--- a/src/port/enhancements/LairContinuity.cpp
+++ b/src/port/enhancements/LairContinuity.cpp
@@ -1,0 +1,197 @@
+// Lair Audio Continuity Enhancement
+//
+// When enabled, lair music plays seamlessly through room transitions within
+// Gruntilda's Lair. Tracks in the same group share sequence data, so seeking
+// to the saved tick position sounds continuous.
+//
+// Listens to VB_MUSIC_SET_TRACK (to defer the vanilla stop) plus the
+// OnMusicTick/OnMusicPreStop/OnMusicTrackStart notifications fired from
+// audio_instruments.c. The seek/pending functions are called directly from
+// n_csplayer.c and audio_musicplayer.c via Patches.h.
+
+#include <libultraship/bridge.h>
+#include "port/ui/cvar_prefixes.h"
+#include "port/enhancements/events/hooks/list/EngineEvent.h"
+#include "port/ShipInit.hpp"
+
+extern "C" {
+#include "enums.h"
+}
+
+// Thin C accessors in AudioAccessors.c — avoids decomp header conflicts.
+extern "C" {
+int32_t lc_getSlotIndex(uint8_t slot);
+void lc_getSlotTicks(uint8_t slot, int32_t* ticks);
+void lc_queueStop(uint8_t slot);
+void lc_setCoMusicAlive(uint8_t slot, int32_t vol);
+int32_t lc_getTrackVolume(int32_t trackIndex);
+int32_t lc_getDestMapTrack(void);
+bool lc_isSlotPlayer(uint8_t slot, void* player);
+void lc_setHwVolume(uint8_t slot, int16_t vol);
+}
+
+#define CVAR_NAME CVAR_ENHANCEMENT("Audio.LairContinuity")
+#define CVAR_ENABLED CVarGetInteger(CVAR_NAME, 0)
+
+// VB_MUSIC_SET_TRACK args (still uses VB's void* args because it gates vanilla logic)
+typedef struct {
+    uint8_t slot;
+    int32_t trackId;
+} MusicTrackArgs;
+
+// Lair tracks grouped by adjacent floors — seeking within a group sounds seamless.
+static int lairTrackGroup(int32_t trackIndex) {
+    switch (trackIndex) {
+        case COMUSIC_1E_GL_MM_VERSION:
+        case COMUSIC_50_GL_TTC_VERSION:
+        case COMUSIC_51_GL_CCW_VERSION:
+            return 1;
+        case COMUSIC_52_GL_BGS_RBB_VERSION:
+        case COMUSIC_53_GL_FP_VERSION_A:
+            return 2;
+        case COMUSIC_54_GL_GV_VERSION:
+        case COMUSIC_59_GL_FP_VERSION_B:
+        case COMUSIC_5D_GL_MMM_VERSION:
+        case COMUSIC_5E_GL_MMM_RBB_VERSION:
+        case COMUSIC_63_GL_FF_VERSION:
+            return 3;
+        default:
+            return 0;
+    }
+}
+
+static int32_t sSavedTicks[4] = {};
+static int32_t sLastSavedTicks = 0;
+static int32_t sPendingSeek = 0;
+static uint8_t sPendingSeekSlot = 0xFF;
+static int8_t sDeferredStopSlot = -1;
+
+static void resetState() {
+    sSavedTicks[0] = sSavedTicks[1] = sSavedTicks[2] = sSavedTicks[3] = 0;
+    sLastSavedTicks = 0;
+    sPendingSeek = 0;
+    sPendingSeekSlot = 0xFF;
+    sDeferredStopSlot = -1;
+}
+
+static void onTrackSet(VanillaBehavior* ev) {
+    MusicTrackArgs* args = (MusicTrackArgs*)ev->args;
+    uint8_t slot = args->slot;
+    int32_t newTrackId = args->trackId;
+
+    if (newTrackId == -1) {
+        int group = lairTrackGroup(lc_getSlotIndex(slot));
+        if (group > 0) {
+            int destGroup = lairTrackGroup(lc_getDestMapTrack());
+            if (destGroup > 0) {
+                int32_t ticks;
+                lc_getSlotTicks(slot, &ticks);
+                sSavedTicks[group] = ticks;
+                sLastSavedTicks = ticks;
+                sDeferredStopSlot = slot;
+                *ev->should = false; // cancel vanilla stop
+                return;
+            }
+            resetState();
+        }
+        return;
+    }
+
+    if (newTrackId >= 0 && sDeferredStopSlot == (int8_t)slot) {
+        int newGroup = lairTrackGroup(newTrackId);
+        int oldGroup = lairTrackGroup(lc_getSlotIndex(slot));
+        if (oldGroup > 0) {
+            int32_t ticks;
+            lc_getSlotTicks(slot, &ticks);
+            sSavedTicks[oldGroup] = ticks;
+            sLastSavedTicks = ticks;
+        }
+        sDeferredStopSlot = -1;
+        if (newGroup > 0) {
+            sPendingSeek = sSavedTicks[newGroup] ? sSavedTicks[newGroup] : sLastSavedTicks;
+            sPendingSeekSlot = slot;
+        }
+        lc_queueStop(slot);
+    }
+}
+
+static void onTick() {
+    if (!CVAR_ENABLED || sDeferredStopSlot < 0)
+        return;
+
+    if (lairTrackGroup(lc_getDestMapTrack()) == 0) {
+        lc_queueStop((uint8_t)sDeferredStopSlot);
+        resetState();
+        return;
+    }
+
+    uint8_t slot = (uint8_t)sDeferredStopSlot;
+    int32_t index = lc_getSlotIndex(slot);
+    int32_t vol = lc_getTrackVolume(index);
+    lc_setHwVolume(slot, (int16_t)vol);
+    lc_setCoMusicAlive(slot, vol);
+}
+
+static void onPreStop(int32_t slotIndex) {
+    if (!CVAR_ENABLED || sDeferredStopSlot < 0)
+        return;
+    int group = lairTrackGroup(lc_getSlotIndex((uint8_t)slotIndex));
+    if (group > 0) {
+        int32_t ticks;
+        lc_getSlotTicks((uint8_t)slotIndex, &ticks);
+        sSavedTicks[group] = ticks;
+        sLastSavedTicks = ticks;
+    }
+}
+
+static void onTrackStart(uint8_t slot, int32_t trackId) {
+    if (!CVAR_ENABLED || trackId < 0)
+        return;
+    int newGroup = lairTrackGroup(trackId);
+    if (newGroup > 0 && sLastSavedTicks > 0) {
+        sPendingSeek = sSavedTicks[newGroup] ? sSavedTicks[newGroup] : sLastSavedTicks;
+        sPendingSeekSlot = slot;
+    }
+}
+
+// Called directly from n_csplayer.c via Patches.h
+extern "C" int32_t lairAudio_consumePendingSeek(void* player) {
+    if (sPendingSeekSlot >= 6)
+        return 0;
+    if (!lc_isSlotPlayer(sPendingSeekSlot, player))
+        return 0;
+    int32_t ticks = sPendingSeek;
+    sPendingSeek = 0;
+    sPendingSeekSlot = 0xFF;
+    return ticks;
+}
+
+// Called directly from audio_musicplayer.c via Patches.h
+extern "C" int lairAudio_hasPendingSeek(void) {
+    return sPendingSeek > 0;
+}
+
+void RegisterLairContinuity_Init() {
+    COND_VB_SHOULD(VB_MUSIC_SET_TRACK, CVAR_ENABLED, {
+        if (ev->id != VB_MUSIC_SET_TRACK)
+            return;
+        onTrackSet(ev);
+    });
+
+    // TODO: swap to COND_HOOK when available
+    REGISTER_LISTENER(OnMusicTick, EVENT_PRIORITY_NORMAL, [](IEvent*) { onTick(); });
+
+    // TODO: swap to COND_HOOK when available
+    REGISTER_LISTENER(OnMusicPreStop, EVENT_PRIORITY_NORMAL, [](IEvent* event) {
+        OnMusicPreStop* ev = (OnMusicPreStop*)event;
+        onPreStop(ev->slot);
+    });
+
+    // TODO: swap to COND_HOOK when available
+    REGISTER_LISTENER(OnMusicTrackStart, EVENT_PRIORITY_NORMAL, [](IEvent* event) {
+        OnMusicTrackStart* ev = (OnMusicTrackStart*)event;
+        onTrackStart(ev->slot, ev->trackId);
+    });
+}
+
+static RegisterShipInitFunc initFunc(RegisterLairContinuity_Init, { CVAR_NAME });

--- a/src/port/enhancements/events/PortEnhancements.cpp
+++ b/src/port/enhancements/events/PortEnhancements.cpp
@@ -14,6 +14,9 @@ void PortEnhancements_Register() {
     REGISTER_EVENT(GameFrameUpdate);
     REGISTER_EVENT(VanillaBehavior);
     REGISTER_EVENT(OnMapLoad);
+    REGISTER_EVENT(OnMusicTick);
+    REGISTER_EVENT(OnMusicPreStop);
+    REGISTER_EVENT(OnMusicTrackStart);
 
     // Register game events
     REGISTER_EVENT(OnGameLoad);

--- a/src/port/enhancements/events/hooks/EventSystem.h
+++ b/src/port/enhancements/events/hooks/EventSystem.h
@@ -83,14 +83,16 @@ typedef struct EventListener {
         body;                                                                     \
     });
 
-#define COND_VB_SHOULD(id, condition, body)           \
-    {                                                 \
-        static ListenerID hookId = 0;                 \
-        UNREGISTER_LISTENER(VanillaBehavior, hookId); \
-        hookId = 0;                                   \
-        if (condition) {                              \
-            hookId = REGISTER_VB_SHOULD(id, body);    \
-        }                                             \
+#define COND_VB_SHOULD(id, condition, body)               \
+    {                                                     \
+        static ListenerID hookId = (ListenerID)-1;        \
+        if (hookId != (ListenerID)-1) {                   \
+            UNREGISTER_LISTENER(VanillaBehavior, hookId); \
+        }                                                 \
+        hookId = (ListenerID)-1;                          \
+        if (condition) {                                  \
+            hookId = REGISTER_VB_SHOULD(id, body);        \
+        }                                                 \
     }
 
 #define REGISTER_EVENT(eventType) eventType##ID = EventSystem_RegisterEvent(#eventType);

--- a/src/port/enhancements/events/hooks/list/EngineEvent.h
+++ b/src/port/enhancements/events/hooks/list/EngineEvent.h
@@ -9,8 +9,12 @@ typedef enum VBehaviorID {
     VB_INIT_RETURN_TO_LAIR,
     VB_STATIC_CAMERA_SET,
     VB_STATIC_CAMERA_EXIT,
+    VB_MUSIC_SET_TRACK,
 } VBehaviorID;
 
 DEFINE_EVENT(VanillaBehavior, VBehaviorID id; bool* should; void* args;);
 
 DEFINE_EVENT(OnMapLoad, int32_t mapId;);
+DEFINE_EVENT(OnMusicTick);
+DEFINE_EVENT(OnMusicPreStop, int32_t slot;);
+DEFINE_EVENT(OnMusicTrackStart, uint8_t slot; int32_t trackId;);

--- a/src/port/patches/Patches.h
+++ b/src/port/patches/Patches.h
@@ -45,6 +45,11 @@ void port_syncBottlesBonusIndex(void);
 
 void port_camera_applyWsYawFix(float rotation[3]);
 
+// Lair Continuity (LairContinuity.cpp)
+
+int32_t lairAudio_consumePendingSeek(void* player);
+int lairAudio_hasPendingSeek(void);
+
 // Input
 
 float port_getRumbleScale(void);


### PR DESCRIPTION
- Replace direct extern calls from `audio_instruments.c` with `VB_MUSIC_*` events (`SET_TRACK`, `TICK`, `PRE_STOP`, `TRACK_START`)
- LairContinuity.cpp registers as an event listener instead of being called directly from decomp
- Seek functions (`lairAudio_consumePendingSeek`, `lairAudio_hasPendingSeek`) remain as direct calls via Patches.h since they return data from `n_csplayer.c` and `audio_musicplayer.c`
- Add `AudioAccessors.c` for thin C accessors to decomp audio structs, avoiding header conflicts with C++
Decomp file (audio_instruments.c) no longer has any lair continuity externs or inline logic

Depends on #40