### PR TITLE
Fix dlist stack overflow: static sizing + overflow guard

### DIFF
--- a/include/core1/core1.h
+++ b/include/core1/core1.h
@@ -121,12 +121,12 @@ void func_80254028(void);
 void drawRectangle2D(Gfx **gfx, s32 x, s32 y, s32 w, s32 h, s32 r, s32 g, s32 b);
 void graphicsCache_release(void);
 void graphicsCache_init(void);
+void graphicsCache_checkFrame(Gfx *gfxStart, Gfx *gfxEnd, Mtx *mtxStart, Mtx *mtxEnd, Vtx *vtxStart, Vtx *vtxEnd);
 void scissorBox_set(s32 left, s32 top, s32 right, s32 bottom);
 void scissorBox_setDefault(void);
 void func_80254374(s32 arg0);
 void toggleTextureFilterPoint(void);
 void getGraphicsStacks(Gfx **gfx, Mtx **mtx, Vtx **vtx);
-void graphicsCache_reportUsage(Gfx *gfxEnd, Gfx *gfxStart, Mtx *mtxEnd, Mtx *mtxStart, Vtx *vtxEnd, Vtx *vtxStart);
 void dummy_func_80254464(void);
 
 /* src/core1/defragmanager.c */

--- a/src/core1/display_list.c
+++ b/src/core1/display_list.c
@@ -15,16 +15,11 @@ static Mtx *sMtxStack[2];
 static Vtx *sVtxStack[2];
 static s32 sStackSelector;
 
-#define INITIAL_GFX_COUNT 3700
-#define INITIAL_MTX_COUNT 700
-#define INITIAL_VTX_COUNT 430
+// [port] Expand DL stack sizes to support draw distance enhancements
+#define GFX_STACK_COUNT 11100
+#define MTX_STACK_COUNT 2100
+#define VTX_STACK_COUNT 1290
 
-static s32 sGfxCapacity;
-static s32 sMtxCapacity;
-static s32 sVtxCapacity;
-static s32 sGfxPeakUsed;
-static s32 sMtxPeakUsed;
-static s32 sVtxPeakUsed;
 s32  gTextureFilterPoint;
 Struct_Core1_15B30 D_80283008[20];
 s32 D_802831E8;
