### PR TITLE
[RANDO] Persistent Jinjos

### DIFF
--- a/src/core2/context/map_info.c
+++ b/src/core2/context/map_info.c
@@ -267,6 +267,7 @@ bool func_8030AF58(enum map_e arg0) {
 
 void func_8030AFA0(enum map_e arg0){
     s32 level = map_getLevel(arg0);
+    CALL_EVENT(OnSetJiggyList, level);
     if(level > 0 && level < LEVEL_C_BOSS){
         jiggylist_set_level(arg0);
     }

--- a/src/port/Rando/CustomObject/CustomObject.cpp
+++ b/src/port/Rando/CustomObject/CustomObject.cpp
@@ -26,7 +26,6 @@ extern u8 D_80383428[0x1C];
 extern ActorMarker* D_8036E7C8;
 }
 
-int32_t currentLevel = -1;
 int32_t currentMap = -1;
 std::map<RandoCheckId, Actor> customActorMap;
 std::vector<std::pair<CustomActor, bool>> actorSpawnQueue;

--- a/src/port/Rando/CustomObject/CustomObject.cpp
+++ b/src/port/Rando/CustomObject/CustomObject.cpp
@@ -21,9 +21,13 @@ extern ActorSpawn* sSpawnableActorList;
 
 enum map_e gsworld_getMap(void);
 enum level_e map_getLevel(enum map_e map);
+
+extern u8 D_80383428[0x1C];
+extern ActorMarker* D_8036E7C8;
 }
 
 int32_t currentLevel = -1;
+int32_t currentMap = -1;
 std::map<RandoCheckId, Actor> customActorMap;
 std::vector<std::pair<CustomActor, bool>> actorSpawnQueue;
 
