### PR TITLE
Remove Lair Continuity code

### DIFF
--- a/src/core1/audio_instruments.c
+++ b/src/core1/audio_instruments.c
@@ -24,47 +24,11 @@ extern u8 *soundfont2ctl_ROM_START;
 extern u8 *soundfont2ctl_ROM_END;
 extern u8 *soundfont2tbl_ROM_START;
 
-extern CoMusic *D_80276E30; // [port] comusic track array from audio_musicplayer.c
-
 /* dependent functions */
 void func_8024FA98(u8, s32);
 void func_8024FD28(u8, s16);
 int func_80250074(u8);
 u8 func_8025F4A0(ALCSPlayer *, u8);
-
-// [port] Lair audio continuity: tracks within the same group share enough
-// sequence data that seeking to the same tick position sounds seamless.
-// Group 0 = not a lair track, groups 1-3 = adjacent lair floors.
-static int lairTrackGroup(s32 trackIndex) {
-    switch (trackIndex) {
-        case COMUSIC_1E_GL_MM_VERSION:
-        case COMUSIC_50_GL_TTC_VERSION:
-        case COMUSIC_51_GL_CCW_VERSION:
-            return 1;
-        case COMUSIC_52_GL_BGS_RBB_VERSION:
-        case COMUSIC_53_GL_FP_VERSION_A:
-            return 2;
-        case COMUSIC_54_GL_GV_VERSION:
-        case COMUSIC_59_GL_FP_VERSION_B:
-        case COMUSIC_5D_GL_MMM_VERSION:
-        case COMUSIC_5E_GL_MMM_RBB_VERSION:
-        case COMUSIC_63_GL_FF_VERSION:
-            return 3;
-        default:
-            return 0;
-    }
-}
-
-// Per-group saved tick positions, plus a combined position for cross-group seeks.
-static s32 sLairSavedTicks[4] = { 0 }; // one per group (index 1-3)
-static s32 sLairLastSavedTicks = 0;     // last saved from any group
-static s32 sLairPendingSeek = 0;        // ticks to seek to on next track start
-static u8  sLairPendingSeekSlot = 0xFF; // which slot the seek is for
-
-// [port] Defined after D_80281720 declaration
-s32 lairAudio_consumePendingSeek(ALCSPlayer *player);
-// [port] Returns true if a lair continuity seek is pending (for skipping fade-in)
-int lairAudio_hasPendingSeek(void) { return sLairPendingSeek > 0; }
 
 void func_8025F3F0(ALCSPlayer *, f32, f32);
 u16 func_80250474(s32 arg0);
@@ -261,17 +225,6 @@ ALBank *     D_80282108;
 structBs     D_80282110[0x20];
 
 /* .code */
