### PR TITLE
[RANDO] RandoCheckId State checks and Junk Implementation

### DIFF
--- a/src/port/Rando/CustomObject/CustomObject.cpp
+++ b/src/port/Rando/CustomObject/CustomObject.cpp
@@ -137,8 +137,14 @@ void CustomObject::InitializeSpawnQueue() {
         customPosition[2] = customActor.location[2];
 
         Rando::StaticData::RandoShuffledPool shuffledObject = Rando::Logic::GetShuffledObject(customActor.randoCheckId);
+        actor_e randoActorId = GetActorIdByShuffledObjectState(shuffledObject);
 
-        Actor* newCustomActor = CustomObject::SpawnCustomActor((actor_e)Rando::StaticData::Items[shuffledObject.randoItemId].actorId, customPosition);
+        if (randoActorId == ACTOR_1_UNKNOWN) {
+            isSpawned = true;
+            continue;
+        }
+
+        Actor* newCustomActor = CustomObject::SpawnCustomActor(randoActorId, customPosition);
         
         if (newCustomActor != NULL) {
             newCustomActor = CustomObject::SetCustomActorParameters(newCustomActor, customActor.randoCheckId);

--- a/src/port/Rando/CustomObject/CustomObject.h
+++ b/src/port/Rando/CustomObject/CustomObject.h
@@ -3,6 +3,7 @@
 
 #include <stdint.h>
 #include "port/Rando/Types.h"
+#include "port/Rando/StaticData/StaticData.h"
 
 #include "prop.h"
 
@@ -31,8 +32,11 @@ typedef struct {
 } BundleInfo;
 
 CustomActor CreateCustomActor(RandoCheckId randoCheckId, int32_t position[3]);
+actor_e GetActorIdByShuffledObjectState(Rando::StaticData::RandoShuffledPool shuffledObject);
 void ApplyBundleActorPhysics(Actor* actor, int32_t bundle_id, BundleInfo* bundle_info, f32 bundleYaw);
 void ApplyCustomActorPhysics(RandoCheckId randoCheckId, Actor* actor);
+
+void UpdateJunkList();
 
 class CustomObject {
 public:

--- a/src/port/Rando/LighthouseMenuRando.cpp
+++ b/src/port/Rando/LighthouseMenuRando.cpp
@@ -5,7 +5,7 @@
 #include "port/ResourceHelpers.h"
 #include "port/ui/UIWidgets.hpp"
 
-#include "port/Rando/StaticData/StaticData.h"
+#include "port/Rando/CustomObject/CustomObject.h"
 
 extern "C" {
 #include "variables.h"
@@ -19,44 +19,73 @@ using namespace UIWidgets;
 
 void LighthouseMenu::AddMenuRando() {
 
-// Add Rando Menu
-AddMenuEntry("Rando", CVAR_SETTING("Menu.RandoSidebarSection"));
-
-// Rando - General
-AddSidebarEntry("Rando", "General", 1);
-WidgetPath path = { "Rando", "General", SECTION_COLUMN_1 };
-
-AddWidget(path, "Enable Rando", WIDGET_SEPARATOR_TEXT);
-
-AddWidget(path, "Enable Rando", WIDGET_CVAR_CHECKBOX)
-    .CVar(CVAR_RANDOMIZER_SETTING("Enable"))
-    .Options(CheckboxOptions().Tooltip("Enables Randomizer on the next new save file."));
-
-// Rando - Shuffle Options
-AddSidebarEntry("Rando", "Shuffle Options", 1);
-path = { "Rando", "Shuffle Options", SECTION_COLUMN_1 };
-
-AddWidget(path, "Shuffle Collectables", WIDGET_SEPARATOR_TEXT);
-
-AddWidget(path, "Shuffle Empty Honeycombs", WIDGET_CVAR_CHECKBOX)
-    .CVar(Rando::StaticData::Options[RO_SHUFFLE_EMPTY_HONEYCOMBS].cvar)
-    .Options(CheckboxOptions().Tooltip("Shuffles Empty Honeycombs into the Pool."));
-AddWidget(path, "Shuffle Jiggies", WIDGET_CVAR_CHECKBOX)
-    .CVar(Rando::StaticData::Options[RO_SHUFFLE_JIGGIES].cvar)
-    .Options(CheckboxOptions().Tooltip("Shuffles Jiggies into the Pool."));
-AddWidget(path, "Shuffle Jinjos", WIDGET_CVAR_CHECKBOX)
-    .CVar(Rando::StaticData::Options[RO_SHUFFLE_JINJOS].cvar)
-    .Options(CheckboxOptions().Tooltip("Shuffles Jinjos into the Pool."));
-AddWidget(path, "Shuffle Molehills", WIDGET_CVAR_CHECKBOX)
-    .CVar(Rando::StaticData::Options[RO_SHUFFLE_MOLEHILLS].cvar)
-    .Options(CheckboxOptions().Tooltip("Shuffles which abilities each Molehill unlocks."));
-AddWidget(path, "Shuffle Mumbo Tokens", WIDGET_CVAR_CHECKBOX)
-    .CVar(Rando::StaticData::Options[RO_SHUFFLE_MUMBO_TOKENS].cvar)
-    .Options(CheckboxOptions().Tooltip("Shuffles Mumbo Tokens into the Pool."));
-AddWidget(path, "Shuffle Music Notes", WIDGET_CVAR_CHECKBOX)
-    .CVar(Rando::StaticData::Options[RO_SHUFFLE_MUSIC_NOTES].cvar)
-    .Options(CheckboxOptions().Tooltip("Shuffles Music Notes into the Pool."));
-
+    // Add Rando Menu
+    AddMenuEntry("Rando", CVAR_SETTING("Menu.RandoSidebarSection"));
+    
+    // Rando - General
+    AddSidebarEntry("Rando", "General", 1);
+    WidgetPath path = { "Rando", "General", SECTION_COLUMN_1 };
+    
+    AddWidget(path, "Enable Rando", WIDGET_SEPARATOR_TEXT);
+    
+    AddWidget(path, "Enable Rando", WIDGET_CVAR_CHECKBOX)
+        .CVar(CVAR_RANDOMIZER_SETTING("Enable"))
+        .Options(CheckboxOptions().Tooltip("Enables Randomizer on the next new save file."));
+    
+    // Rando - Shuffle Options
+    AddSidebarEntry("Rando", "Shuffle Options", 1);
+    path = { "Rando", "Shuffle Options", SECTION_COLUMN_1 };
+    
+    AddWidget(path, "Shuffle Collectables", WIDGET_SEPARATOR_TEXT);
+    
+    AddWidget(path, "Shuffle Empty Honeycombs", WIDGET_CVAR_CHECKBOX)
+        .CVar(Rando::StaticData::Options[RO_SHUFFLE_EMPTY_HONEYCOMBS].cvar)
+        .Options(CheckboxOptions().Tooltip("Shuffles Empty Honeycombs into the Pool."));
+    AddWidget(path, "Shuffle Jiggies", WIDGET_CVAR_CHECKBOX)
+        .CVar(Rando::StaticData::Options[RO_SHUFFLE_JIGGIES].cvar)
+        .Options(CheckboxOptions().Tooltip("Shuffles Jiggies into the Pool."));
+    AddWidget(path, "Shuffle Jinjos", WIDGET_CVAR_CHECKBOX)
+        .CVar(Rando::StaticData::Options[RO_SHUFFLE_JINJOS].cvar)
+        .Options(CheckboxOptions().Tooltip("Shuffles Jinjos into the Pool."));
+    AddWidget(path, "Shuffle Molehills", WIDGET_CVAR_CHECKBOX)
+        .CVar(Rando::StaticData::Options[RO_SHUFFLE_MOLEHILLS].cvar)
+        .Options(CheckboxOptions().Tooltip("Shuffles which abilities each Molehill unlocks."));
+    AddWidget(path, "Shuffle Mumbo Tokens", WIDGET_CVAR_CHECKBOX)
+        .CVar(Rando::StaticData::Options[RO_SHUFFLE_MUMBO_TOKENS].cvar)
+        .Options(CheckboxOptions().Tooltip("Shuffles Mumbo Tokens into the Pool."));
+    AddWidget(path, "Shuffle Music Notes", WIDGET_CVAR_CHECKBOX)
+        .CVar(Rando::StaticData::Options[RO_SHUFFLE_MUSIC_NOTES].cvar)
+        .Options(CheckboxOptions().Tooltip("Shuffles Music Notes into the Pool."));
+    
+    // Rando - Junk Options
+    AddSidebarEntry("Rando", "Junk Options", 1);
+    path = { "Rando", "Junk Options", SECTION_COLUMN_1 };
+    
+    AddWidget(path, "Enable Junk", WIDGET_SEPARATOR_TEXT);
+    
+    AddWidget(path, "Spawn Junk For Obtained Checks", WIDGET_CVAR_CHECKBOX)
+        .CVar(Rando::StaticData::Options[RO_SPAWN_JUNK].cvar)
+        .Options(CheckboxOptions().Tooltip("Spawns a junk item in place of an object that has already been collected."))
+        .Callback([](WidgetInfo& info) { UpdateJunkList(); });
+    
+    AddWidget(path, "Junk Selection", WIDGET_SEPARATOR_TEXT);
+    
+    AddWidget(path, "Honeycomb Refills", WIDGET_CVAR_CHECKBOX)
+        .CVar(CVAR_RANDOMIZER_SETTING("Junk.HealthRefill"))
+        .Options(CheckboxOptions().Tooltip("Adds Health Refills to the Junk List."))
+        .Callback([](WidgetInfo& info) { UpdateJunkList(); });
+    AddWidget(path, "Blue Eggs", WIDGET_CVAR_CHECKBOX)
+        .CVar(CVAR_RANDOMIZER_SETTING("Junk.BlueEggs"))
+        .Options(CheckboxOptions().Tooltip("Adds Blue Eggs to the Junk List."))
+        .Callback([](WidgetInfo& info) { UpdateJunkList(); });
+    AddWidget(path, "Red Feathers", WIDGET_CVAR_CHECKBOX)
+        .CVar(CVAR_RANDOMIZER_SETTING("Junk.RedFeathers"))
+        .Options(CheckboxOptions().Tooltip("Adds Red Feathers to the Junk List."))
+        .Callback([](WidgetInfo& info) { UpdateJunkList(); });
+    AddWidget(path, "Gold Feathers", WIDGET_CVAR_CHECKBOX)
+        .CVar(CVAR_RANDOMIZER_SETTING("Junk.GoldFeathers"))
+        .Options(CheckboxOptions().Tooltip("Adds Gold Feathers to the Junk List."))
+        .Callback([](WidgetInfo& info) { UpdateJunkList(); });
 }
 
 } // namespace LighthouseGui

--- a/src/port/Rando/MiscBehavior/Junk.cpp
+++ b/src/port/Rando/MiscBehavior/Junk.cpp
@@ -1,0 +1,49 @@
+#include "port/Rando/CustomObject/CustomObject.h"
+#include "port/Rando/Logic/Logic.h"
+
+#include <libultraship/bridge.h>
+#include "port/ui/cvar_prefixes.h"
+#include <libultraship/bridge/consolevariablebridge.h>
+#include "port/enhancements/events/PortEnhancements.h"
+#include "port/enhancements/events/hooks/Events.h"
+
+std::vector<actor_e> junkItemList;
+
+std::map<actor_e, const char*> junkOptionsMap = {
+    { ACTOR_50_HONEYCOMB, CVAR_RANDOMIZER_SETTING("Junk.HealthRefill") },
+    { ACTOR_52_BLUE_EGG, CVAR_RANDOMIZER_SETTING("Junk.BlueEggs") },
+    { ACTOR_129_RED_FEATHER, CVAR_RANDOMIZER_SETTING("Junk.RedFeathers") },
+    { ACTOR_370_GOLD_FEATHER, CVAR_RANDOMIZER_SETTING("Junk.GoldFeathers") },
+};
+
+void UpdateJunkList() {
+    junkItemList.clear();
+
+    if (CVarGetInteger(Rando::StaticData::Options[RO_SPAWN_JUNK].cvar, 0) == RO_GENERIC_OFF) {
+        return;
+    }
+
+    for (auto& [actorId, cvar] : junkOptionsMap) {
+        if (CVarGetInteger(cvar, 0)) {
+            junkItemList.push_back(actorId);
+        }
+    }
+
+    if (junkItemList.empty()) {
+        junkItemList.push_back(ACTOR_50_HONEYCOMB);
+    }
+}
+
+actor_e GetActorIdByShuffledObjectState(Rando::StaticData::RandoShuffledPool shuffledObject) {
+    actor_e randoActorId = ACTOR_1_UNKNOWN;
+
+    if (CVarGetInteger(Rando::StaticData::Options[RO_SPAWN_JUNK].cvar, 0) == RO_GENERIC_ON) {
+        randoActorId = shuffledObject.obtained ? junkItemList[(rand() % junkItemList.size())]
+                                               : (actor_e)Rando::StaticData::Items[shuffledObject.randoItemId].actorId;
+    } else {
+        randoActorId = shuffledObject.obtained ? ACTOR_1_UNKNOWN
+                                               : (actor_e)Rando::StaticData::Items[shuffledObject.randoItemId].actorId;
+    }
+
+    return randoActorId;
+}

--- a/src/port/Rando/MiscBehavior/Junk.cpp
+++ b/src/port/Rando/MiscBehavior/Junk.cpp
@@ -35,7 +35,12 @@ void UpdateJunkList() {
 }
 
 actor_e GetActorIdByShuffledObjectState(Rando::StaticData::RandoShuffledPool shuffledObject) {
-    actor_e randoActorId = ACTOR_1_UNKNOWN;
+    actor_e randoActorId = (actor_e)Rando::StaticData::Items[shuffledObject.randoItemId].actorId;
+
+    // TODO: Add Cvar Check for Persistant when added
+    if (randoActorId == ACTOR_51_MUSIC_NOTE || (randoActorId >= ACTOR_5E_JINJO_YELLOW && randoActorId <= ACTOR_62_JINJO_GREEN)) {
+        return randoActorId;
+    }
 
     if (CVarGetInteger(Rando::StaticData::Options[RO_SPAWN_JUNK].cvar, 0) == RO_GENERIC_ON) {
         randoActorId = shuffledObject.obtained ? junkItemList[(rand() % junkItemList.size())]

--- a/src/port/Rando/ObjectBehavior/Bundle.cpp
+++ b/src/port/Rando/ObjectBehavior/Bundle.cpp
@@ -25,49 +25,53 @@ void Rando::ObjectBehavior::InitBundleBehavior() {
         spawnPosition[1] = (int32_t)position[1];
         spawnPosition[2] = (int32_t)position[2];
 
-        Rando::StaticData::RandoShuffledPool randoShuffledObject;
-        randoShuffledObject.randoCheckId = RC_UNKNOWN;
+        Rando::StaticData::RandoShuffledPool shuffledObject;
+        shuffledObject.randoCheckId = RC_UNKNOWN;
 
         switch (bundleId) {
             case BUNDLE_3_MM_HUT_JINJO_GREEN:
-                randoShuffledObject = Rando::Logic::GetShuffledObject(RC_MM_JINJO_GREEN);
+                shuffledObject = Rando::Logic::GetShuffledObject(RC_MM_JINJO_GREEN);
                 break;
             case BUNDLE_4_MM_HUT_JIGGY:
                 if (spawnPosition[1] < 2000) {
-                    randoShuffledObject = Rando::Logic::GetShuffledObject(RC_MM_JIGGY_ORANGE_PADS);
+                    shuffledObject = Rando::Logic::GetShuffledObject(RC_MM_JIGGY_ORANGE_PADS);
                 } else {
-                    randoShuffledObject = Rando::Logic::GetShuffledObject(RC_MM_JIGGY_HUTS);
+                    shuffledObject = Rando::Logic::GetShuffledObject(RC_MM_JIGGY_HUTS);
                 }
                 break;
             case BUNDLE_0_MM_HUT_MUSIC_NOTE:
-                randoShuffledObject =
+                shuffledObject =
                     Rando::Logic::GetShuffledObject((RandoCheckId)((int32_t)RC_MM_NOTE_HUT_BUNDLE_1 + bundleCount));
                 break;
             case BUNDLE_1F_SM_EMPTY_HONEYCOMB:
                 if (spawnPosition[1] >= 500 && spawnPosition[1] <= 800) {
-                    randoShuffledObject = Rando::Logic::GetShuffledObject(RC_SM_EMPTY_HONEYCOMB_COLLIWOBBLE);
+                    shuffledObject = Rando::Logic::GetShuffledObject(RC_SM_EMPTY_HONEYCOMB_COLLIWOBBLE);
                 } else if (spawnPosition[1] >= -200 && spawnPosition[1] <= 0) {
-                    randoShuffledObject = Rando::Logic::GetShuffledObject(RC_SM_EMPTY_HONEYCOMB_QUARRIES);
+                    shuffledObject = Rando::Logic::GetShuffledObject(RC_SM_EMPTY_HONEYCOMB_QUARRIES);
                 }
                 break;
             default:
                 return;
         }
 
-        if (randoShuffledObject.randoCheckId == RC_UNKNOWN) {
+        if (shuffledObject.randoCheckId == RC_UNKNOWN) {
             return;
         }
 
-        actor = CustomObject::SpawnCustomActor(
-            (actor_e)Rando::StaticData::Items[randoShuffledObject.randoItemId].actorId, spawnPosition);
+        actor_e randoActorId = GetActorIdByShuffledObjectState(shuffledObject);
+        if (randoActorId == ACTOR_1_UNKNOWN) {
+            return;
+        }
+
+        actor = CustomObject::SpawnCustomActor(randoActorId, spawnPosition);
         if (actor == NULL) {
             return;
         }
 
-        actor = CustomObject::SetCustomActorParameters(actor, randoShuffledObject.randoCheckId);
-        CustomObject::AddToCustomActorMap(randoShuffledObject.randoCheckId, actor);
-        if (randoShuffledObject.randoCheckId == RC_MM_JIGGY_HUTS) {
-            ApplyCustomActorPhysics(randoShuffledObject.randoCheckId, actor);
+        actor = CustomObject::SetCustomActorParameters(actor, shuffledObject.randoCheckId);
+        CustomObject::AddToCustomActorMap(shuffledObject.randoCheckId, actor);
+        if (shuffledObject.randoCheckId == RC_MM_JIGGY_HUTS) {
+            ApplyCustomActorPhysics(shuffledObject.randoCheckId, actor);
         } else {
             ApplyBundleActorPhysics(actor, bundleId, (BundleInfo*)bundleInfo, gBundle_yaw);
         }

--- a/src/port/Rando/ObjectBehavior/Jiggy.cpp
+++ b/src/port/Rando/ObjectBehavior/Jiggy.cpp
@@ -24,21 +24,26 @@ void Rando::ObjectBehavior::InitJiggyBehavior() {
                 return;
             }
             
-            Rando::StaticData::RandoShuffledPool randoShuffledObject;
-            randoShuffledObject.randoCheckId = RC_UNKNOWN;
+            Rando::StaticData::RandoShuffledPool shuffledObject;
+            shuffledObject.randoCheckId = RC_UNKNOWN;
             
-            randoShuffledObject = Rando::Logic::GetShuffledObject(randoCheckId);
-            if (randoShuffledObject.randoCheckId == RC_UNKNOWN) {
+            shuffledObject = Rando::Logic::GetShuffledObject(randoCheckId);
+            if (shuffledObject.randoCheckId == RC_UNKNOWN) {
                 return;
             }
-            
+
+            actor_e randoActorId = GetActorIdByShuffledObjectState(shuffledObject);
+
+            if (randoActorId == ACTOR_1_UNKNOWN) {
+                return;
+            }
+
             int32_t spawnPosition[3];
             spawnPosition[0] = (int32_t)position[0];
             spawnPosition[1] = (int32_t)position[1];
             spawnPosition[2] = (int32_t)position[2];
             
-            Actor* newCustomActor = CustomObject::SpawnCustomActor(
-                (actor_e)Rando::StaticData::Items[randoShuffledObject.randoItemId].actorId, spawnPosition);
+            Actor* newCustomActor = CustomObject::SpawnCustomActor(randoActorId, spawnPosition);
             newCustomActor = CustomObject::SetCustomActorParameters(newCustomActor, randoCheckId);
             CustomObject::AddToCustomActorMap(randoCheckId, newCustomActor);
             

--- a/src/port/Rando/ObjectBehavior/ObjectBehavior.cpp
+++ b/src/port/Rando/ObjectBehavior/ObjectBehavior.cpp
@@ -110,6 +110,8 @@ void Rando::ObjectBehavior::Init() {
     InitMolehillBehavior();
     InitPropBehavior();
 
+    UpdateJunkList();
+
     REGISTER_LISTENER(OnActorSpawn, EVENT_PRIORITY_NORMAL, [](IEvent* event) {
         OnActorSpawn* ev = (OnActorSpawn*)event;
 

--- a/src/port/Rando/StaticData/Options.cpp
+++ b/src/port/Rando/StaticData/Options.cpp
@@ -14,6 +14,7 @@ namespace StaticData {
 // clang-format off
 std::map<RandoOptionId, RandoStaticOption> Options = {
     RO(RO_LOGIC,                    RO_LOGIC_GLITCHLESS),
+    RO(RO_SPAWN_JUNK,               RO_GENERIC_OFF),
     RO(RO_SHUFFLE_EMPTY_HONEYCOMBS, RO_GENERIC_OFF),
     RO(RO_SHUFFLE_JIGGIES,          RO_GENERIC_OFF),
     RO(RO_SHUFFLE_JINJOS,           RO_GENERIC_OFF),

--- a/src/port/Rando/Types.h
+++ b/src/port/Rando/Types.h
@@ -196,6 +196,7 @@ typedef enum {
 
 typedef enum {
     RO_LOGIC,
+    RO_SPAWN_JUNK,
     RO_SHUFFLE_EMPTY_HONEYCOMBS,
     RO_SHUFFLE_JIGGIES,
     RO_SHUFFLE_JINJOS,


### PR DESCRIPTION
Checks if a RandoCheckId has been collected before determining which actor to spawn.

Adds Junk Options to allow previously collected Checks to spawn as Selected Junk Items or not spawn anything at all.