@@ -39,10 +43,10 @@ bool CustomObject::CheckSpawnQueue(RandoCheckId randoCheckId) {
 }
 
 void ClearSpawnQueue() {
-    if (currentLevel != map_getLevel(gsworld_getMap())) {
-        currentLevel = map_getLevel(gsworld_getMap());
-        actorSpawnQueue.clear();
+    if (currentMap != gsworld_getMap()) {
+        currentMap = gsworld_getMap();
         customActorMap.clear();
+        actorSpawnQueue.clear();
     }
 }
 
@@ -101,7 +105,9 @@ Actor* CustomObject::GetCustomActor(RandoCheckId randoCheckId) {
 
 void CustomObject::AddToCustomActorMap(RandoCheckId randoCheckId, Actor* actor) {
     Actor customActor = *actor;
-    customActorMap.emplace(randoCheckId, customActor);
+
+    customActorMap.insert_or_assign(randoCheckId, *actor);
+    //customActorMap.emplace(randoCheckId, customActor);
 }
 
 void CustomObject::AddToSpawnQueue(RandoCheckId randoCheckId, int32_t position[3]) {
@@ -131,6 +137,7 @@ void CustomObject::InitializeSpawnQueue() {
         if (isSpawned) {
             continue;
         }
+
         int32_t customPosition[3];
         customPosition[0] = customActor.location[0];
         customPosition[1] = customActor.location[1];
@@ -166,6 +173,7 @@ void CustomObject::CheckObtained(RandoCheckId randoCheckId) {
 
 void CustomObject::ObjectCollected(Prop* prop) {
     for (auto& [randoCheckId, customActor] : customActorMap) {
+        // TODO: Fix null actors when changing interiors...
         if (customActor.marker->propPtr->words[0] == prop->actorProp.words[0]) {
             CustomObject::CheckObtained(randoCheckId);
             return;

--- a/src/port/Rando/MiscBehavior/Junk.cpp
+++ b/src/port/Rando/MiscBehavior/Junk.cpp
@@ -37,8 +37,8 @@ void UpdateJunkList() {
 actor_e GetActorIdByShuffledObjectState(Rando::StaticData::RandoShuffledPool shuffledObject) {
     actor_e randoActorId = (actor_e)Rando::StaticData::Items[shuffledObject.randoItemId].actorId;
 
-    // TODO: Add Cvar Check for Persistant when added
-    if (randoActorId == ACTOR_51_MUSIC_NOTE || (randoActorId >= ACTOR_5E_JINJO_YELLOW && randoActorId <= ACTOR_62_JINJO_GREEN)) {
+    // TODO: Add Cvar Check for Persistant Notes when added
+    if (randoActorId == ACTOR_51_MUSIC_NOTE) {
         return randoActorId;
     }
 

--- a/src/port/Rando/ObjectBehavior/Jinjo.cpp
+++ b/src/port/Rando/ObjectBehavior/Jinjo.cpp
@@ -1,0 +1,66 @@
+#include "ObjectBehavior.h"
+#include "port/Rando/Logic/Logic.h"
+#include "port/Rando/CustomObject/CustomObject.h"
+
+#include <libultraship/bridge.h>
+#include "port/ui/cvar_prefixes.h"
+#include <libultraship/bridge/consolevariablebridge.h>
+#include "port/enhancements/events/PortEnhancements.h"
+#include "port/enhancements/events/hooks/Events.h"
+
+extern "C" {
+enum map_e gsworld_getMap(void);
+enum level_e map_getLevel(enum map_e map);
+
+s32 item_adjustByDiffWithHud(enum item_e item, s32 diff);
+}
+
+std::map<RandoItemId, int32_t> jinjoDiffMap = {
+    { RI_JINJO_BLUE, 1 }, { RI_JINJO_GREEN, 2 }, { RI_JINJO_ORANGE, 4 }, { RI_JINJO_PINK, 8 }, { RI_JINJO_YELLOW, 16 },
+};
+
+// TODO: SWAP TO RANDO_SAVE_OPTIONS
+#define CVAR_NAME Rando::StaticData::Options[RO_SHUFFLE_JINJOS].cvar
+#define CVAR CVarGetInteger(CVAR_NAME, 0)
+
+void Test(int32_t level) {
+    int hi = 0;
+
+    for (auto& pool : Rando::Logic::shuffledPool) {
+        if (Rando::StaticData::Checks[pool.randoCheckId].worldId != level) {
+            continue;
+        }
+
+        if (pool.randoItemId >= RI_JINJO_BLUE && pool.randoItemId <= RI_JINJO_YELLOW) {
+            if (pool.obtained) {
+                item_adjustByDiffWithHud(ITEM_12_JINJOS, jinjoDiffMap.at(pool.randoItemId));
+            }
+        }
+    }
+}
+
+void Rando::ObjectBehavior::InitJinjoBehavior() {
+    REGISTER_LISTENER(OnSetJiggyList, EVENT_PRIORITY_NORMAL, [](IEvent* event) {
+        OnSetJiggyList* ev = (OnSetJiggyList*)event;
+
+        // if (!IS_RANDO) {
+        //     return;
+        // }
+
+        if (CVAR) {
+            Test(ev->levelId);
+            //for (auto& pool : Rando::Logic::shuffledPool) {
+            //    if (Rando::StaticData::Checks[pool.randoCheckId].worldId != ev->levelId) {
+            //        continue;
+            //    }
+            //
+            //    if (pool.randoItemId >= RI_JINJO_BLUE && pool.randoItemId <= RI_JINJO_YELLOW) {
+            //        if (pool.obtained) {
+            //            Test();
+            //            item_adjustByDiffWithHud(ITEM_12_JINJOS, jinjoDiffMap.at(pool.randoItemId));
+            //        }
+            //    }
+            //}
+        }
+    })
+}

--- a/src/port/Rando/ObjectBehavior/Jinjo.cpp
+++ b/src/port/Rando/ObjectBehavior/Jinjo.cpp
@@ -23,22 +23,6 @@ std::map<RandoItemId, int32_t> jinjoDiffMap = {
 #define CVAR_NAME Rando::StaticData::Options[RO_SHUFFLE_JINJOS].cvar
 #define CVAR CVarGetInteger(CVAR_NAME, 0)
 
-void Test(int32_t level) {
-    int hi = 0;
-
-    for (auto& pool : Rando::Logic::shuffledPool) {
-        if (Rando::StaticData::Checks[pool.randoCheckId].worldId != level) {
-            continue;
-        }
-
-        if (pool.randoItemId >= RI_JINJO_BLUE && pool.randoItemId <= RI_JINJO_YELLOW) {
-            if (pool.obtained) {
-                item_adjustByDiffWithHud(ITEM_12_JINJOS, jinjoDiffMap.at(pool.randoItemId));
-            }
-        }
-    }
-}
-
 void Rando::ObjectBehavior::InitJinjoBehavior() {
     REGISTER_LISTENER(OnSetJiggyList, EVENT_PRIORITY_NORMAL, [](IEvent* event) {
         OnSetJiggyList* ev = (OnSetJiggyList*)event;
@@ -48,19 +32,18 @@ void Rando::ObjectBehavior::InitJinjoBehavior() {
         // }
 
         if (CVAR) {
-            Test(ev->levelId);
-            //for (auto& pool : Rando::Logic::shuffledPool) {
-            //    if (Rando::StaticData::Checks[pool.randoCheckId].worldId != ev->levelId) {
-            //        continue;
-            //    }
-            //
-            //    if (pool.randoItemId >= RI_JINJO_BLUE && pool.randoItemId <= RI_JINJO_YELLOW) {
-            //        if (pool.obtained) {
-            //            Test();
-            //            item_adjustByDiffWithHud(ITEM_12_JINJOS, jinjoDiffMap.at(pool.randoItemId));
-            //        }
-            //    }
-            //}
+            for (auto& pool : Rando::Logic::shuffledPool) {
+                if (Rando::StaticData::Checks[pool.randoCheckId].worldId != ev->levelId) {
+                    continue;
+                }
+            
+                if (pool.randoItemId >= RI_JINJO_BLUE && pool.randoItemId <= RI_JINJO_YELLOW) {
+                    if (pool.obtained) {
+                        // TODO: Spawn World specific RC for Jinjo Jiggy when 5 are collected anywhere.
+                        item_adjustByDiffWithHud(ITEM_12_JINJOS, jinjoDiffMap.at(pool.randoItemId));
+                    }
+                }
+            }
         }
     })
 }

--- a/src/port/Rando/ObjectBehavior/ObjectBehavior.cpp
+++ b/src/port/Rando/ObjectBehavior/ObjectBehavior.cpp
@@ -107,6 +107,7 @@ bool ShouldOverrideSpawn(RandoCheckId randoCheckId) {
 void Rando::ObjectBehavior::Init() {
     InitBundleBehavior();
     InitJiggyBehavior();
+    InitJinjoBehavior();
     InitMolehillBehavior();
     InitPropBehavior();
 
@@ -121,11 +122,6 @@ void Rando::ObjectBehavior::Init() {
 
         if (IsActorWhitelisted(ev->actorId)) {
             LogOutSpawns(ev->actorId, ev->posX, ev->posY, ev->posZ);
-        }
-
-        if (nextActorSaveState) {
-            nextActorSaveState = false;
-            return;
         }
 
         if (!IsActorWhitelisted(ev->actorId)) {
@@ -150,6 +146,14 @@ void Rando::ObjectBehavior::Init() {
         CustomObject::AddToSpawnQueue(randoCheckId, position);
         CustomObject::InitializeSpawnQueue();
 
+        if (nextActorSaveState) {
+            event->cancelled = true;
+            ev->result = CustomObject::GetCustomActor(randoCheckId);
+            nextActorSaveState = false;
+            return;
+        }
+
+
         switch (ev->actorId) {
             case ACTOR_12C_MOLEHILL:
                 event->cancelled = true;
@@ -169,7 +173,6 @@ void Rando::ObjectBehavior::Init() {
         //     return;
         // }
 
-        CustomObject::InitializeSpawnQueue();
         nextActorSaveState = true;
     })
 

--- a/src/port/Rando/ObjectBehavior/ObjectBehavior.h
+++ b/src/port/Rando/ObjectBehavior/ObjectBehavior.h
@@ -12,6 +12,7 @@ namespace ObjectBehavior {
 void Init();
 void InitBundleBehavior();
 void InitJiggyBehavior();
+void InitJinjoBehavior();
 void InitMolehillBehavior();
 void InitPropBehavior();
 

--- a/src/port/enhancements/events/PortEnhancements.cpp
+++ b/src/port/enhancements/events/PortEnhancements.cpp
@@ -32,6 +32,7 @@ void PortEnhancements_Register() {
     REGISTER_EVENT(OnSaveFileLoad);
     REGISTER_EVENT(OnSaveFileSave);
     REGISTER_EVENT(OnWarpDispatch);
+    REGISTER_EVENT(OnSetJiggyList);
 
     // Register rando events
     REGISTER_EVENT(OnSaveLoad);

--- a/src/port/enhancements/events/hooks/list/GameEvent.h
+++ b/src/port/enhancements/events/hooks/list/GameEvent.h
@@ -28,4 +28,8 @@ DEFINE_EVENT(OnWarpDispatch,
 	int32_t warpId;
 	int32_t warpDest;
 )
+
+DEFINE_EVENT(OnSetJiggyList,
+	int32_t levelId;
+)
 // clang-format on


### PR DESCRIPTION
Makes Jinjos persistent. once you collect the RandoCheckId that contains a Jinjo it will iterate over the shuffle list when you enter a world and check if you collected jinjos for that specific world and apply them to the Hud.

TODO: Once we have multiple worlds I will need to create a small addition that will spawn the Jinjo Jiggy RC for the specific world when 5 for a world is obtained anywhere in the game.