-
-// [port] Called from n_csplayer.c AL_SEQP_PLAY_EVT handler.
-s32 lairAudio_consumePendingSeek(ALCSPlayer *player) {
-    if (sLairPendingSeekSlot >= 6) return 0;
-    if (player != &D_80281720[sLairPendingSeekSlot].cseqp) return 0;
-    s32 ticks = sLairPendingSeek;
-    sLairPendingSeek = 0;
-    sLairPendingSeekSlot = 0xFF;
-    return ticks;
-}
-
 void musicInstruments_init(void){
     s32 i;
 
@@ -378,8 +331,6 @@ void func_8024F890(u8 arg0, s32 arg1){
         if (arg1 >= 0 && arg1 < 0xB0 && D_802820E0 != NULL) {
             n_alCSeqNew(&D_80281720[arg0].cseq, (u8 *)D_802820E0[arg1]);
         }
-        // [port] Lair continuity: pending seek is applied in the AL_SEQP_PLAY_EVT
-        // handler (n_csplayer.c) after bank init but before the first event posts.
         D_80281720[arg0].cseqp.chanMask = func_80250474(arg0);
         alCSPSetSeq(&D_80281720[arg0].cseqp, &D_80281720[arg0].cseq);
         alCSPPlay(&D_80281720[arg0].cseqp);
@@ -404,16 +355,6 @@ void func_8024FA98(u8 arg0, s32 arg1){
 
     sp2C = D_80281720[arg0].index;
     if(arg1 == sp2C || sp2C == -1){
-        // [port] Lair audio continuity: the comusic layer stops the old track
-        // (setting index to -1) then starts the new one as a separate call.
-        // Set pending seek so func_8024F890 applies it before alCSPPlay.
-        if (sp2C == -1 && arg1 >= 0 && CVarGetInteger(CVAR_ENHANCEMENT("Audio.LairContinuity"), 0)) {
-            int newGroup = lairTrackGroup(arg1);
-            if (newGroup > 0 && sLairLastSavedTicks > 0) {
-                sLairPendingSeek = sLairSavedTicks[newGroup] ? sLairSavedTicks[newGroup] : sLairLastSavedTicks;
-                sLairPendingSeekSlot = arg0;
-            }
-        }
         func_8024F890(arg0, arg1);
     }else{
         func_8024F890(arg0, -1);
@@ -450,43 +391,7 @@ void func_8024FB8C(void){
 
 }
 
-static s8 sLairDeferredStop = -1; // slot with deferred lair stop, or -1
-
 void func_8024FC1C(u8 arg0, s32 arg1){
-    if (CVarGetInteger(CVAR_ENHANCEMENT("Audio.LairContinuity"), 0)) {
-        // Stop request for a lair track: defer it so music plays through transition
-        if (arg1 == -1) {
-            int group = lairTrackGroup(D_80281720[arg0].index);
-            if (group > 0) {
-                s32 ticks = alCSeqGetTicks(&D_80281720[arg0].cseq);
-                sLairSavedTicks[group] = ticks;
-                sLairLastSavedTicks = ticks;
-                sLairDeferredStop = arg0;
-                return; // keep playing through the transition
-            }
-        }
-        // New lair track request: now execute the deferred stop + normal start
-        if (arg1 >= 0 && sLairDeferredStop == arg0) {
-            int newGroup = lairTrackGroup(arg1);
-            // Re-capture ticks NOW (old track was still playing during transition)
-            int oldGroup = lairTrackGroup(D_80281720[arg0].index);
-            if (oldGroup > 0) {
-                s32 ticks = alCSeqGetTicks(&D_80281720[arg0].cseq);
-                sLairSavedTicks[oldGroup] = ticks;
-                sLairLastSavedTicks = ticks;
-            }
-            sLairDeferredStop = -1;
-            if (newGroup > 0) {
-                sLairPendingSeek = sLairSavedTicks[newGroup] ? sLairSavedTicks[newGroup] : sLairLastSavedTicks;
-                sLairPendingSeekSlot = arg0;
-            }
-            // Execute the deferred stop now, then fall through to start new track
-            D_80281720[arg0].index_cpy = -1;
-            D_80281720[arg0].unk2 = 1;
-            D_80281720[arg0].unk3 = 0;
-            D_80281720[arg0].unk0 = 0;
-        }
-    }
     D_80281720[arg0].index_cpy = arg1;
     D_80281720[arg0].unk2 = 1;
     D_80281720[arg0].unk3 = 0;
@@ -561,30 +466,10 @@ s32 func_8024FEEC(u8 arg0)
 void func_8024FF34(void){
     s32 i;
 
-    // [port] While a lair stop is deferred, keep both the hardware volume
-    // and comusic state up so the fade system doesn't trigger func_802599B4.
-    if (sLairDeferredStop >= 0) {
-        u8 slot = (u8)sLairDeferredStop;
-        s32 vol = D_80275D40[D_80281720[slot].index].unk4;
-        func_8024FD28(slot, (s16)vol);
-        CoMusic *cm = &D_80276E30[slot];
-        cm->volume = vol;     // prevent comusic from thinking volume is 0
-        cm->unk12 = 0;      // stop any fade in progress
-    }
-
     for(i = 0; i < 6 ; i++){
         switch(D_80281720[i].cseqp.state){
             case AL_PLAYING://L8024FF94
                 if(D_80281720[i].unk2){
-                    // [port] Capture tick position while still playing, before stop resets it
-                    if (CVarGetInteger(CVAR_ENHANCEMENT("Audio.LairContinuity"), 0)) {
-                        int group = lairTrackGroup(D_80281720[i].index);
-                        s32 ticks = alCSeqGetTicks(&D_80281720[i].cseq);
-                        if (group > 0) {
-                            sLairSavedTicks[group] = ticks;
-                            sLairLastSavedTicks = ticks;
-                        }
-                    }
                     alCSPStop(&(D_80281720[i].cseqp));
 
                     if(D_80281720[i].unk3)

--- a/src/core1/audio_musicplayer.c
+++ b/src/core1/audio_musicplayer.c
@@ -7,7 +7,6 @@
 #include "version.h"
 
 extern void func_8024FDDC(u8, s32);
-extern int lairAudio_hasPendingSeek(void); // [port]
 
 void func_8025AE50(s32, f32);
 
@@ -579,27 +578,13 @@ void func_8025AC7C(enum comusic_e comusic_id, s32 arg1, s32 arg2, f32 arg3, void
         trackPtr->volume = 0;
         trackPtr->unk15 = 0;
         trackPtr->unk4 = 0.0f;
-        // [port] Skip fade-in for lair continuity — start at target volume
-        if (lairAudio_hasPendingSeek()) {
-            s32 vol = func_80250034(comusic_id);
-            func_80259994(trackPtr, vol);
-            func_8024FD28(slot_index, (s16)vol);
-        } else {
-            func_80259994(trackPtr, 0);
-            func_8024FD28(slot_index, 0);
-        }
+        func_80259994(trackPtr, 0);
+        func_8024FD28(slot_index, 0);
     }
     func_80259F7C(trackPtr,&arg1, &arg2, fadeSlot);
     trackPtr->unk0 = arg3;
-    // [port] No fade needed for lair continuity — jump to target volume
-    if (lairAudio_hasPendingSeek()) {
-        trackPtr->unk12 = 0;
-        trackPtr->unkC = arg1;
-        trackPtr->volume = arg1;
-    } else {
-        trackPtr->unk12 = (trackPtr->volume < arg1)? arg2: -arg2;
-        trackPtr->unkC = arg1;
-    }
+    trackPtr->unk12 = (trackPtr->volume < arg1)? arg2: -arg2;
+    trackPtr->unkC = arg1;
     D_80276E34 = 1;
 }
 

--- a/src/core1/libaudio/n_csplayer.c
+++ b/src/core1/libaudio/n_csplayer.c
@@ -18,7 +18,6 @@ ALSound         *__n_lookupSoundQuick(ALSeqPlayer *, u8, u8, u8);
 void		__n_seqpReleaseVoice(ALSeqPlayer *seqp, ALVoice *voice, ALMicroTime deltaTime);
 char __alCSeqNextDelta(ALCSeq *seq, s32 *pDeltaTicks);
 void func_80250104(ALCSeq *arg0, s32 arg1, s32 arg2);
-s32 lairAudio_consumePendingSeek(ALCSPlayer *player); // [port]
 
 /*====================================================================
  * csplayer.c
@@ -238,25 +237,6 @@ static ALMicroTime __n_CSPVoiceHandler(void *node)
 	    {
 		seqp->state = AL_PLAYING;
         func_80250650();
-        /* [port] Lair audio continuity: fast-forward through the sequence,
-         * processing only channel setup events (ProgramChange, ControlChange)
-         * so instruments and volumes are correct at the seek point. */
-        {
-            s32 seekTicks = lairAudio_consumePendingSeek(seqp);
-            if (seekTicks > 0 && seqp->target != NULL) {
-                N_ALEvent seekEvt;
-                while (seqp->target->lastTicks < (u32)seekTicks) {
-                    n_alCSeqNextEvent(seqp->target, &seekEvt);
-                    if (seekEvt.type == AL_SEQ_END_EVT) break;
-                    if (seekEvt.type == AL_SEQ_MIDI_EVT) {
-                        u8 status = seekEvt.msg.midi.status & 0xF0;
-                        if (status == AL_MIDI_ProgramChange || status == AL_MIDI_ControlChange) {
-                            __n_CSPHandleMIDIMsg((N_ALCSPlayer *)seqp, (ALEvent *)&seekEvt);
-                        }
-                    }
-                }
-            }
-        }
 		__n_CSPPostNextSeqEvent(seqp);	/* seqp must be AL_PLAYING before we call this routine. */
 	    }
 	    break;

--- a/src/port/ui/LighthouseMenuEnhancements.cpp
+++ b/src/port/ui/LighthouseMenuEnhancements.cpp
@@ -34,22 +34,6 @@ void LighthouseMenu::AddMenuEnhancements() {
         .Options(CheckboxOptions().Tooltip(
             "Skips the jiggy collection dance, collecting the jiggy immediately like underwater pickups."));
 
-    // Enhancements -> Audio
-    path = { "Enhancements", "Audio", SECTION_COLUMN_1 };
-    AddSidebarEntry("Enhancements", path.sidebarName, 1);
-    path.column = SECTION_COLUMN_1;
-
-    AddWidget(path, "Lair Music Continuity", WIDGET_CVAR_CHECKBOX)
-        .CVar(CVAR_ENHANCEMENT("Audio.LairContinuity"))
-        .RaceDisable(false)
-        .PreFunc([](WidgetInfo& info) {
-            if (mLighthouseMenu->disabledMap.at(DISABLE_FOR_ROMHACK).active) {
-                info.activeDisables.push_back(DISABLE_FOR_ROMHACK);
-            }
-        })
-        .Options(CheckboxOptions().Tooltip(
-            "Maintain music position when moving between Gruntilda's Lair floors that share the same theme."));
-
     // Enhancements -> Graphics
     path = { "Enhancements", "Graphics", SECTION_COLUMN_1 };
     AddSidebarEntry("Enhancements", path.sidebarName, 1);


### PR DESCRIPTION
Lair Continuity is an attempted enhancement which does function, but is too intrusive and has unresolvable gaps when tracks change between lair floors. Remove it.