### PR TITLE
[RANDO] Clean up & Organize ObjectBehavior

### DIFF
--- a/src/core2/actor_cubepropsystem.c
+++ b/src/core2/actor_cubepropsystem.c
@@ -956,7 +956,7 @@ void code7AF80_initCubeFromFile(File *file_ptr, Cube *cube) {
                 memcpy(&pos[1], raw + 6, 2);
                 memcpy(&pos[2], raw + 8, 2);
                 memcpy(&flags, raw + 10, 2);
-                CALL_CANCELLABLE_EVENT(OnPropSpawn, (word0 >> 20) & 0xFFF, pos[0], pos[1], pos[2]) {
+                if (!EventSystem_Should(VB_OVERRIDE_PROP_SPAWN, false, pos)) {
                 // Extract flag bits using N64 BE bit positions within the u16
                     {
                         bool mf = flags & 1;            // markerFlag (BE bit 0)

--- a/src/core2/bundle.c
+++ b/src/core2/bundle.c
@@ -144,7 +144,7 @@ Actor *__bundle_spawnWithFirstActor(enum bundle_e bundle_id, f32 position[3], Ac
         }
 
         //L802C9114
-        CALL_CANCELLABLE_EVENT(OnBundleSpawn, bundle_id, gBundle_yaw, bundle_info, i, position[0], position[1], position[2], &actor) {
+        if (!EventSystem_Should(VB_OVERRIDE_BUNDLE_SPAWN, false, bundle_id, bundle_info, i, position, &actor)) {
             actor = (i == 0 && firstActor) ? firstActor : actor_spawnWithYaw_f32(bundle_info->actor_id, position, 0);
             //}
             actor->is_bundle = true;

--- a/src/core2/fx/effect_jiggy_list.c
+++ b/src/core2/fx/effect_jiggy_list.c
@@ -245,7 +245,7 @@ void jiggy_spawn(enum jiggy_e jiggy_id, f32 pos[3]) {
     Struct_core2_ABC00_0 *temp_v0;
 
     jiggy_id = ((jiggy_id <= 0) || (jiggy_id >= (s_jiggyList_level_jiggy_count * 10))) ? JIGGY_A_MM_CONGA : jiggy_id;
-    CALL_CANCELLABLE_EVENT(OnJiggySpawn, jiggy_id, pos[0], pos[1], pos[2]) {
+    if (!EventSystem_Should(VB_OVERRIDE_JIGGY_SPAWN, false, jiggy_id, pos)) {
         temp_v0 = &jiggylist_list[jiggy_id - 1];
         if (jiggylist_list[jiggy_id - 1].unk10.marker == NULL) {
             temp_v0->unk10.position[0] = pos[0];

--- a/src/core2/map/warp_dispatch.c
+++ b/src/core2/map/warp_dispatch.c
@@ -561,6 +561,7 @@ void func_80334448(NodeProp *arg0, ActorMarker *arg1) {
                 // [port] BB romhacks remap warp destinations via BKCF config
                 warpIdx = codeA5BC0_getNodePropUnk8(arg0);
                 warpDest = port_getRomhackWarpDest(warpIdx);
+                CALL_EVENT(OnWarpDispatch, warpIdx, warpDest);
                 if (warpDest >= 0) {
                     func_8031CC8C(arg0, warpDest);
                 } else {

--- a/src/port/Rando/CustomObject/CustomObjectSettings.cpp
+++ b/src/port/Rando/CustomObject/CustomObjectSettings.cpp
@@ -45,6 +45,7 @@ std::map<RandoCheckId, BundlePhysics> customActorPhysicsMap = {
     { RC_MM_JIGGY_CHIMPY, { 0, 800.0f, 0, 0, 10.0f, 0, 0, 0x1 } },
     { RC_MM_JIGGY_CONGA, { 150.0f, 175.0f, 0, 0, 10.0f, 0, 0, 0x1 } },
     { RC_MM_JIGGY_HUTS, { 200.0f, 300.0f, 0, 0, 10.0f, 0, 0, 0x1 } },
+    { RC_MM_JIGGY_JUJU, { 0, 300.0f, 0, 0, 10.0f, 0, 0, 0x1 } },
 };
 
 BundlePhysics GetPhysicsByCheckId(RandoCheckId randoCheckId) {

--- a/src/port/Rando/ObjectBehavior/Bundle.cpp
+++ b/src/port/Rando/ObjectBehavior/Bundle.cpp
@@ -1,0 +1,70 @@
+#include "ObjectBehavior.h"
+#include "port/Rando/Logic/Logic.h"
+#include "port/Rando/CustomObject/CustomObject.h"
+
+#include <libultraship/bridge.h>
+#include "port/ui/cvar_prefixes.h"
+#include <libultraship/bridge/consolevariablebridge.h>
+#include "port/enhancements/events/PortEnhancements.h"
+#include "port/enhancements/events/hooks/Events.h"
+
+extern "C" {
+extern f32 gBundle_yaw;
+}
+
+void Rando::ObjectBehavior::InitBundleBehavior() {
+    COND_VB_SHOULD(VB_OVERRIDE_BUNDLE_SPAWN, EVENT_PRIORITY_NORMAL, true, {
+        bundle_e bundleId = va_arg(args, bundle_e);
+        BundleInfo* bundleInfo = va_arg(args, BundleInfo*);
+        s32 bundleCount = va_arg(args, s32);
+		f32* position = va_arg(args, f32*);
+        Actor* actor = va_arg(args, Actor*);
+
+        int32_t spawnPosition[3];
+        spawnPosition[0] = (int32_t)position[0];
+        spawnPosition[1] = (int32_t)position[1];
+        spawnPosition[2] = (int32_t)position[2];
+
+        Rando::StaticData::RandoShuffledPool randoShuffledObject;
+        randoShuffledObject.randoCheckId = RC_UNKNOWN;
+
+        switch (bundleId) {
+            case BUNDLE_3_MM_HUT_JINJO_GREEN:
+                randoShuffledObject = Rando::Logic::GetShuffledObject(RC_MM_JINJO_GREEN);
+                break;
+            case BUNDLE_4_MM_HUT_JIGGY:
+                if (spawnPosition[1] < 2000) {
+                    randoShuffledObject = Rando::Logic::GetShuffledObject(RC_MM_JIGGY_ORANGE_PADS);
+                } else {
+                    randoShuffledObject = Rando::Logic::GetShuffledObject(RC_MM_JIGGY_HUTS);
+                }
+                break;
+            case BUNDLE_0_MM_HUT_MUSIC_NOTE:
+                randoShuffledObject =
+                    Rando::Logic::GetShuffledObject((RandoCheckId)((int32_t)RC_MM_NOTE_HUT_BUNDLE_1 + bundleCount));
+                break;
+            default:
+                return;
+        }
+
+        if (randoShuffledObject.randoCheckId == RC_UNKNOWN) {
+            return;
+        }
+
+        actor = CustomObject::SpawnCustomActor(
+            (actor_e)Rando::StaticData::Items[randoShuffledObject.randoItemId].actorId, spawnPosition);
+        if (actor == NULL) {
+            return;
+        }
+
+        actor = CustomObject::SetCustomActorParameters(actor, randoShuffledObject.randoCheckId);
+        CustomObject::AddToCustomActorMap(randoShuffledObject.randoCheckId, actor);
+        if (randoShuffledObject.randoCheckId == RC_MM_JIGGY_HUTS) {
+            ApplyCustomActorPhysics(randoShuffledObject.randoCheckId, actor);
+        } else {
+            ApplyBundleActorPhysics(actor, bundleId, (BundleInfo*)bundleInfo, gBundle_yaw);
+        }
+
+        *should = true;
+	})
+}

--- a/src/port/Rando/ObjectBehavior/Jiggy.cpp
+++ b/src/port/Rando/ObjectBehavior/Jiggy.cpp
@@ -1,0 +1,51 @@
+#include "ObjectBehavior.h"
+#include "port/Rando/Logic/Logic.h"
+#include "port/Rando/CustomObject/CustomObject.h"
+
+#include <libultraship/bridge.h>
+#include "port/ui/cvar_prefixes.h"
+#include <libultraship/bridge/consolevariablebridge.h>
+#include "port/enhancements/events/PortEnhancements.h"
+#include "port/enhancements/events/hooks/Events.h"
+
+// TODO: SWAP TO RANDO_SAVE_OPTIONS
+#define CVAR_NAME Rando::StaticData::Options[RO_SHUFFLE_JIGGIES].cvar
+#define CVAR CVarGetInteger(CVAR_NAME, 0)
+
+void Rando::ObjectBehavior::InitJiggyBehavior() {
+    COND_VB_SHOULD(VB_OVERRIDE_JIGGY_SPAWN, EVENT_PRIORITY_NORMAL, true, {
+		jiggy_e jiggyId = va_arg(args, jiggy_e);
+        f32* position = va_arg(args, f32*);
+
+        if (CVAR) {
+            RandoCheckId randoCheckId = Rando::StaticData::GetCheckByJiggyId(jiggyId);
+            
+            if (randoCheckId == RC_UNKNOWN) {
+                return;
+            }
+            
+            Rando::StaticData::RandoShuffledPool randoShuffledObject;
+            randoShuffledObject.randoCheckId = RC_UNKNOWN;
+            
+            randoShuffledObject = Rando::Logic::GetShuffledObject(randoCheckId);
+            if (randoShuffledObject.randoCheckId == RC_UNKNOWN) {
+                return;
+            }
+            
+            int32_t spawnPosition[3];
+            spawnPosition[0] = (int32_t)position[0];
+            spawnPosition[1] = (int32_t)position[1];
+            spawnPosition[2] = (int32_t)position[2];
+            
+            Actor* newCustomActor = CustomObject::SpawnCustomActor(
+                (actor_e)Rando::StaticData::Items[randoShuffledObject.randoItemId].actorId, spawnPosition);
+            newCustomActor = CustomObject::SetCustomActorParameters(newCustomActor, randoCheckId);
+            CustomObject::AddToCustomActorMap(randoCheckId, newCustomActor);
+            
+            ApplyCustomActorPhysics(randoCheckId, newCustomActor);
+            
+            CustomObject::InitializeSpawnQueue();
+            *should = true;
+        }
+	})
+}

--- a/src/port/Rando/ObjectBehavior/ObjectBehavior.cpp
+++ b/src/port/Rando/ObjectBehavior/ObjectBehavior.cpp
@@ -105,6 +105,7 @@ bool ShouldOverrideSpawn(RandoCheckId randoCheckId) {
 
 // Entry point for the module, run once on game boot
 void Rando::ObjectBehavior::Init() {
+    InitJiggyBehavior();
     InitMolehillBehavior();
 
     REGISTER_LISTENER(OnActorSpawn, EVENT_PRIORITY_NORMAL, [](IEvent* event) {
@@ -240,47 +241,6 @@ void Rando::ObjectBehavior::Init() {
             ApplyBundleActorPhysics(*ev->result, ev->bundle_id, (BundleInfo*)ev->bundleInfo, ev->bundleYaw);
         }
 
-        event->cancelled = true;
-    })
-
-    REGISTER_LISTENER(OnJiggySpawn, EVENT_PRIORITY_NORMAL, [](IEvent* event) {
-        OnJiggySpawn* ev = (OnJiggySpawn*)event;
-
-        // if (!IS_RANDO) {
-        //     return;
-        // }
-
-        if (map_getLevel(gsworld_getMap()) != LEVEL_1_MUMBOS_MOUNTAIN) {
-            return;
-        }
-
-        RandoCheckId randoCheckId = Rando::StaticData::GetCheckByJiggyId(ev->jiggyId);
-
-        if (randoCheckId == RC_UNKNOWN) {
-            return;
-        }
-
-        Rando::StaticData::RandoShuffledPool randoShuffledObject;
-        randoShuffledObject.randoCheckId = RC_UNKNOWN;
-
-        randoShuffledObject = Rando::Logic::GetShuffledObject(randoCheckId);
-        if (randoShuffledObject.randoCheckId == RC_UNKNOWN) {
-            return;
-        }
-
-        int32_t position[3];
-        position[0] = (int32_t)ev->posX;
-        position[1] = (int32_t)ev->posY;
-        position[2] = (int32_t)ev->posZ;
-
-        Actor* newCustomActor = CustomObject::SpawnCustomActor(
-            (actor_e)Rando::StaticData::Items[randoShuffledObject.randoItemId].actorId, position);
-        newCustomActor = CustomObject::SetCustomActorParameters(newCustomActor, randoCheckId);
-        CustomObject::AddToCustomActorMap(randoCheckId, newCustomActor);
-
-        ApplyCustomActorPhysics(randoCheckId, newCustomActor);
-
-        CustomObject::InitializeSpawnQueue();
         event->cancelled = true;
     })
 

--- a/src/port/Rando/ObjectBehavior/ObjectBehavior.cpp
+++ b/src/port/Rando/ObjectBehavior/ObjectBehavior.cpp
@@ -105,6 +105,7 @@ bool ShouldOverrideSpawn(RandoCheckId randoCheckId) {
 
 // Entry point for the module, run once on game boot
 void Rando::ObjectBehavior::Init() {
+    InitBundleBehavior();
     InitJiggyBehavior();
     InitMolehillBehavior();
     InitPropBehavior();
@@ -157,66 +158,6 @@ void Rando::ObjectBehavior::Init() {
                 ev->result = NULL;
                 break;
         }
-    })
-
-    REGISTER_LISTENER(OnBundleSpawn, EVENT_PRIORITY_NORMAL, [](IEvent* event) {
-        OnBundleSpawn* ev = (OnBundleSpawn*)event;
-
-        BundleInfo* bundle_info = (BundleInfo*)ev->bundleInfo;
-
-        // if (!IS_RANDO) {
-        //     return;
-        // }
-
-        if (map_getLevel(gsworld_getMap()) != LEVEL_1_MUMBOS_MOUNTAIN) {
-            return;
-        }
-
-        int32_t position[3];
-        position[0] = (int32_t)ev->posX;
-        position[1] = (int32_t)ev->posY;
-        position[2] = (int32_t)ev->posZ;
-
-        Rando::StaticData::RandoShuffledPool randoShuffledObject;
-        randoShuffledObject.randoCheckId = RC_UNKNOWN;
-
-        switch (ev->bundle_id) {
-            case BUNDLE_3_MM_HUT_JINJO_GREEN:
-                randoShuffledObject = Rando::Logic::GetShuffledObject(RC_MM_JINJO_GREEN);
-                break;
-            case BUNDLE_4_MM_HUT_JIGGY:
-                if (position[1] < 2000) {
-                    randoShuffledObject = Rando::Logic::GetShuffledObject(RC_MM_JIGGY_ORANGE_PADS);
-                } else {
-                    randoShuffledObject = Rando::Logic::GetShuffledObject(RC_MM_JIGGY_HUTS);
-                }
-                break;
-            case BUNDLE_0_MM_HUT_MUSIC_NOTE:
-                randoShuffledObject = Rando::Logic::GetShuffledObject((RandoCheckId)((int32_t)RC_MM_NOTE_HUT_BUNDLE_1 + ev->curCount));
-                break;
-            default:
-                return;
-        }
-
-        if (randoShuffledObject.randoCheckId == RC_UNKNOWN) {
-            return;
-        }
-
-        *ev->result = CustomObject::SpawnCustomActor(
-            (actor_e)Rando::StaticData::Items[randoShuffledObject.randoItemId].actorId, position);
-        if (*ev->result == NULL) {
-            return;
-        }
-
-        *ev->result = CustomObject::SetCustomActorParameters(*ev->result, randoShuffledObject.randoCheckId);
-        CustomObject::AddToCustomActorMap(randoShuffledObject.randoCheckId, *ev->result);
-        if (randoShuffledObject.randoCheckId == RC_MM_JIGGY_HUTS) {
-            ApplyCustomActorPhysics(randoShuffledObject.randoCheckId, *ev->result);
-        } else {
-            ApplyBundleActorPhysics(*ev->result, ev->bundle_id, (BundleInfo*)ev->bundleInfo, ev->bundleYaw);
-        }
-
-        event->cancelled = true;
     })
 
     REGISTER_LISTENER(OnActorSaveState, EVENT_PRIORITY_NORMAL, [](IEvent* event) {

--- a/src/port/Rando/ObjectBehavior/ObjectBehavior.cpp
+++ b/src/port/Rando/ObjectBehavior/ObjectBehavior.cpp
@@ -87,31 +87,7 @@ void SendCollisionNotification(RandoItemId randoItemId) {
                          .messageColor = WIDGET_TEXT_COLOR(randoItemColors.at(randoItemId)) });
 };
 
-bool ShouldOverrideSpawn(int32_t posX, int32_t posY, int32_t posZ) {
-    RandoCheckId randoCheckId = Rando::StaticData::GetCheckByPosition(posX, posY, posZ);
-    if (randoCheckId == RC_UNKNOWN) {
-        return false;
-    }
-
-    if (CustomObject::CheckSpawnQueue(randoCheckId)) {
-        return false;
-    }
-
-    if (Rando::Logic::IsCheckShuffled(randoCheckId)) {
-        int32_t position[3];
-        position[0] = posX;
-        position[1] = posY;
-        position[2] = posZ;
-
-        CustomObject::AddToSpawnQueue(randoCheckId, position);
-
-        return true;
-    }
-
-    return false;
-}
-
-bool ShouldOverride(RandoCheckId randoCheckId) {
+bool ShouldOverrideSpawn(RandoCheckId randoCheckId) {
     if (randoCheckId == RC_UNKNOWN) {
         return false;
     }
@@ -157,7 +133,7 @@ void Rando::ObjectBehavior::Init() {
 
         RandoCheckId randoCheckId = Rando::StaticData::GetCheckByPosition(ev->posX, ev->posY, ev->posZ);
         
-        if (!ShouldOverride(randoCheckId)) {
+        if (!ShouldOverrideSpawn(randoCheckId)) {
             return;
         }
 
@@ -191,10 +167,20 @@ void Rando::ObjectBehavior::Init() {
         if (map_getLevel(gsworld_getMap()) != LEVEL_1_MUMBOS_MOUNTAIN) {
             return;
         }
-                
-        if (ShouldOverrideSpawn(ev->posX, ev->posY, ev->posZ)) {
-            event->cancelled = true;
+
+        RandoCheckId randoCheckId = Rando::StaticData::GetCheckByPosition(ev->posX, ev->posY, ev->posZ);
+
+        if (!ShouldOverrideSpawn(randoCheckId)) {
+            return;
         }
+
+        int32_t position[3];
+        position[0] = ev->posX;
+        position[1] = ev->posY;
+        position[2] = ev->posZ;
+
+        CustomObject::AddToSpawnQueue(randoCheckId, position);
+        event->cancelled = true;
     })
 
     REGISTER_LISTENER(OnBundleSpawn, EVENT_PRIORITY_NORMAL, [](IEvent* event) {
@@ -326,7 +312,6 @@ void Rando::ObjectBehavior::Init() {
         RandoItemId randoItemId = RI_UNKNOWN;
 
         if (!ev->propId->markerFlag) {
-            BK_LOG_INFO("!MarkerFlag");
             switch (ev->propId->spriteProp.spriteId) {
                 case RP_MUSIC_NOTE:
                     LogOutCollision(ACTOR_51_MUSIC_NOTE, ev->propId->actorProp.x, ev->propId->actorProp.y,
@@ -337,7 +322,6 @@ void Rando::ObjectBehavior::Init() {
                     break;
             }
         } else {
-            BK_LOG_INFO("IS MarkerFlag");
             Actor* markerActor = marker_getActor(ev->propId->actorProp.marker);
 
             if (markerActor->is_bundle && func_802C9C14(markerActor)) {
@@ -380,10 +364,19 @@ void Rando::ObjectBehavior::Init() {
             }
         }
 
-        BK_LOG_INFO("RandoItem: %i", randoItemId);
         if (randoItemId != RI_UNKNOWN) {
             CustomObject::ObjectCollected(ev->propId);
             SendCollisionNotification(randoItemId);
         }
+    })
+
+    REGISTER_LISTENER(OnWarpDispatch, EVENT_PRIORITY_NORMAL, [](IEvent* event) {
+        OnWarpDispatch* ev = (OnWarpDispatch*)event;
+
+        // if (!IS_RANDO) {
+        //     return;
+        // }
+
+        CustomObject::InitializeSpawnQueue();
     })
 }

--- a/src/port/Rando/ObjectBehavior/ObjectBehavior.cpp
+++ b/src/port/Rando/ObjectBehavior/ObjectBehavior.cpp
@@ -107,6 +107,7 @@ bool ShouldOverrideSpawn(RandoCheckId randoCheckId) {
 void Rando::ObjectBehavior::Init() {
     InitJiggyBehavior();
     InitMolehillBehavior();
+    InitPropBehavior();
 
     REGISTER_LISTENER(OnActorSpawn, EVENT_PRIORITY_NORMAL, [](IEvent* event) {
         OnActorSpawn* ev = (OnActorSpawn*)event;
@@ -156,32 +157,6 @@ void Rando::ObjectBehavior::Init() {
                 ev->result = NULL;
                 break;
         }
-    })
-
-    REGISTER_LISTENER(OnPropSpawn, EVENT_PRIORITY_NORMAL, [](IEvent* event) {
-        OnPropSpawn* ev = (OnPropSpawn*)event;
-
-        // if (!IS_RANDO) {
-        //     return;
-        // }
-
-        if (map_getLevel(gsworld_getMap()) != LEVEL_1_MUMBOS_MOUNTAIN) {
-            return;
-        }
-
-        RandoCheckId randoCheckId = Rando::StaticData::GetCheckByPosition(ev->posX, ev->posY, ev->posZ);
-
-        if (!ShouldOverrideSpawn(randoCheckId)) {
-            return;
-        }
-
-        int32_t position[3];
-        position[0] = ev->posX;
-        position[1] = ev->posY;
-        position[2] = ev->posZ;
-
-        CustomObject::AddToSpawnQueue(randoCheckId, position);
-        event->cancelled = true;
     })
 
     REGISTER_LISTENER(OnBundleSpawn, EVENT_PRIORITY_NORMAL, [](IEvent* event) {

--- a/src/port/Rando/ObjectBehavior/ObjectBehavior.h
+++ b/src/port/Rando/ObjectBehavior/ObjectBehavior.h
@@ -8,6 +8,7 @@ namespace Rando {
 namespace ObjectBehavior {
 
 void Init();
+void InitJiggyBehavior();
 void InitMolehillBehavior();
 
 } // namespace ObjectBehavior

--- a/src/port/Rando/ObjectBehavior/ObjectBehavior.h
+++ b/src/port/Rando/ObjectBehavior/ObjectBehavior.h
@@ -3,6 +3,8 @@
 
 #include "port/Rando/Rando.h"
 
+bool ShouldOverrideSpawn(RandoCheckId randoCheckId);
+
 namespace Rando {
 
 namespace ObjectBehavior {
@@ -10,6 +12,7 @@ namespace ObjectBehavior {
 void Init();
 void InitJiggyBehavior();
 void InitMolehillBehavior();
+void InitPropBehavior();
 
 } // namespace ObjectBehavior
 

--- a/src/port/Rando/ObjectBehavior/ObjectBehavior.h
+++ b/src/port/Rando/ObjectBehavior/ObjectBehavior.h
@@ -10,6 +10,7 @@ namespace Rando {
 namespace ObjectBehavior {
 
 void Init();
+void InitBundleBehavior();
 void InitJiggyBehavior();
 void InitMolehillBehavior();
 void InitPropBehavior();

--- a/src/port/Rando/ObjectBehavior/Prop.cpp
+++ b/src/port/Rando/ObjectBehavior/Prop.cpp
@@ -1,0 +1,34 @@
+#include "ObjectBehavior.h"
+#include "port/Rando/Logic/Logic.h"
+#include "port/Rando/CustomObject/CustomObject.h"
+
+#include <libultraship/bridge.h>
+#include "port/ui/cvar_prefixes.h"
+#include <libultraship/bridge/consolevariablebridge.h>
+#include "port/enhancements/events/PortEnhancements.h"
+#include "port/enhancements/events/hooks/Events.h"
+
+void Rando::ObjectBehavior::InitPropBehavior() {
+	COND_VB_SHOULD(VB_OVERRIDE_PROP_SPAWN, EVENT_PRIORITY_NORMAL, true, {
+		s16* position = va_arg(args, s16*);
+
+		// if (!IS_RANDO) {
+        //     return;
+        // }
+
+        RandoCheckId randoCheckId = Rando::StaticData::GetCheckByPosition(position[0], position[1], position[2]);
+
+        if (!ShouldOverrideSpawn(randoCheckId)) {
+            return;
+        }
+
+        int32_t spawnPosition[3];
+        spawnPosition[0] = (int32_t)position[0];
+        spawnPosition[1] = (int32_t)position[1];
+        spawnPosition[2] = (int32_t)position[2];
+
+        CustomObject::AddToSpawnQueue(randoCheckId, spawnPosition);
+        *should = true;
+	})
+
+}

--- a/src/port/enhancements/events/PortEnhancements.cpp
+++ b/src/port/enhancements/events/PortEnhancements.cpp
@@ -31,6 +31,7 @@ void PortEnhancements_Register() {
     REGISTER_EVENT(OnGameSave);
     REGISTER_EVENT(OnSaveFileLoad);
     REGISTER_EVENT(OnSaveFileSave);
+    REGISTER_EVENT(OnWarpDispatch);
 
     // Register rando events
     REGISTER_EVENT(OnSaveLoad);

--- a/src/port/enhancements/events/PortEnhancements.cpp
+++ b/src/port/enhancements/events/PortEnhancements.cpp
@@ -38,7 +38,6 @@ void PortEnhancements_Register() {
     REGISTER_EVENT(OnActorSpawn);
     REGISTER_EVENT(OnPropSpawn);
     REGISTER_EVENT(OnBundleSpawn);
-    REGISTER_EVENT(OnJiggySpawn);
     REGISTER_EVENT(OnActorSaveState);
     REGISTER_EVENT(OnActorCollision);
 

--- a/src/port/enhancements/events/PortEnhancements.cpp
+++ b/src/port/enhancements/events/PortEnhancements.cpp
@@ -36,7 +36,6 @@ void PortEnhancements_Register() {
     // Register rando events
     REGISTER_EVENT(OnSaveLoad);
     REGISTER_EVENT(OnActorSpawn);
-    REGISTER_EVENT(OnPropSpawn);
     REGISTER_EVENT(OnBundleSpawn);
     REGISTER_EVENT(OnActorSaveState);
     REGISTER_EVENT(OnActorCollision);

--- a/src/port/enhancements/events/PortEnhancements.cpp
+++ b/src/port/enhancements/events/PortEnhancements.cpp
@@ -36,7 +36,6 @@ void PortEnhancements_Register() {
     // Register rando events
     REGISTER_EVENT(OnSaveLoad);
     REGISTER_EVENT(OnActorSpawn);
-    REGISTER_EVENT(OnBundleSpawn);
     REGISTER_EVENT(OnActorSaveState);
     REGISTER_EVENT(OnActorCollision);
 

--- a/src/port/enhancements/events/hooks/EventSystem.h
+++ b/src/port/enhancements/events/hooks/EventSystem.h
@@ -40,6 +40,7 @@ typedef enum VBehaviorID {
     VB_PLAY_JIGGY_DANCE,
     VB_VOID_OUT_GAME_OVER,
     VB_OVERRIDE_MOLEHILL_ABILITY,
+    VB_OVERRIDE_JIGGY_SPAWN,
 } VBehaviorID;
 
 #ifndef __cplusplus

--- a/src/port/enhancements/events/hooks/EventSystem.h
+++ b/src/port/enhancements/events/hooks/EventSystem.h
@@ -42,6 +42,7 @@ typedef enum VBehaviorID {
     VB_OVERRIDE_MOLEHILL_ABILITY,
     VB_OVERRIDE_JIGGY_SPAWN,
     VB_OVERRIDE_PROP_SPAWN,
+    VB_OVERRIDE_BUNDLE_SPAWN,
 } VBehaviorID;
 
 #ifndef __cplusplus

--- a/src/port/enhancements/events/hooks/EventSystem.h
+++ b/src/port/enhancements/events/hooks/EventSystem.h
@@ -41,6 +41,7 @@ typedef enum VBehaviorID {
     VB_VOID_OUT_GAME_OVER,
     VB_OVERRIDE_MOLEHILL_ABILITY,
     VB_OVERRIDE_JIGGY_SPAWN,
+    VB_OVERRIDE_PROP_SPAWN,
 } VBehaviorID;
 
 #ifndef __cplusplus

--- a/src/port/enhancements/events/hooks/list/GameEvent.h
+++ b/src/port/enhancements/events/hooks/list/GameEvent.h
@@ -23,4 +23,9 @@ DEFINE_EVENT(OnSaveFileSave,
 	int32_t fileNum;
 	int32_t * result;
 )
+
+DEFINE_EVENT(OnWarpDispatch,
+	int32_t warpId;
+	int32_t warpDest;
+)
 // clang-format on

--- a/src/port/enhancements/events/hooks/list/RandoEvent.h
+++ b/src/port/enhancements/events/hooks/list/RandoEvent.h
@@ -19,17 +19,6 @@ DEFINE_EVENT(OnActorSpawn,
 	Actor* result;
 )
 
-DEFINE_EVENT(OnBundleSpawn,
-	int32_t bundle_id;
-	f32 bundleYaw;
-	void* bundleInfo;
-	int32_t curCount;
-	f32 posX;
-	f32 posY;
-	f32 posZ;
-	Actor** result; 
-)
-
 DEFINE_EVENT(OnActorSaveState)
 
 DEFINE_EVENT(OnActorCollision,

--- a/src/port/enhancements/events/hooks/list/RandoEvent.h
+++ b/src/port/enhancements/events/hooks/list/RandoEvent.h
@@ -37,13 +37,6 @@ DEFINE_EVENT(OnBundleSpawn,
 	Actor** result; 
 )
 
-DEFINE_EVENT(OnJiggySpawn,
-	int32_t jiggyId;
-	f32 posX;
-	f32 posY;
-	f32 posZ;
-)
-
 DEFINE_EVENT(OnActorSaveState)
 
 DEFINE_EVENT(OnActorCollision,

--- a/src/port/enhancements/events/hooks/list/RandoEvent.h
+++ b/src/port/enhancements/events/hooks/list/RandoEvent.h
@@ -19,13 +19,6 @@ DEFINE_EVENT(OnActorSpawn,
 	Actor* result;
 )
 
-DEFINE_EVENT(OnPropSpawn,
-	int32_t propId;
-	int32_t posX;
-	int32_t posY;
-	int32_t posZ;
-)
-
 DEFINE_EVENT(OnBundleSpawn,
 	int32_t bundle_id;
 	f32 bundleYaw;


### PR DESCRIPTION
This heavily cleans up ObjectBehavior:

- Splits Props, Bundles, Jiggies, and Molehills into their own separate files.
- Removes event defines from PortEnhancements/RandoEvents.
- Migrates new files to VanillaBehavior instead of defined events.
- Addresses some minor inconsistencies.