### PR TITLE
Hook up quit/reset buttons, improve game stats, fix UI strings

### DIFF
--- a/src/core1/audio_instruments.c
+++ b/src/core1/audio_instruments.c
@@ -360,6 +360,7 @@ void func_8024FA98(u8 arg0, s32 arg1){
         func_8024F890(arg0, -1);
         sp20 = osGetTime();
         while(D_80281720[arg0].cseqp.state != AL_STOPPED){
+            if(gPortResetPending) break; // [port] avoid deadlock during reset
             osGetTime();
         };
         func_8024F7C4(sp2C);
@@ -381,6 +382,8 @@ void func_8024FB8C(void){
     sp2C = osGetTime();
 
     do{
+        // [port] During reset, audio callback may not run to clear player states
+        if(gPortResetPending) break;
         allStopped = 0;
         for(i = 0; i < 6; i++){
             if(func_8024FB60(i) != AL_STOPPED)

--- a/src/core1/init.c
+++ b/src/core1/init.c
@@ -180,6 +180,7 @@ void mainLoop(void){
     if(D_80275610){
         func_8023DA9C(D_80275610 - 1);
         D_80275610 = 0;
+        gPortResetPending = 0; // [port] clear flag so normal audio spin-waits work again
     }//L8023DE54
 
 // [port] This doesn't break anything, but better safe than sorry

--- a/src/core2/sfx/source.c
+++ b/src/core2/sfx/source.c
@@ -446,6 +446,11 @@ void func_8030D778(void){
             sfxsource_freeSfxsourceByIndex(i);
     }
     do{
+        // [port] During reset, audio callback may not run to clear busy flags
+        if(gPortResetPending){
+            for(i = 1; i < 35; i++) sfxsources[i].busy = false;
+            break;
+        }
         temp_s1 = 0;
         func_8030D644();
         for(i = 1; i < 35; i++){

--- a/src/port/Engine.cpp
+++ b/src/port/Engine.cpp
@@ -26,6 +26,7 @@
 #include "ui/LighthouseGui.hpp"
 #include "2.0L/PR/libaudio.h"
 #include "port/enhancements/events/PortEnhancements.h"
+#include "port/patches/Patches.h"
 #include "libultraship/libultra/AudioDmaRegistry.h"
 
 #include <fast/interpreter.h>
@@ -50,12 +51,18 @@ std::string assets_path;
 namespace fs = std::filesystem;
 
 extern "C" {
+
+// Reset support
+extern s32 D_80275610;
+int getDefaultBootMap(void);
+void setBootMap(int map_id);
+
 bool prevAltAssets = false;
 // bool gEnableGammaBoost = true;
 
-// [port] Audio synthesis entry point (decomp n_synthesizer.c)
+// Audio synthesis entry point (decomp n_synthesizer.c)
 Acmd* n_alAudioFrame(Acmd* cmdList, s32* cmdLen, s16* outBuf, s32 outLen);
-// [port] DMA cache cleanup (decomp audio_manager.c)
+// DMA cache cleanup (decomp audio_manager.c)
 void func_802403F0(void);
 void func_80250650(void);
 
@@ -141,6 +148,22 @@ GameEngine::GameEngine() {
     this->context->InitControlDeck(controlDeck);
     this->context->InitResourceManager({ assets_path }, {}, 3, true);
     this->context->InitConsole();
+
+    // Register console commands for menu buttons
+    Ship::Context::GetInstance()->GetConsole()->AddCommand(
+        "reset", { [](std::shared_ptr<Ship::Console>, const std::vector<std::string>&, std::string*) -> bool {
+                      gPortResetPending = 1; // lets audio spin-waits exit immediately
+                      setBootMap(getDefaultBootMap());
+                      D_80275610 = 3 + 1; // deferred: mainLoop picks this up next frame
+                      return 0;
+                  },
+                   "Reset to boot map." });
+    Ship::Context::GetInstance()->GetConsole()->AddCommand(
+        "quit", { [](std::shared_ptr<Ship::Console>, const std::vector<std::string>&, std::string*) -> bool {
+                     Ship::Context::GetInstance()->GetWindow()->Close();
+                     return 0;
+                 },
+                  "Quit the game." });
 
     lhFast3dWindow = std::make_shared<Fast::Fast3dWindow>(std::vector<std::shared_ptr<Ship::GuiWindow>>({}));
     this->context->InitWindow(lhFast3dWindow);
@@ -1089,8 +1112,6 @@ void GameEngine::AudioExit() {
         audio.thread.join();
     }
 }
-
-extern "C" int port_isViBlack(void);
 
 void GameEngine::RunCommands(Gfx* Commands, const std::vector<std::unordered_map<Mtx*, MtxF>>& mtx_replacements) {
     auto wnd = std::dynamic_pointer_cast<Fast::Fast3dWindow>(Ship::Context::GetInstance()->GetWindow());

--- a/src/port/GameStatus.cpp
+++ b/src/port/GameStatus.cpp
@@ -94,8 +94,13 @@ static const char* trimName(const char* name) {
 }
 
 extern "C" void port_setWindowTitle(int map_id) {
-    const char* levelName = trimName(port_getLevelName(map_id));
     enum level_e level = map_getLevel((enum map_e)map_id);
+    const char* levelName;
+    // Override the level name for file select
+    if (map_id == MAP_91_FILE_SELECT)
+        levelName = "FILE SELECT";
+    else
+        levelName = trimName(port_getLevelName(map_id));
 
     // Determine which stats to hide (mirrors pause menu totals screen logic)
     int hideCollLvl = port_getRomhackHideCollectiblesLevel();
@@ -105,10 +110,13 @@ extern "C" void port_setWindowTitle(int map_id) {
     if (hideJigLvl < 0)
         hideJigLvl = 0xB; // LEVEL_B_SPIRAL_MOUNTAIN
 
+    // File select and cutscenes have no meaningful stats
+    bool isNonGameplay = (map_id == MAP_91_FILE_SELECT || (int)level == LEVEL_D_CUTSCENE);
+
     // hideCollLvl hides notes + honeycombs, hideJigLvl hides notes + jiggies
-    bool showNotes = ((int)level != hideCollLvl && (int)level != hideJigLvl);
-    bool showJiggies = ((int)level != hideJigLvl);
-    bool showHoneycombs = ((int)level != hideCollLvl);
+    bool showNotes = !isNonGameplay && ((int)level != hideCollLvl && (int)level != hideJigLvl);
+    bool showJiggies = !isNonGameplay && ((int)level != hideJigLvl);
+    bool showHoneycombs = !isNonGameplay && ((int)level != hideCollLvl);
 
     s32 noteVal, noteMax, jiggyVal, jiggyMax, hcVal, hcMax;
     port_getLevelStats(map_id, &noteVal, &noteMax, &jiggyVal, &jiggyMax, &hcVal, &hcMax);
@@ -127,14 +135,20 @@ extern "C" void port_setWindowTitle(int map_id) {
     else
         snprintf(hcStr, sizeof(hcStr), "--");
 
-    u16 timeSec = port_getLevelTime(map_id);
-    int hours = timeSec / 3600;
-    int minutes = (timeSec / 60) % 60;
-    int seconds = timeSec % 60;
+    char timeStr[16];
+    if (!isNonGameplay && showNotes) {
+        u16 timeSec = port_getLevelTime(map_id);
+        int hours = timeSec / 3600;
+        int minutes = (timeSec / 60) % 60;
+        int seconds = timeSec % 60;
+        snprintf(timeStr, sizeof(timeStr), "%02d:%02d:%02d", hours, minutes, seconds);
+    } else {
+        snprintf(timeStr, sizeof(timeStr), "--");
+    }
 
     char title[256];
-    snprintf(title, sizeof(title), "Lighthouse - %s | Notes: %s | Jiggies: %s | Honeycombs: %s | Time: %02d:%02d:%02d",
-             levelName, noteStr, jiggyStr, hcStr, hours, minutes, seconds);
+    snprintf(title, sizeof(title), "Lighthouse - %s | Notes: %s | Jiggies: %s | Honeycombs: %s | Time: %s", levelName,
+             noteStr, jiggyStr, hcStr, timeStr);
 
 #ifdef _WIN32
     HWND hwnd = GetActiveWindow();

--- a/src/port/ShipUtils.cpp
+++ b/src/port/ShipUtils.cpp
@@ -21,10 +21,21 @@
 #include <filesystem>
 namespace fs = std::filesystem;
 
-// Furnace Fun active flag
-extern "C" s32 volatileFlag_get(s32);
+// Helper for C-style variadic log functions
+static void bk_log_vfmt(spdlog::level::level_enum level, const char* fmt, va_list args) {
+    char buf[512];
+    vsnprintf(buf, sizeof(buf), fmt, args);
+    spdlog::default_logger_raw()->log(spdlog::source_loc{}, level, buf);
+}
 
-extern "C" uint64_t GetUnixTimestamp() {
+extern "C" {
+
+// Furnace Fun active flag
+s32 volatileFlag_get(s32);
+
+int gPortResetPending = 0;
+
+uint64_t GetUnixTimestamp() {
     auto time = std::chrono::system_clock::now();
     auto since_epoch = time.time_since_epoch();
     auto millis = std::chrono::duration_cast<std::chrono::milliseconds>(since_epoch);
@@ -32,15 +43,15 @@ extern "C" uint64_t GetUnixTimestamp() {
     return now;
 }
 
-extern "C" bool Ship_IsCStringEmpty(const char* str) {
+bool Ship_IsCStringEmpty(const char* str) {
     return str == NULL || str[0] == '\0';
 }
 
-extern "C" void port_audioStartThread(void) {
+void port_audioStartThread(void) {
     GameEngine::AudioStartThread();
 }
 
-extern "C" int port_checkHeap(const char* label) {
+int port_checkHeap(const char* label) {
 #ifdef _DEBUG
     if (!_CrtCheckMemory()) {
         SPDLOG_ERROR("[port] HEAP CORRUPT at: {}", label);
@@ -50,34 +61,29 @@ extern "C" int port_checkHeap(const char* label) {
     return 1;
 }
 
-static void bk_log_vfmt(spdlog::level::level_enum level, const char* fmt, va_list args) {
-    char buf[512];
-    vsnprintf(buf, sizeof(buf), fmt, args);
-    spdlog::default_logger_raw()->log(spdlog::source_loc{}, level, buf);
-}
-
-extern "C" void BK_LOG_INFO(const char* fmt, ...) {
+// Wrappers to use SPDLOG from C code
+void BK_LOG_INFO(const char* fmt, ...) {
     va_list args;
     va_start(args, fmt);
     bk_log_vfmt(spdlog::level::info, fmt, args);
     va_end(args);
 }
 
-extern "C" void BK_LOG_WARN(const char* fmt, ...) {
+void BK_LOG_WARN(const char* fmt, ...) {
     va_list args;
     va_start(args, fmt);
     bk_log_vfmt(spdlog::level::warn, fmt, args);
     va_end(args);
 }
 
-extern "C" void BK_LOG_ERROR(const char* fmt, ...) {
+void BK_LOG_ERROR(const char* fmt, ...) {
     va_list args;
     va_start(args, fmt);
     bk_log_vfmt(spdlog::level::err, fmt, args);
     va_end(args);
 }
 
-extern "C" const char* port_mapName(int map_id) {
+const char* port_mapName(int map_id) {
     switch (map_id) {
         // Spiral Mountain
         case 0x01:
@@ -238,38 +244,11 @@ extern "C" const char* port_mapName(int map_id) {
     }
 }
 
-extern "C" int port_getBootSequence(void) {
+int port_getBootSequence(void) {
     return CVarGetInteger(CVAR_SETTING("BootSequence"), 0);
 }
 
-extern "C" int port_getViewportWidth(void) {
-    // Returns the logical viewport width based on the actual game viewport aspect ratio.
-    // Uses the interpreter's current dimensions (respects imgui aspect ratio settings).
-    // At 4:3, returns 320. At 16:9, returns ~427.
-    auto ctx = Ship::Context::GetInstance();
-    if (!ctx)
-        return 320;
-    auto fastWnd = std::dynamic_pointer_cast<Fast::Fast3dWindow>(ctx->GetWindow());
-    if (!fastWnd)
-        return 320;
-    auto interp = fastWnd->GetInterpreterWeak().lock();
-    if (!interp)
-        return 320;
-    uint32_t w = 0, h = 0;
-    interp->GetCurDimensions(&w, &h);
-    if (h == 0)
-        return 320;
-    float vpAspect = (float)w / (float)h;
-    float gameAspect = 320.0f / 240.0f;
-    if (vpAspect > gameAspect + 0.01f) {
-        return (int)(320.0f * vpAspect / gameAspect);
-    }
-    return 320;
-}
-
-// Returns 0.0–1.0 rumble intensity scale from the ImGui controller config.
-// Uses the average of low/high frequency percentages for the given controller port.
-extern "C" float port_getRumbleScale(void) {
+float port_getRumbleScale(void) {
     auto ctx = Ship::Context::GetInstance();
     if (!ctx) {
         return 0.5f;
@@ -289,7 +268,7 @@ extern "C" float port_getRumbleScale(void) {
     return 1.0f;
 }
 
-extern "C" bool port_CButtonIsAxis(void) {
+bool port_CButtonIsAxis(void) {
     auto ctx = Ship::Context::GetInstance();
     if (!ctx) {
         return false;
@@ -300,7 +279,6 @@ extern "C" bool port_CButtonIsAxis(void) {
         return false;
     }
 
-    // Check if any C button (CLeft, CRight, CUp, CDown) has an axis-direction mapping
     const CONTROLLERBUTTONS_T cButtons[] = { BTN_CLEFT, BTN_CRIGHT, BTN_CUP, BTN_CDOWN };
     for (auto bitmask : cButtons) {
         auto button = controller->GetButton(bitmask);
@@ -315,6 +293,8 @@ extern "C" bool port_CButtonIsAxis(void) {
     }
     return false;
 }
+
+} // extern "C"
 
 json Ship_RetrieveSaveFile(int32_t filenum) {
     std::string fileName = "file" + std::to_string(filenum) + ".json";

--- a/src/port/ShipUtils.h
+++ b/src/port/ShipUtils.h
@@ -14,31 +14,27 @@ uint64_t GetUnixTimestamp();
 bool Ship_IsCStringEmpty(const char* str);
 int port_checkHeap(const char* label);
 
-// [port] SPDLOG level wrappers callable from C
+// SPDLOG level wrappers callable from C
 void BK_LOG_INFO(const char* fmt, ...);
 void BK_LOG_WARN(const char* fmt, ...);
 void BK_LOG_ERROR(const char* fmt, ...);
 
-// [port] Start the audio processing thread (called from audioManager_startThread after soundfont patching)
+// Start the audio processing thread (called from audioManager_startThread after soundfont patching)
 void port_audioStartThread(void);
 
+// Flag: when true, audio spin-waits should force-stop immediately.
+extern int gPortResetPending;
+
+// Get the name of a map by its ID
 const char* port_mapName(int map_id);
 
-// [port] Get the boot sequence setting (0=Default, 1=Authentic, 2=FileSelect)
+// Get the boot sequence setting (0=Default, 1=Authentic, 2=FileSelect)
 int port_getBootSequence(void);
 
-// [port] Currently selected game number (0-2), set at file pick. -1 if none.
+// Currently selected game number (0-2), set at file pick. -1 if none.
 extern s32 gSelectedGameNum;
 
-// [port] Get the widescreen logical width (320 at 4:3, wider for widescreen)
-int port_getViewportWidth(void);
-
-// [port] Demo frame pacing: returns the N64 VI count for the current demo tick
-// (typically 2 for 30fps, higher during original frame drops). Returns 0 outside demos.
-int port_getDemoViCount(void);
-
-// stick axis via LUS controller mappings. Used to enable the stick
-// diagonal/rebound filter only when relevant.
+// Check if any C button is mapped to a stick axis via LUS controller mappings.
 bool port_CButtonIsAxis(void);
 
 #ifdef __cplusplus

--- a/src/port/ui/LighthouseMenuSettings.cpp
+++ b/src/port/ui/LighthouseMenuSettings.cpp
@@ -147,7 +147,7 @@ void LighthouseMenu::AddMenuSettings() {
             { LANGUAGE_FRE, "French" },
             { LANGUAGE_GER, "German" },
         };
-        AddWidget(path, "Dialog Language", WIDGET_CVAR_COMBOBOX)
+        AddWidget(path, "Dialog Language\n(Needs map change)", WIDGET_CVAR_COMBOBOX)
             .CVar(CVAR_SETTING("DialogLanguage"))
             .RaceDisable(false)
             .PreFunc([](WidgetInfo& info) {
@@ -159,7 +159,8 @@ void LighthouseMenu::AddMenuSettings() {
                 ResourceMgr_SetDialogLanguage(lang);
             })
             .Options(ComboboxOptions()
-                         .Tooltip("Select dialog language.\nOnly available with PAL o2r (English, French, German).")
+                         .Tooltip("Select dialog language.\nOnly available with PAL o2r (English, French, "
+                                  "German).\nRequires a map change to take effect.")
                          .LabelPosition(LabelPositions::Far)
                          .ComponentAlignment(ComponentAlignments::Right)
                          .ComboMap(languageOptions)

--- a/src/port/ui/Menu.cpp
+++ b/src/port/ui/Menu.cpp
@@ -750,10 +750,10 @@ void Menu::DrawElement() {
     UIWidgets::ButtonOptions options3 = {};
     options3.color = UIWidgets::Colors::Red;
     options3.size = UIWidgets::Sizes::Inline;
-    options3.tooltip = "Quit SoH";
+    options3.tooltip = "Quit Lighthouse";
     if (UIWidgets::Button(ICON_FA_POWER_OFF, options3)) {
         LighthouseGui::mModalWindow->RegisterPopup(
-            "Quit SoH", "Are you sure you want to quit SoH?", "Quit", "Cancel",
+            "Quit Lighthouse", "Are you sure you want to quit Lighthouse?", "Quit", "Cancel",
             []() {
                 std::shared_ptr<Menu> menu =
                     static_pointer_cast<Menu>(Ship::Context::GetInstance()->GetWindow()->GetGui()->GetMenu());


### PR DESCRIPTION
- Add reset and quit console commands so the imgui menu buttons work
- Introduce `gPortResetPending` flag to break audio spin-waits that deadlock when the audio callback isn't running during reset
- Improve window title stats: show "FILE SELECT" label, hide stats during cutscenes and file select, use "--" placeholders
- Fix "Quit SoH" to "Quit Lighthouse" in quit confirmation dialog
- Move map change requirement into dialog language widget label and expand tooltip
- Clean up ShipUtils: consolidate extern "C" block, remove `port_getViewportWidth`, tidy comments