### PR TITLE
Fix loading vtx section before gfx in model import and add sentinel ENDDL byte

### DIFF
--- a/config.yml
+++ b/config.yml
@@ -87,3 +87,33 @@ a9f62c403a21ae9d9a1bbf9e92d752fc2cf85c2b:
       code: src/assets
       headers: include/assets
       modding: src/assets
+
+3624bcc9e96918232f4920e5f95bdcc3fed156a6:
+  name: Banjo-Kazooie - Gruntilda's Mask
+  path: assets/yaml/us/rev0
+  config:
+    gbi: F3DEX_BK64
+    sort: OFFSET
+    logging: WARN
+    textures: ADDITIONAL_DEFINES
+    include_autogen: true
+    output:
+      binary: bk-gm.o2r
+      code: src/assets
+      headers: include/assets
+      modding: src/assets
+
+1f2a71516fb337bc6f7ccdaadb809c94753db534:
+  name: Banjo-Kazooie - The Bear Waker DX
+  path: assets/yaml/us/rev0
+  config:
+    gbi: F3DEX_BK64
+    sort: OFFSET
+    logging: WARN
+    textures: ADDITIONAL_DEFINES
+    include_autogen: true
+    output:
+      binary: bk-bwdx.o2r
+      code: src/assets
+      headers: include/assets
+      modding: src/assets

--- a/src/core2/abilityprogress.c
+++ b/src/core2/abilityprogress.c
@@ -1,6 +1,7 @@
 #include <ultra64.h>
 #include "functions.h"
 #include "variables.h"
+#include "port/GameConfig.h"
 
 // [port] These must be contiguous — ability_getSizeAndPtr returns &learned with
 // size 8, expecting used to follow immediately. Separate globals aren't guaranteed
@@ -106,6 +107,9 @@ s32 ability_getAllLearned(void){
 void ability_debug(void){}
 
 void ability_clearAll(void){
+    if (port_isRomhack()) {
+        return;
+    }
     abilityprogress_learnedAbilities = 0;
     abilityprogress_usedAbilities = 0;
 }

--- a/src/core2/actor_cubebounds.c
+++ b/src/core2/actor_cubebounds.c
@@ -2493,9 +2493,14 @@ static void __code7AF80_func_80308F0C(Cube *cube) {
     s32 indx;
 
     indx = cube - sCubeList.cubes;
-    D_803821E0[indx >> 5] |= 1 << (indx & 0x1F);
+    // [port] Bounds check: romhack maps may exceed the 2912-cube bitfield capacity.
+    if ((u32)(indx >> 5) < 0x5B) {
+        D_803821E0[indx >> 5] |= 1 << (indx & 0x1F);
+    }
 }
 
 bool func_80308F54(s32 cube_index) {
+    // [port] Bounds check: romhack maps may exceed the 2912-cube bitfield capacity.
+    if ((u32)(cube_index >> 5) >= 0x5B) return false;
     return D_803821E0[cube_index >> 5] & (1 << (cube_index & 0x1F));
 }

--- a/src/core2/gameSelect.c
+++ b/src/core2/gameSelect.c
@@ -438,9 +438,9 @@ void func_802C4C14(Actor *this){
                             }
                             timedFunc_set_3(0.0f, (GenFunction_3)transitionToMap, newGameMap, 0, 1);
                             {
-                                s32 knowAll = port_getRomhackKnowAllMoves();
-                                if (knowAll >= 0) {
-                                    ability_setAllLearned(knowAll);
+                                if (port_getRomhackKnowAllMoves() >= 0) {
+                                    ability_setAllLearned(-1);
+                                    ability_setAllUsed(-1);
                                 }
                             }
                         }

--- a/src/port/Engine.cpp
+++ b/src/port/Engine.cpp
@@ -242,7 +242,7 @@ void CheckAndCreateModFolder() {
     }
 }
 