@@ -221,32 +216,48 @@ void drawRectangle2D(Gfx **gfx, s32 x, s32 y, s32 w, s32 h, s32 r, s32 g, s32 b)
 
 void graphicsCache_release(void) {
     if (sGfxStack[0]) {
-        bk_free(sGfxStack[0]);
-        bk_free(sGfxStack[1]);
-        bk_free(sMtxStack[0]);
-        bk_free(sMtxStack[1]);
-        bk_free(sVtxStack[0]);
-        bk_free(sVtxStack[1]);
+        GameEngine_Free(sGfxStack[0]);
+        GameEngine_Free(sGfxStack[1]);
+        GameEngine_Free(sMtxStack[0]);
+        GameEngine_Free(sMtxStack[1]);
+        GameEngine_Free(sVtxStack[0]);
+        GameEngine_Free(sVtxStack[1]);
         sGfxStack[0] = NULL;
     }
 }
 
 void graphicsCache_init(void){
     if(sGfxStack[0] == NULL){
-        sGfxCapacity = INITIAL_GFX_COUNT;
-        sMtxCapacity = INITIAL_MTX_COUNT;
-        sVtxCapacity = INITIAL_VTX_COUNT;
-        sGfxPeakUsed = sMtxPeakUsed = sVtxPeakUsed = 0;
-        sGfxStack[0] = (Gfx *)GameEngine_Malloc(sGfxCapacity * sizeof(Gfx));
-        sGfxStack[1] = (Gfx *)GameEngine_Malloc(sGfxCapacity * sizeof(Gfx));
-        sMtxStack[0] = (Mtx *)GameEngine_Malloc(sMtxCapacity * sizeof(Mtx));
-        sMtxStack[1] = (Mtx *)GameEngine_Malloc(sMtxCapacity * sizeof(Mtx));
-        sVtxStack[0] = (Vtx *)GameEngine_Malloc(sVtxCapacity * sizeof(Vtx));
-        sVtxStack[1] = (Vtx *)GameEngine_Malloc(sVtxCapacity * sizeof(Vtx));
+        sGfxStack[0] = (Gfx *)GameEngine_Malloc(GFX_STACK_COUNT * sizeof(Gfx));
+        sGfxStack[1] = (Gfx *)GameEngine_Malloc(GFX_STACK_COUNT * sizeof(Gfx));
+        sMtxStack[0] = (Mtx *)GameEngine_Malloc(MTX_STACK_COUNT * sizeof(Mtx));
+        sMtxStack[1] = (Mtx *)GameEngine_Malloc(MTX_STACK_COUNT * sizeof(Mtx));
+        sVtxStack[0] = (Vtx *)GameEngine_Malloc(VTX_STACK_COUNT * sizeof(Vtx));
+        sVtxStack[1] = (Vtx *)GameEngine_Malloc(VTX_STACK_COUNT * sizeof(Vtx));
         dummy_func_80254464();
     }
     sStackSelector = 0;
     gTextureFilterPoint = 0;
+}
+
+// [port] Verify the frame's dlist emission fit within the static stack
+// capacities. If it didn't, we've already written past the buffer and
+// corrupted the heap, but logging it loudly (instead of silently deferring
+// to a CRT debug-heap break at the next malloc/free) makes the root cause
+// obvious. Mirrors Shipwright's THGA_IsCrash() canary pattern.
+void graphicsCache_checkFrame(Gfx *gfxStart, Gfx *gfxEnd, Mtx *mtxStart, Mtx *mtxEnd, Vtx *vtxStart, Vtx *vtxEnd) {
+    s32 gfxUsed = (s32)(gfxEnd - gfxStart);
+    s32 mtxUsed = (s32)(mtxEnd - mtxStart);
+    s32 vtxUsed = (s32)(vtxEnd - vtxStart);
+    if (gfxUsed > GFX_STACK_COUNT) {
+        BK_LOG_ERROR("Gfx stack overflow: %d used vs %d capacity", gfxUsed, GFX_STACK_COUNT);
+    }
+    if (mtxUsed > MTX_STACK_COUNT) {
+        BK_LOG_ERROR("Mtx stack overflow: %d used vs %d capacity", mtxUsed, MTX_STACK_COUNT);
+    }
+    if (vtxUsed > VTX_STACK_COUNT) {
+        BK_LOG_ERROR("Vtx stack overflow: %d used vs %d capacity", vtxUsed, VTX_STACK_COUNT);
+    }
 }
 
 void scissorBox_set(s32 left, s32 top, s32 right, s32 bottom) {
@@ -281,31 +292,7 @@ void toggleTextureFilterPoint(void){
     gTextureFilterPoint = ret_val < 1;
 }
 
-static void _graphicsCache_growIfNeeded(void **stack0, void **stack1, s32 *capacity, s32 peakUsed, size_t elemSize) {
-    if (peakUsed > *capacity * 3 / 4) {
-        s32 newCap = peakUsed * 2;
-        GameEngine_Free(*stack0);
-        GameEngine_Free(*stack1);
-        *stack0 = GameEngine_Malloc(newCap * elemSize);
-        *stack1 = GameEngine_Malloc(newCap * elemSize);
-        *capacity = newCap;
-    }
-}
-
-void graphicsCache_reportUsage(Gfx *gfxEnd, Gfx *gfxStart, Mtx *mtxEnd, Mtx *mtxStart, Vtx *vtxEnd, Vtx *vtxStart) {
-    s32 gfxUsed = (s32)(gfxEnd - gfxStart);
-    s32 mtxUsed = (s32)(mtxEnd - mtxStart);
-    s32 vtxUsed = (s32)(vtxEnd - vtxStart);
-    if (gfxUsed > sGfxPeakUsed) sGfxPeakUsed = gfxUsed;
-    if (mtxUsed > sMtxPeakUsed) sMtxPeakUsed = mtxUsed;
-    if (vtxUsed > sVtxPeakUsed) sVtxPeakUsed = vtxUsed;
-}
-
 void getGraphicsStacks(Gfx **gfx, Mtx **mtx, Vtx **vtx){
-    _graphicsCache_growIfNeeded((void **)&sGfxStack[0], (void **)&sGfxStack[1], &sGfxCapacity, sGfxPeakUsed, sizeof(Gfx));
-    _graphicsCache_growIfNeeded((void **)&sMtxStack[0], (void **)&sMtxStack[1], &sMtxCapacity, sMtxPeakUsed, sizeof(Mtx));
-    _graphicsCache_growIfNeeded((void **)&sVtxStack[0], (void **)&sVtxStack[1], &sVtxCapacity, sVtxPeakUsed, sizeof(Vtx));
-
     sStackSelector = (1 - sStackSelector);
     *gfx = sGfxStack[sStackSelector];
     *mtx = sMtxStack[sStackSelector];

--- a/src/core2/frame/rendermem.c
+++ b/src/core2/frame/rendermem.c
@@ -62,7 +62,7 @@ void func_802E329C(s32 arg0, Gfx **gfx_begin, Gfx **gfx_end) {
         func_802F1858(D_8037E8C0.unk10, &gfx, &mtx, &vtx);
     }
     finishFrame(&gfx);
-    graphicsCache_reportUsage(gfx, gfx_start, mtx, mtx_start, vtx, vtx_start);
+    graphicsCache_checkFrame(gfx_start, gfx, mtx_start, mtx, vtx_start, vtx);
     osWritebackDCache(mtx_start, (mtx - mtx_start) * sizeof(Mtx));
     osWritebackDCache(vtx_start, (vtx - vtx_start) * sizeof(Vtx));
     *gfx_begin = gfx_start;

--- a/src/core2/gameloop.c
+++ b/src/core2/gameloop.c
@@ -341,7 +341,7 @@ void game_draw(s32 arg0){
 
     func_802E39D0(&gfx, &mtx, &vtx, getActiveFramebuffer(), arg0);
 
-    graphicsCache_reportUsage(gfx, gfx_start, mtx, mtx_start, vtx, vtx_start);
+    graphicsCache_checkFrame(gfx_start, gfx, mtx_start, mtx, vtx_start, vtx);
 
     // Lighthouse [Port] not sure if this should be here or after the following block
     Graphics_PushFrame(gfx_start);


### PR DESCRIPTION
- Replaces the reactive dynamic-growth display-list stacks with statically-sized buffers big enough for Extended Draw Distance at 100%.
- Adds a post-emission capacity check that logs via `BK_LOG_ERROR` if a frame ever overruns.
- Fixes CRT heap-corruption crashes at higher draw distances and during some runtime CVar changes.

### Background

`src/core1/display_list.c` was using a reactive grow scheme added in #32: each frame reported its peak Gfx/Mtx/Vtx usage, and the next call to `getGraphicsStacks` would double the capacity if peak crossed 3/4. It was added to silence ASAN heap-buffer-overflow reports on the original N64 sizes (3700/700/430).

The scheme doesn't actually prevent overflow. Peak is recorded *after* the frame has already written, so any frame whose usage exceeds the current capacity overruns before the grow can react.

### What changed

Stacks are now allocated once at boot at ~3x N64 sizes (11100/2100/1290, ~490 KB total) and freed at shutdown. No runtime resize, no pointer invalidation and matches Shipwright's `GfxPool` pattern.

Added `graphicsCache_checkFrame`, called after the emission sites in `gameloop.c` and `rendermem.c`. It compares frame usage against capacity and logs a loud `BK_LOG_ERROR` with the buffer name and overage if any stack was exceeded. This is the same idea as Shipwright's `THGA_IsCrash` canary; if something does ever overflow, we get an actionable log line instead of a silent heap corruption that surfaces frames later.
