### PR TITLE
Fix viBlack emulation for Metal

### DIFF
--- a/src/port/Engine.cpp
+++ b/src/port/Engine.cpp
@@ -1129,7 +1129,7 @@ void GameEngine::RunCommands(Gfx* Commands, const std::vector<std::unordered_map
 
     interpreter->mInterpolationIndex = 0;
 
-    // [port] Expand DrawAndRunGraphicsCommands so we can read the backbuffer between
+    // Expand DrawAndRunGraphicsCommands so we can read the backbuffer between
     // Run() (frame rendered) and EndFrame() (buffer swap). On N64, CPU/RDP shared
     // physical memory so gFramebuffers always had valid pixel data after rendering.
     auto wndBase = Ship::Context::GetInstance()->GetWindow();
@@ -1137,7 +1137,7 @@ void GameEngine::RunCommands(Gfx* Commands, const std::vector<std::unordered_map
     size_t frameCount = mtx_replacements.size();
     for (const auto& m : mtx_replacements) {
         bool isFinalFrame = (frameIdx == frameCount - 1);
-        // [port] Bypass IsFrameReady() when interpolation is active — render all
+        // Bypass IsFrameReady() when interpolation is active — render all
         // frames per tick and let vsync pace them.
         if (frameCount > 1 || wndBase->IsFrameReady()) {
             auto gui = wndBase->GetGui();
@@ -1145,14 +1145,16 @@ void GameEngine::RunCommands(Gfx* Commands, const std::vector<std::unordered_map
             gui->StartDraw();
             interpreter->StartFrame();
             interpreter->Run(Commands, m);
-            // [port] Emulate N64 osViBlack: skip presentation so the previous
-            // frame stays on screen (readback still runs so transitions can capture).
-            gui->EndDraw();
+            // Emulate N64 osViBlack to prevent a flicker when the scene is drawn
+            // for the falling jiggy transition framebuffer capture.
             if (port_isViBlack()) {
-                interpreter->Flush();
-            } else {
-                interpreter->EndFrame();
+                interpreter->mGfxFrameBuffer = 0;
+                auto rapi = interpreter->GetCurrentRenderingAPI();
+                rapi->StartDrawToFramebuffer(0, 1.0f);
+                rapi->ClearFramebuffer(true, false);
             }
+            gui->EndDraw();
+            interpreter->EndFrame();
         }
         interpreter->mInterpolationIndex++;
         frameIdx++;


### PR DESCRIPTION
Fixes a stutter during viBlack transitions and a title logo flash that affected all backends but was most easily noticed with Metal.

The previous `Flush()-on-viBlack` path skipped presentation to freeze the last frame, but Metal's `EndFrame()` is where command buffers commit, the drawable presents, and the frame autorelease pool releases — skipping it leaked drawables and stalled `nextDrawable()`.

Now we always call `EndFrame()` and blank the game output on viBlack frames:

Zero `mGfxFrameBuffer` so ImGui skips compositing `mGameFb` (covers `mRendersToFb=true`).
Clear `fb 0` directly so direct-to-screen draws get wiped (covers `mRendersToFb=false`.