-static const std::vector<std::string> sRomArchives = { "bk.o2r", "bk-jot.o2r", "bk-n64.o2r" };
+static const std::vector<std::string> sRomArchives = { "bk.o2r", "bk-jot.o2r", "bk-n64.o2r", "bk-gm.o2r", "bk-bwdx.o2r" };
 
 static bool AnyRomArchiveExists() {
     for (const auto& archive : sRomArchives) {

--- a/src/port/ShipUtils.cpp
+++ b/src/port/ShipUtils.cpp
@@ -1,4 +1,5 @@
 #include "ShipUtils.h"
+#include "save/SaveManager.h"
 #include "Engine.h"
 #include <chrono>
 #include <cstdarg>
@@ -298,7 +299,7 @@ bool port_CButtonIsAxis(void) {
 
 json Ship_RetrieveSaveFile(int32_t filenum) {
     std::string fileName = "file" + std::to_string(filenum) + ".json";
-    std::string filePath = Ship::Context::GetPathRelativeToAppDirectory("saves/" + fileName);
+    std::string filePath = SaveManager_GetSavePath(fileName);
 
     if (!std::filesystem::exists(filePath)) {
         return json::object();

--- a/src/port/resource/importers/GameConfigFactory.cpp
+++ b/src/port/resource/importers/GameConfigFactory.cpp
@@ -251,7 +251,11 @@ static void LoadGameConfig() {
                             break;
                     }
                     if (target) {
-                        *target = val;
+                        if (key == CCK_KNOW_ALL_MOVES) {
+                            *target = (int)(int16_t)val;
+                        } else {
+                            *target = val;
+                        }
                     }
                 }
                 break;

--- a/src/port/resource/importers/GameConfigFactory.cpp
+++ b/src/port/resource/importers/GameConfigFactory.cpp
@@ -251,11 +251,7 @@ static void LoadGameConfig() {
                             break;
                     }
                     if (target) {
-                        if (key == CCK_KNOW_ALL_MOVES) {
-                            *target = (int)(int16_t)val;
-                        } else {
-                            *target = val;
-                        }
+                        *target = val;
                     }
                 }
                 break;

--- a/src/port/resource/importers/ModelFactory.cpp
+++ b/src/port/resource/importers/ModelFactory.cpp
@@ -128,7 +128,7 @@ ResourceFactoryBinaryModelV0::ReadResource(std::shared_ptr<Ship::File> file,
                      tm.type, tm.width, tm.height, tm.tlutColors, tm.textureDataOffset);
     }
 
-    // [port] Raw texture data blob — full contiguous pixel area from the ROM.
+    // Raw texture data blob — full contiguous pixel area from the ROM.
     // Preserves animated texture frames and unlisted data between textures.
     uint32_t rawTexDataSize = reader->ReadUInt32();
     std::vector<uint8_t> rawTexBlob;
@@ -368,12 +368,6 @@ ResourceFactoryBinaryModelV0::ReadResource(std::shared_ptr<Ship::File> file,
         }
     }
 
-    // GFX sub-resources are no longer loaded individually — raw N64 DL words
-    // are embedded directly in the model resource and widened at assembly time.
-    // This preserves the original N64 command layout so geo indices remain valid.
-
-    SPDLOG_TRACE("[BKModel] '{}' metadata read complete, assembling buffer...", initData->Path);
-
     // ── Load GEO sub-resource (GeoLayout render tree) ─────────────────────────
     std::shared_ptr<Ship::Blob> geoBlob;
     if (hasGeo) {
@@ -416,7 +410,7 @@ ResourceFactoryBinaryModelV0::ReadResource(std::shared_ptr<Ship::File> file,
         PadTo8(out);
         hdr()->texture_list_offset_8 = static_cast<int16_t>(out.size());
 
-        // [port] Use raw texture blob directly — preserves animated frames and
+        // Use raw texture blob directly — preserves animated frames and
         // all unlisted data. OTEX overlay for alt assets can be added later.
         const uint8_t* blobPtr = rawTexBlob.empty() ? nullptr : rawTexBlob.data();
         uint32_t totalPixSize = rawTexDataSize;
@@ -617,6 +611,79 @@ ResourceFactoryBinaryModelV0::ReadResource(std::shared_ptr<Ship::File> file,
         }
     }
 
+    // GFX section — widen raw N64 commands (8 bytes each) to native Gfx (16 bytes each).
+    // This preserves the exact N64 command count and indices so geo layout references
+    // (list[cmd->unk8]) remain correct. No OTR markers or expanded commands.
+    if (hasDL && !rawDLWords.empty()) {
+        PadTo8(out);
+        hdr()->gfx_list_offset_C = static_cast<int32_t>(out.size());
+
+        // BKGfxList: s32 dlCount, s32 dlUnkInfo
+        AppendValue<int32_t>(out, static_cast<int32_t>(dlCount));
+        AppendValue<int32_t>(out, static_cast<int32_t>(dlUnkInfo));
+
+        // Widen each N64 command: (u32 w0, u32 w1) → (uintptr_t w0, uintptr_t w1)
+        for (uint32_t i = 0; i < dlCount; i++) {
+            uintptr_t w0 = rawDLWords[i * 2];
+            uintptr_t w1 = rawDLWords[i * 2 + 1];
+
+            // F3DEX opcodes that carry a segmented address in w1.
+            // G_DL byte offsets must be scaled for widened Gfx (16 bytes vs N64's 8).
+            uint8_t opcode = (uint8_t)(w0 >> 24);
+            if (opcode == 0x06 && sizeof(uintptr_t) > 4) { // G_DL
+                if (w1 != 0 && (w1 >> 24) != 0 && w1 <= 0xFFFFFFFF) {
+                    uint32_t seg = (uint32_t)(w1 >> 24);
+                    uint32_t off = (uint32_t)(w1 & 0x00FFFFFF);
+                    off *= (sizeof(Gfx) / 8);
+                    w1 = ((uintptr_t)seg << 24) | (off & 0x00FFFFFF);
+                }
+            }
+            // G_VTX (F3DEX opcode 0x04): w1 is a segmented address into the
+            // vertex buffer. With GBI_FLOATS, sizeof(Vtx) = 24 instead of N64's 16,
+            // so byte offsets must be scaled: new_off = (old_off / 16) * sizeof(Vtx).
+            if (opcode == 0x04 && sizeof(Vtx) != 16) {
+                if (w1 != 0 && (w1 >> 24) != 0 && w1 <= 0xFFFFFFFF) {
+                    uint32_t seg = (uint32_t)(w1 >> 24);
+                    uint32_t off = (uint32_t)(w1 & 0x00FFFFFF);
+                    off = (off / 16) * sizeof(Vtx);
+                    w1 = ((uintptr_t)seg << 24) | (off & 0x00FFFFFF);
+                }
+            }
+
+            // Tag segmented addresses with bit 0 so SegAddr() identifies them.
+            // Only tag opcodes that carry a segmented address in w1. Other commands
+            // (G_SETTILE, G_LOADBLOCK, G_SETCOMBINE, G_SETPRIMCOLOR, etc.) have
+            // literal values in w1 that must NOT be modified.
+            switch (opcode) {
+                case 0x01: // G_MTX
+                case 0x03: // G_MOVEMEM
+                case 0x04: // G_VTX
+                case 0x06: // G_DL
+                case 0xFD: // G_SETTIMG (gDPSetTextureImage)
+                case 0xFE: // G_SETZIMG
+                case 0xFF: // G_SETCIMG
+                    if (w1 != 0 && w1 <= 0xFFFFFFFF && (w1 >> 24) != 0) {
+                        w1 |= 1;
+                    }
+                    break;
+                default:
+                    break;
+            }
+
+            AppendValue<uintptr_t>(out, w0);
+            AppendValue<uintptr_t>(out, w1);
+        }
+
+        // Append gSPEndDisplayList sentinel. Some BK models don't include
+        // the terminator in dlCount (the N64 game knew chunk sizes from the geo
+        // layout and didn't need it). The port's interpreter walks DLs sequentially
+        // until gSPEndDisplayList, so we must provide one.
+        uintptr_t endW0 = (uintptr_t)0xB8 << 24; // F3DEX G_ENDDL
+        uintptr_t endW1 = 0;
+        AppendValue<uintptr_t>(out, endW0);
+        AppendValue<uintptr_t>(out, endW1);
+    }
+
     // Vertex section
     if (hasVtx) {
         PadTo8(out);
@@ -624,7 +691,7 @@ ResourceFactoryBinaryModelV0::ReadResource(std::shared_ptr<Ship::File> file,
 
         auto vtxRes = std::static_pointer_cast<Fast::Vertex>(resourceMgr->LoadResourceProcess(initData->Path + "_VTX"));
 
-        // [port] Fast::Vertex resource already holds properly-sized Vtx structs
+        // Fast::Vertex resource already holds properly-sized Vtx structs
         // (with GBI_FLOATS, sizeof(Vtx) = 24, not the N64's 16 bytes).
         if (vtxRes) {
             const size_t resBytes = vtxRes->GetPointerSize();
@@ -652,20 +719,19 @@ ResourceFactoryBinaryModelV0::ReadResource(std::shared_ptr<Ship::File> file,
         AppendValue<int16_t>(out, vtxLocalNorm);
         AppendValue<uint16_t>(out, vtxCount);
         AppendValue<int16_t>(out, vtxGlobalNorm);
-        // [port] Pad header to sizeof(BKVertexList) so vtx_18[] aligns correctly.
+
+        // Pad header to sizeof(BKVertexList) so vtx_18[] aligns correctly.
         // BKVertexList has 24 bytes of fields but sizeof may be larger due to
         // flexible array member alignment (Vtx requires 8-byte alignment).
-        {
-            const size_t headerFieldBytes = 24; // 12 s16 fields = 24 bytes
-            const size_t headerSize = sizeof(BKVertexList);
-            if (headerSize > headerFieldBytes) {
-                for (size_t p = 0; p < headerSize - headerFieldBytes; p++)
-                    out.push_back(0);
-            }
+        const size_t headerFieldBytes = 24; // 12 s16 fields = 24 bytes
+        const size_t headerSize = sizeof(BKVertexList);
+        if (headerSize > headerFieldBytes) {
+            for (size_t p = 0; p < headerSize - headerFieldBytes; p++)
+                out.push_back(0);
         }
 
         if (vtxRes) {
-            // [port] Fast::Vertex stores Vtx structs (with GBI_FLOATS, ob[] are
+            // Fast::Vertex stores Vtx structs (with GBI_FLOATS, ob[] are
             // floats, sizeof(Vtx) = 24 not N64's 16). Copy at native stride so
             // the interpreter can index as F3DVtx* (same layout).
             const Vtx* vtxArray = vtxRes->GetPointer();
@@ -673,91 +739,6 @@ ResourceFactoryBinaryModelV0::ReadResource(std::shared_ptr<Ship::File> file,
             AppendBytes(out, vtxArray, vtxBytes);
         } else {
             SPDLOG_WARN("[BKModel] _VTX not found: {}", initData->Path);
-        }
-    }
-
-    // GFX section — widen raw N64 commands (8 bytes each) to native Gfx (16 bytes each).
-    // This preserves the exact N64 command count and indices so geo layout references
-    // (list[cmd->unk8]) remain correct. No OTR markers or expanded commands.
-    if (hasDL && !rawDLWords.empty()) {
-        PadTo8(out);
-        hdr()->gfx_list_offset_C = static_cast<int32_t>(out.size());
-
-        // BKGfxList: s32 dlCount, s32 dlUnkInfo
-        AppendValue<int32_t>(out, static_cast<int32_t>(dlCount));
-        AppendValue<int32_t>(out, static_cast<int32_t>(dlUnkInfo));
-
-        // Widen each N64 command: (u32 w0, u32 w1) → (uintptr_t w0, uintptr_t w1)
-        // [port] N64 display lists contain segmented addresses in w1 (e.g. 0x03000000
-        // for segment 3). The interpreter's SegAddr() uses bit 0 to identify segmented
-        // addresses, so we tag them with |= 1 after any offset scaling.
-        // G_DL byte offsets need scaling for the widened Gfx stride (16 vs 8 bytes).
-        for (uint32_t i = 0; i < dlCount; i++) {
-            uintptr_t w0 = rawDLWords[i * 2];
-            uintptr_t w1 = rawDLWords[i * 2 + 1];
-
-            // [port] F3DEX opcodes that carry a segmented address in w1.
-            // G_DL byte offsets must be scaled for widened Gfx (16 bytes vs N64's 8).
-            uint8_t opcode = (uint8_t)(w0 >> 24);
-            if (opcode == 0x06 && sizeof(uintptr_t) > 4) { // G_DL
-                if (w1 != 0 && (w1 >> 24) != 0 && w1 <= 0xFFFFFFFF) {
-                    uint32_t seg = (uint32_t)(w1 >> 24);
-                    uint32_t off = (uint32_t)(w1 & 0x00FFFFFF);
-                    off *= (sizeof(Gfx) / 8);
-                    w1 = ((uintptr_t)seg << 24) | (off & 0x00FFFFFF);
-                }
-            }
-            // [port] G_VTX (F3DEX opcode 0x04): w1 is a segmented address into the
-            // vertex buffer. With GBI_FLOATS, sizeof(Vtx) = 24 instead of N64's 16,
-            // so byte offsets must be scaled: new_off = (old_off / 16) * sizeof(Vtx).
-            if (opcode == 0x04 && sizeof(Vtx) != 16) {
-                if (w1 != 0 && (w1 >> 24) != 0 && w1 <= 0xFFFFFFFF) {
-                    uint32_t seg = (uint32_t)(w1 >> 24);
-                    uint32_t off = (uint32_t)(w1 & 0x00FFFFFF);
-                    off = (off / 16) * sizeof(Vtx);
-                    w1 = ((uintptr_t)seg << 24) | (off & 0x00FFFFFF);
-                }
-            }
-
-            // [port] Tag segmented addresses with bit 0 so SegAddr() identifies them.
-            // Only tag opcodes that carry a segmented address in w1. Other commands
-            // (G_SETTILE, G_LOADBLOCK, G_SETCOMBINE, G_SETPRIMCOLOR, etc.) have
-            // literal values in w1 that must NOT be modified.
-            switch (opcode) {
-                case 0x01: // G_MTX
-                case 0x03: // G_MOVEMEM
-                case 0x04: // G_VTX
-                case 0x06: // G_DL
-                case 0xFD: // G_SETTIMG (gDPSetTextureImage)
-                case 0xFE: // G_SETZIMG
-                case 0xFF: // G_SETCIMG
-                    if (w1 != 0 && w1 <= 0xFFFFFFFF && (w1 >> 24) != 0) {
-                        w1 |= 1;
-                    }
-                    break;
-                default:
-                    break;
-            }
-
-            AppendValue<uintptr_t>(out, w0);
-            AppendValue<uintptr_t>(out, w1);
-        }
-    }
-
-    // [port] Diagnostic: log final buffer layout for debugging heap corruption
-    {
-        auto* h = hdr();
-        SPDLOG_TRACE("[BKModel] '{}' total={} bytes | geo={} tex={} gfx={} vtx={} anim={} col={} unk14={} unk20={} "
-                     "fx={} unk28={} animTex={}",
-                     initData->Path, out.size(), h->geo_list_offset_4, h->texture_list_offset_8, h->gfx_list_offset_C,
-                     h->vtx_list_offset_10, h->animation_list_offset_18, h->collision_list_offset_1C, h->unk14,
-                     h->unk20, h->effects_list_setup_24, h->unk28, h->animated_texture_list_offset);
-
-        // Warn if texture offset overflowed s16
-        if (texCount > 0 && (h->texture_list_offset_8 <= 0 || h->texture_list_offset_8 > 32000)) {
-            SPDLOG_WARN("[BKModel] '{}' POSSIBLE s16 OVERFLOW: texture_list_offset_8={} (buffer was {} bytes at "
-                        "texture section)",
-                        initData->Path, h->texture_list_offset_8, out.size());
         }
     }
 

--- a/src/port/save/SaveManager.cpp
+++ b/src/port/save/SaveManager.cpp
@@ -3,6 +3,7 @@
 #include <libultraship/bridge/consolevariablebridge.h>
 #include "port/enhancements/events/hooks/Events.h"
 #include "port/ShipUtils.h"
+#include "port/GameConfig.h"
 #include <fstream>
 #include <filesystem>
 #include <regex>
@@ -23,6 +24,16 @@ using nlohmann::json;
 using nlohmann::ordered_json;
 namespace fs = std::filesystem;
 static bool mLoaded = false;
+
+std::string SaveManager_GetSavePath(const std::string& filename) {
+    const char* romName = port_getRomhackName();
+    if (romName && romName[0] != '\0') {
+        std::string dir = Ship::Context::GetPathRelativeToAppDirectory("saves/" + std::string(romName));
+        fs::create_directories(dir);
+        return dir + "/" + filename;
+    }
+    return Ship::Context::GetPathRelativeToAppDirectory("saves/" + filename);
+}
 
 static int BitfieldGetBit(const uint8_t* array, int index) {
     return (array[index / 8] & (1 << (index & 7))) ? 1 : 0;
@@ -432,7 +443,7 @@ SaveData* Convert_JSONToSaveData(int32_t fileNum) {
 }
 
 static void LoadGlobalData() {
-    std::string globalPath = Ship::Context::GetPathRelativeToAppDirectory("saves/global.json");
+    std::string globalPath = SaveManager_GetSavePath("global.json");
     if (!fs::exists(globalPath)) {
         return;
     }
@@ -505,7 +516,7 @@ static void SaveGlobalData() {
     }
     j["bottlesBonusCompleted"] = bb;
 
-    std::string globalPath = Ship::Context::GetPathRelativeToAppDirectory("saves/global.json");
+    std::string globalPath = SaveManager_GetSavePath("global.json");
     std::ofstream ofs(globalPath);
     if (ofs.is_open()) {
         ofs << CollapsedJSONArray(j);
@@ -517,7 +528,7 @@ void SaveManager_Init() {
     SaveManager_LoadAll();
 
     // Ensure global.json exists
-    std::string globalPath = Ship::Context::GetPathRelativeToAppDirectory("saves/global.json");
+    std::string globalPath = SaveManager_GetSavePath("global.json");
     if (!fs::exists(globalPath)) {
         SaveGlobalData();
     }
@@ -546,7 +557,7 @@ void SaveManager_Init() {
             std::string collapsedString = CollapsedJSONArray(saveFile);
 
             std::string fileName = "file" + std::to_string(SlotToFileIndex(ev->fileNum)) + ".json";
-            std::string filePath = Ship::Context::GetPathRelativeToAppDirectory("saves/" + fileName);
+            std::string filePath = SaveManager_GetSavePath(fileName);
 
             std::ofstream outputFile(filePath);
             if (outputFile.is_open()) {

--- a/src/port/save/SaveManager.cpp
+++ b/src/port/save/SaveManager.cpp
@@ -27,7 +27,7 @@ static bool mLoaded = false;
 
 std::string SaveManager_GetSavePath(const std::string& filename) {
     const char* romName = port_getRomhackName();
-    if (romName && romName[0] != '\0') {
+    if (!Ship_IsCStringEmpty(romName)) {
         std::string dir = Ship::Context::GetPathRelativeToAppDirectory("saves/" + std::string(romName));
         fs::create_directories(dir);
         return dir + "/" + filename;

--- a/src/port/save/SaveManager.h
+++ b/src/port/save/SaveManager.h
@@ -1,7 +1,9 @@
 #ifndef SAVE_MANAGER_H
 #define SAVE_MANAGER_H
 #include "ship/Context.h"
+#include <string>
 
 void SaveManager_Init();
+std::string SaveManager_GetSavePath(const std::string& filename);
 
 #endif // SAVE_MANAGER_H


### PR DESCRIPTION
This fixes a crash in Nostalgia64 and is correct for N64 behavior, where GFX comes before VTX. We add a sentinel byte because some models exported by Torch don't have an ENDDL byte, so the importer reads past the DL into the next chunk. On N64, this would be the VTX section which is harmless. If GFX is the final chunk, though, we read into heap and can crash. But we also add a sentinel byte so we don't shoot past the end of the DL in the first place.

Also fixes a bug in importing move flags from romhacks.

Also fixes save isolation which was lost in the transition to the new save system.