### PR TITLE
[RANDO] Custom Collision Resolution

### DIFF
--- a/src/core2/ch/jinjo.c
+++ b/src/core2/ch/jinjo.c
@@ -49,7 +49,7 @@ void __chJinjo_802CDBA8(ActorMarker *this, ActorMarker *other){
             fileProgressFlag_set(FILEPROG_E_JINJO_TEXT, 1);
         }
         subaddie_set_state_with_direction(actorPtr, 6, 0.0f , -1);
-        if (EventSystem_Should(VB_OVERRIDE_ITEM_COUNT, false, actorPtr->position)) {
+        if (EventSystem_Should(VB_SET_JINJO_COUNT, true, actorPtr->position)) {
             if (item_adjustByDiffWithHud(ITEM_12_JINJOS, 1 << ((this->id + 6) & 0x1F)) == 0x1f) // [port] MIPS SLL uses low 5 bits; mask to avoid UB
                 localPtr->unk4 = 1;
         }

--- a/src/core2/ch/jinjo.c
+++ b/src/core2/ch/jinjo.c
@@ -49,8 +49,10 @@ void __chJinjo_802CDBA8(ActorMarker *this, ActorMarker *other){
             fileProgressFlag_set(FILEPROG_E_JINJO_TEXT, 1);
         }
         subaddie_set_state_with_direction(actorPtr, 6, 0.0f , -1);
-        if(item_adjustByDiffWithHud(ITEM_12_JINJOS, 1 << ((this->id + 6) & 0x1F) ) == 0x1f) // [port] MIPS SLL uses low 5 bits; mask to avoid UB
-            localPtr->unk4 = 1;
+        if (EventSystem_Should(VB_OVERRIDE_ITEM_COUNT, false, actorPtr->position)) {
+            if (item_adjustByDiffWithHud(ITEM_12_JINJOS, 1 << ((this->id + 6) & 0x1F)) == 0x1f) // [port] MIPS SLL uses low 5 bits; mask to avoid UB
+                localPtr->unk4 = 1;
+        }
         actor_loopAnimation(actorPtr);
         this->collidable = false;
     }

--- a/src/port/Rando/CustomObject/CustomObject.cpp
+++ b/src/port/Rando/CustomObject/CustomObject.cpp
@@ -33,6 +33,7 @@ void fxSparkle_musicNote(s16 position[3]);
 }
 
 extern int32_t GetJinjoActorMarkerId(actor_e actorId);
+extern std::map<RandoItemId, int32_t> jinjoDiffMap;
 
 int32_t currentMap = -1;
 std::map<RandoCheckId, Actor> customActorMap;
@@ -215,7 +216,8 @@ void CustomObject::ResolveCustomActorCollision(RandoCheckId randoCheckId, Actor*
         case RI_JINJO_YELLOW:
             if (Rando::StaticData::Checks[shuffledObject.shuffleCheckId].worldId == map_getLevel(gsworld_getMap())) {
                 int32_t jinjoMarkerId = GetJinjoActorMarkerId((actor_e)Rando::StaticData::Items[shuffledObject.randoItemId].actorId);
-                item_adjustByDiffWithHud(ITEM_12_JINJOS, 1 << ((jinjoMarkerId + 6) & 0x1F));
+                // item_adjustByDiffWithHud(ITEM_12_JINJOS, (1 << ((jinjoMarkerId + 6) & 0x1F)));
+                item_adjustByDiffWithHud(ITEM_12_JINJOS, jinjoDiffMap.at(shuffledObject.randoItemId));
             } else {
                 if (Rando::Logic::ShouldSpawnJinjoJiggy(
                         Rando::StaticData::Checks[shuffledObject.shuffleCheckId].worldId)) {

--- a/src/port/Rando/CustomObject/CustomObject.cpp
+++ b/src/port/Rando/CustomObject/CustomObject.cpp
@@ -27,8 +27,10 @@ extern ActorMarker* D_8036E7C8;
 
 void marker_despawn(ActorMarker* marker);
 void item_inc(enum item_e item);
+s32 item_adjustByDiffWithHud(enum item_e item, s32 diff);
 
 void fxSparkle_musicNote(s16 position[3]);
+void actor_loopAnimation(Actor* thisx);
 }
 
 int32_t currentMap = -1;
@@ -177,6 +179,16 @@ void CustomObject::ResolveCustomActorCollision(RandoCheckId randoCheckId, Actor*
     position[2] = (int16_t)customActor->position[2];
 
     switch (shuffledObject.randoItemId) {
+        case RI_JINJO_BLUE:
+        case RI_JINJO_GREEN:
+        case RI_JINJO_ORANGE:
+        case RI_JINJO_PINK:
+        case RI_JINJO_YELLOW:
+            if (Rando::StaticData::Checks[shuffledObject.shuffleCheckId].worldId == map_getLevel(gsworld_getMap())) {
+                item_adjustByDiffWithHud(
+                    ITEM_12_JINJOS, 1 << ((Rando::StaticData::Items[shuffledObject.randoItemId].actorId + 6) & 0x1F));
+            }
+            break;
         case RI_MUSIC_NOTE:
             if (Rando::StaticData::Checks[shuffledObject.shuffleCheckId].worldId == map_getLevel(gsworld_getMap())) {
                 item_inc(ITEM_C_NOTE);
@@ -187,7 +199,7 @@ void CustomObject::ResolveCustomActorCollision(RandoCheckId randoCheckId, Actor*
             break;
     }
 
-    if (shuffledObject.randoItemId != RI_UNKNOWN) {
+    if (shuffledObject.randoItemId == RI_MUSIC_NOTE) {
         marker_despawn(customActorMap.at(randoCheckId).marker);
         customActorMap.erase(randoCheckId);
     }

--- a/src/port/Rando/CustomObject/CustomObject.cpp
+++ b/src/port/Rando/CustomObject/CustomObject.cpp
@@ -30,8 +30,9 @@ void item_inc(enum item_e item);
 s32 item_adjustByDiffWithHud(enum item_e item, s32 diff);
 
 void fxSparkle_musicNote(s16 position[3]);
-void actor_loopAnimation(Actor* thisx);
 }
+
+extern int32_t GetJinjoActorMarkerId(actor_e actorId);
 
 int32_t currentMap = -1;
 std::map<RandoCheckId, Actor> customActorMap;
@@ -107,6 +108,34 @@ Actor* CustomObject::GetCustomActor(RandoCheckId randoCheckId) {
         }
     }
     return NULL;
+}
+
+void CustomObject::SpawnJinjoJiggy(int16_t levelId, int16_t position[3]) {
+    RandoCheckId jiggyCheckId = Rando::StaticData::GetJinjoJiggyCheckByLevelId(levelId);
+
+    int32_t spawnPosition[3];
+    spawnPosition[0] = (int32_t)position[0];
+    spawnPosition[1] = (int32_t)position[1];
+    spawnPosition[2] = (int32_t)position[2];
+
+    if (jiggyCheckId != RC_UNKNOWN) {
+        Actor* actor;
+        Rando::StaticData::RandoShuffledPool shuffledObject = Rando::Logic::GetShuffledObject(jiggyCheckId);
+        if (shuffledObject.randoCheckId != RC_UNKNOWN) {
+            actor = CustomObject::SpawnCustomActor(
+                (actor_e)Rando::StaticData::Items[shuffledObject.randoItemId].actorId, spawnPosition);
+            if (actor != NULL) {
+                actor = CustomObject::SetCustomActorParameters(actor, shuffledObject.randoCheckId);
+                ApplyCustomActorPhysics(shuffledObject.randoCheckId, actor, true);
+            }
+        } else {
+            actor = CustomObject::SpawnCustomActor((actor_e)Rando::StaticData::Checks[jiggyCheckId].actorId, spawnPosition);
+            if (actor != NULL) {
+                chjiggy_setJiggyId(actor, Rando::StaticData::Checks[jiggyCheckId].collectionId);
+                ApplyCustomActorPhysics(jiggyCheckId, actor, true);
+            }
+        }
+    }
 }
 
 void CustomObject::AddToCustomActorMap(RandoCheckId randoCheckId, Actor* actor) {
@@ -185,8 +214,13 @@ void CustomObject::ResolveCustomActorCollision(RandoCheckId randoCheckId, Actor*
         case RI_JINJO_PINK:
         case RI_JINJO_YELLOW:
             if (Rando::StaticData::Checks[shuffledObject.shuffleCheckId].worldId == map_getLevel(gsworld_getMap())) {
-                item_adjustByDiffWithHud(
-                    ITEM_12_JINJOS, 1 << ((Rando::StaticData::Items[shuffledObject.randoItemId].actorId + 6) & 0x1F));
+                int32_t jinjoMarkerId = GetJinjoActorMarkerId((actor_e)Rando::StaticData::Items[shuffledObject.randoItemId].actorId);
+                item_adjustByDiffWithHud(ITEM_12_JINJOS, 1 << ((jinjoMarkerId + 6) & 0x1F));
+            } else {
+                if (Rando::Logic::ShouldSpawnJinjoJiggy(
+                        Rando::StaticData::Checks[shuffledObject.shuffleCheckId].worldId)) {
+                    CustomObject::SpawnJinjoJiggy(Rando::StaticData::Checks[shuffledObject.shuffleCheckId].worldId, position);
+                }
             }
             break;
         case RI_MUSIC_NOTE:

--- a/src/port/Rando/CustomObject/CustomObject.cpp
+++ b/src/port/Rando/CustomObject/CustomObject.cpp
@@ -33,7 +33,6 @@ void fxSparkle_musicNote(s16 position[3]);
 }
 
 extern int32_t GetJinjoActorMarkerId(actor_e actorId);
-extern std::map<RandoItemId, int32_t> jinjoDiffMap;
 
 int32_t currentMap = -1;
 std::map<RandoCheckId, Actor> customActorMap;
@@ -216,8 +215,7 @@ void CustomObject::ResolveCustomActorCollision(RandoCheckId randoCheckId, Actor*
         case RI_JINJO_YELLOW:
             if (Rando::StaticData::Checks[shuffledObject.shuffleCheckId].worldId == map_getLevel(gsworld_getMap())) {
                 int32_t jinjoMarkerId = GetJinjoActorMarkerId((actor_e)Rando::StaticData::Items[shuffledObject.randoItemId].actorId);
-                // item_adjustByDiffWithHud(ITEM_12_JINJOS, (1 << ((jinjoMarkerId + 6) & 0x1F)));
-                item_adjustByDiffWithHud(ITEM_12_JINJOS, jinjoDiffMap.at(shuffledObject.randoItemId));
+                item_adjustByDiffWithHud(ITEM_12_JINJOS, (1 << ((jinjoMarkerId + 6) & 0x1F)));
             } else {
                 if (Rando::Logic::ShouldSpawnJinjoJiggy(
                         Rando::StaticData::Checks[shuffledObject.shuffleCheckId].worldId)) {

--- a/src/port/Rando/CustomObject/CustomObject.cpp
+++ b/src/port/Rando/CustomObject/CustomObject.cpp
@@ -24,6 +24,11 @@ enum level_e map_getLevel(enum map_e map);
 
 extern u8 D_80383428[0x1C];
 extern ActorMarker* D_8036E7C8;
+
+void marker_despawn(ActorMarker* marker);
+void item_inc(enum item_e item);
+
+void fxSparkle_musicNote(s16 position[3]);
 }
 
 int32_t currentMap = -1;
@@ -160,13 +165,48 @@ void CustomObject::InitializeSpawnQueue() {
     }
 }
 
+void CustomObject::ResolveCustomActorCollision(RandoCheckId randoCheckId, Actor* customActor) {
+    if (randoCheckId == RC_UNKNOWN) {
+        return;
+    }
+
+    Rando::StaticData::RandoShuffledPool shuffledObject = Rando::Logic::GetShuffledObject(randoCheckId);
+    int16_t position[3];
+    position[0] = (int16_t)customActor->position[0];
+    position[1] = (int16_t)customActor->position[1];
+    position[2] = (int16_t)customActor->position[2];
+
+    switch (shuffledObject.randoItemId) {
+        case RI_MUSIC_NOTE:
+            if (Rando::StaticData::Checks[shuffledObject.shuffleCheckId].worldId == map_getLevel(gsworld_getMap())) {
+                item_inc(ITEM_C_NOTE);
+            }
+            fxSparkle_musicNote(position);
+            break;
+        default:
+            break;
+    }
+
+    if (shuffledObject.randoItemId != RI_UNKNOWN) {
+        marker_despawn(customActorMap.at(randoCheckId).marker);
+        customActorMap.erase(randoCheckId);
+    }
+}
+
 void CustomObject::CheckObtained(RandoCheckId randoCheckId) {
+    bool shouldRemove = false;
     for (auto& pool : Rando::Logic::shuffledPool) {
         if (pool.randoCheckId == randoCheckId && !pool.obtained) {
             pool.obtained = true;
+            shouldRemove = true;
             BK_LOG_INFO("RandoCheckId %s collected!", Rando::StaticData::Checks[randoCheckId].name);
-            return;
+            break;
         }
+    }
+
+    if (shouldRemove) {
+        CustomObject::ResolveCustomActorCollision(randoCheckId, &customActorMap.at(randoCheckId));
+        shouldRemove = false;
     }
 }
 

--- a/src/port/Rando/CustomObject/CustomObject.h
+++ b/src/port/Rando/CustomObject/CustomObject.h
@@ -34,7 +34,7 @@ typedef struct {
 CustomActor CreateCustomActor(RandoCheckId randoCheckId, int32_t position[3]);
 actor_e GetActorIdByShuffledObjectState(Rando::StaticData::RandoShuffledPool shuffledObject);
 void ApplyBundleActorPhysics(Actor* actor, int32_t bundle_id, BundleInfo* bundle_info, f32 bundleYaw);
-void ApplyCustomActorPhysics(RandoCheckId randoCheckId, Actor* actor);
+void ApplyCustomActorPhysics(RandoCheckId randoCheckId, Actor* actor, bool isJinjoJiggy);
 
 void UpdateJunkList();
 
@@ -44,6 +44,7 @@ public:
     static Actor* SetCustomActorParameters(Actor* actor, RandoCheckId randoCheckId);
     static Actor* SpawnCustomActor(actor_e actorId, int32_t position[3]);
     static Actor* GetCustomActor(RandoCheckId randoCheckId);
+    static void SpawnJinjoJiggy(int16_t levelId, int16_t position[3]);
     static void AddToCustomActorMap(RandoCheckId randoCheckId, Actor* actor);
     static void AddToSpawnQueue(RandoCheckId randoCheckId, int32_t position[3]);
     static void InitializeSpawnQueue();

--- a/src/port/Rando/CustomObject/CustomObject.h
+++ b/src/port/Rando/CustomObject/CustomObject.h
@@ -47,6 +47,7 @@ public:
     static void AddToCustomActorMap(RandoCheckId randoCheckId, Actor* actor);
     static void AddToSpawnQueue(RandoCheckId randoCheckId, int32_t position[3]);
     static void InitializeSpawnQueue();
+    static void ResolveCustomActorCollision(RandoCheckId randoCheckId, Actor* customActor);
     static void CheckObtained(RandoCheckId randoCheckId);
     static void ObjectCollected(Prop* prop);
 };

--- a/src/port/Rando/CustomObject/CustomObjectSettings.cpp
+++ b/src/port/Rando/CustomObject/CustomObjectSettings.cpp
@@ -48,6 +48,8 @@ std::map<RandoCheckId, BundlePhysics> customActorPhysicsMap = {
     { RC_MM_JIGGY_JUJU, { 0, 300.0f, 0, 0, 10.0f, 0, 0, 0x1 } },
 };
 
+BundlePhysics jinjoJiggySpawnPhysics = { 0, 300.0f, 0, 0, 10.0f, 0, 0, 0x1 };
+
 BundlePhysics GetPhysicsByCheckId(RandoCheckId randoCheckId) {
     for (auto& [check, physics] : customActorPhysicsMap) {
         if (check == randoCheckId) {
@@ -98,13 +100,13 @@ void ApplyBundleActorPhysics(Actor* actor, int32_t bundle_id, BundleInfo* bundle
     }
 }
 
-void ApplyCustomActorPhysics(RandoCheckId randoCheckId, Actor* actor) {
+void ApplyCustomActorPhysics(RandoCheckId randoCheckId, Actor* actor, bool isJinjoJiggy) {
     if (actor == NULL) {
         return;
     }
 
     float bundleYaw = gBundle_yaw;
-    BundlePhysics physicsData = GetPhysicsByCheckId(randoCheckId);
+    BundlePhysics physicsData = isJinjoJiggy ? jinjoJiggySpawnPhysics : GetPhysicsByCheckId(randoCheckId);
 
     actor->is_bundle = true;
     Bundle* bundle = (Bundle*)&actor->unkBC;

--- a/src/port/Rando/Logic/GeneratePools.cpp
+++ b/src/port/Rando/Logic/GeneratePools.cpp
@@ -11,10 +11,10 @@ namespace Rando {
 
 namespace Logic {
 std::vector<RandoCheckId> checkPool;
-std::vector<std::pair<actor_e, int32_t>> itemPool;
+std::vector<std::tuple<actor_e, int32_t, RandoCheckId>> itemPool;
 
 std::vector<RandoCheckId> abilityCheckPool;
-std::vector<std::pair<actor_e, int32_t>> abilityItemPool;
+std::vector<std::tuple<actor_e, int32_t, RandoCheckId>> abilityItemPool;
 
 std::vector<Rando::StaticData::RandoShuffledPool> shuffledPool;
 
@@ -36,7 +36,7 @@ uint32_t GetRandoSeed(const std::string& input) {
     return rd();
 }
 
-void ShuffleRandoItems(const std::string& input, std::vector<std::pair<actor_e, int32_t>>& pool) {
+void ShuffleRandoItems(const std::string& input, std::vector<std::tuple<actor_e, int32_t, RandoCheckId>>& pool) {
     uint32_t seed = GetRandoSeed(input);
 
     std::mt19937 g(seed);
@@ -76,7 +76,7 @@ void GenerateShufflePool() {
         if (randoStaticCheck.randoCheckType == RCTYPE_MOLEHILL) {
             if (CVarGetInteger(Rando::StaticData::Options[RO_SHUFFLE_MOLEHILLS].cvar, 0) == RO_GENERIC_ON) {
                 abilityCheckPool.push_back(randoCheckId);
-                abilityItemPool.push_back({ (actor_e)randoStaticCheck.actorId, randoStaticCheck.collectionId });
+                abilityItemPool.push_back({ (actor_e)randoStaticCheck.actorId, randoStaticCheck.collectionId, randoCheckId });
             }
             continue;
         }
@@ -92,7 +92,7 @@ void GenerateShufflePool() {
         }
 
         checkPool.push_back(randoCheckId);
-        itemPool.push_back({ (actor_e)randoStaticCheck.actorId, randoStaticCheck.collectionId });
+        itemPool.push_back({ (actor_e)randoStaticCheck.actorId, randoStaticCheck.collectionId, randoCheckId });
     }
 
     ShuffleRandoItems("", itemPool);
@@ -100,8 +100,9 @@ void GenerateShufflePool() {
     for (int i = 0; i < checkPool.size(); i++) {
         Rando::StaticData::RandoShuffledPool randoShuffleEntry = {
             .randoCheckId = checkPool[i],
-            .randoItemId = Rando::StaticData::GetRandoItemByActorId(itemPool[i].first),
-            .randoCollectionId = itemPool[i].second,
+            .shuffleCheckId = std::get<2>(itemPool[i]),
+            .randoItemId = Rando::StaticData::GetRandoItemByActorId(std::get<0>(itemPool[i])),
+            .randoCollectionId = std::get<1>(itemPool[i]),
             .isShuffled = true,
             .obtained = false,
             .skipped = false,
@@ -116,8 +117,9 @@ void GenerateShufflePool() {
         for (int a = 0; a < abilityCheckPool.size(); a++) {
             Rando::StaticData::RandoShuffledPool randoShuffleEntry = {
                 .randoCheckId = abilityCheckPool[a],
-                .randoItemId = Rando::StaticData::GetRandoItemByActorId(abilityItemPool[a].first),
-                .randoCollectionId = abilityItemPool[a].second,
+                .shuffleCheckId = std::get<2>(abilityItemPool[a]),
+                .randoItemId = Rando::StaticData::GetRandoItemByActorId(std::get<0>(abilityItemPool[a])),
+                .randoCollectionId = std::get<1>(abilityItemPool[a]),
                 .isShuffled = true,
                 .obtained = false,
                 .skipped = false,

--- a/src/port/Rando/Logic/Logic.h
+++ b/src/port/Rando/Logic/Logic.h
@@ -55,6 +55,31 @@ inline bool IsCheckObtained(RandoCheckId randoCheckId) {
     return isObtained;
 }
 
+inline bool ShouldSpawnJinjoJiggy(int16_t levelId) {
+    bool shouldSpawn = false;
+    int16_t jinjoCount = 0;
+
+    for (auto& pool : Rando::Logic::shuffledPool) {
+        if (!pool.obtained) {
+            continue;
+        }
+
+        if (Rando::StaticData::Checks[pool.shuffleCheckId].worldId != levelId) {
+            continue;
+        }
+
+        if (pool.randoItemId >= RI_JINJO_BLUE && pool.randoItemId <= RI_JINJO_YELLOW) {
+            jinjoCount++;
+        }
+    }
+
+    if (jinjoCount == 5) {
+        shouldSpawn = true;
+    }
+
+    return shouldSpawn;
+}
+
 // Regions
 inline std::string LogicString(std::string condition) {
     if (condition == "true")

--- a/src/port/Rando/ObjectBehavior/Bundle.cpp
+++ b/src/port/Rando/ObjectBehavior/Bundle.cpp
@@ -71,7 +71,7 @@ void Rando::ObjectBehavior::InitBundleBehavior() {
         actor = CustomObject::SetCustomActorParameters(actor, shuffledObject.randoCheckId);
         CustomObject::AddToCustomActorMap(shuffledObject.randoCheckId, actor);
         if (shuffledObject.randoCheckId == RC_MM_JIGGY_HUTS) {
-            ApplyCustomActorPhysics(shuffledObject.randoCheckId, actor);
+            ApplyCustomActorPhysics(shuffledObject.randoCheckId, actor, false);
         } else {
             ApplyBundleActorPhysics(actor, bundleId, (BundleInfo*)bundleInfo, gBundle_yaw);
         }

--- a/src/port/Rando/ObjectBehavior/Jiggy.cpp
+++ b/src/port/Rando/ObjectBehavior/Jiggy.cpp
@@ -49,7 +49,7 @@ void Rando::ObjectBehavior::InitJiggyBehavior() {
             newCustomActor = CustomObject::SetCustomActorParameters(newCustomActor, randoCheckId);
             CustomObject::AddToCustomActorMap(randoCheckId, newCustomActor);
             
-            ApplyCustomActorPhysics(randoCheckId, newCustomActor);
+            ApplyCustomActorPhysics(randoCheckId, newCustomActor, false);
             
             CustomObject::InitializeSpawnQueue();
             *should = true;

--- a/src/port/Rando/ObjectBehavior/Jinjo.cpp
+++ b/src/port/Rando/ObjectBehavior/Jinjo.cpp
@@ -38,10 +38,8 @@ void Rando::ObjectBehavior::InitJinjoBehavior() {
                 }
             
                 if (pool.randoItemId >= RI_JINJO_BLUE && pool.randoItemId <= RI_JINJO_YELLOW) {
-                    // TODO: Spawn World specific RC for Jinjo Jiggy when 5 are collected anywhere.
-                    // int32_t jinjoMarkerId = GetJinjoActorMarkerId((actor_e)Rando::StaticData::Items[pool.randoItemId].actorId);
-                    int32_t jinjoMarkerId = jinjoDiffMap.at(pool.randoItemId);
-                    item_adjustByDiffWithHud(ITEM_12_JINJOS, jinjoMarkerId);
+                    int32_t jinjoMarkerId = GetJinjoActorMarkerId((actor_e)Rando::StaticData::Items[pool.randoItemId].actorId);
+                    item_adjustByDiffWithHud(ITEM_12_JINJOS, (1 << ((jinjoMarkerId + 6) & 0x1F)));
                 }
             }
         }

--- a/src/port/Rando/ObjectBehavior/Jinjo.cpp
+++ b/src/port/Rando/ObjectBehavior/Jinjo.cpp
@@ -36,7 +36,7 @@ void Rando::ObjectBehavior::InitJinjoBehavior() {
                 if (Rando::StaticData::Checks[pool.randoCheckId].worldId != ev->levelId) {
                     continue;
                 }
-            
+
                 if (pool.randoItemId >= RI_JINJO_BLUE && pool.randoItemId <= RI_JINJO_YELLOW) {
                     if (pool.obtained) {
                         // TODO: Spawn World specific RC for Jinjo Jiggy when 5 are collected anywhere.
@@ -44,6 +44,34 @@ void Rando::ObjectBehavior::InitJinjoBehavior() {
                     }
                 }
             }
+        }
+    })
+
+    COND_VB_SHOULD(VB_OVERRIDE_BUNDLE_SPAWN, EVENT_PRIORITY_NORMAL, true, {
+        f32* position = va_arg(args, f32*);
+        // if (!IS_RANDO) {
+        //     return;
+        // }
+
+        if (CVAR) {
+            int16_t actorPos[3];
+            actorPos[0] = (int16_t)position[0];
+            actorPos[1] = (int16_t)position[1];
+            actorPos[2] = (int16_t)position[2];
+
+            RandoCheckId randoCheckId = Rando::StaticData::GetCheckByPosition(actorPos[0], actorPos[1], actorPos[2]);
+            if (randoCheckId == RC_UNKNOWN) {
+                *should = false; 
+                return;
+            }
+
+            Rando::StaticData::RandoShuffledPool shuffledObject = Rando::Logic::GetShuffledObject(randoCheckId);
+            if (shuffledObject.randoCheckId == RC_UNKNOWN) {
+                *should = false;
+                return;
+            }
+
+            *should = true;
         }
     })
 }

--- a/src/port/Rando/ObjectBehavior/Jinjo.cpp
+++ b/src/port/Rando/ObjectBehavior/Jinjo.cpp
@@ -15,10 +15,6 @@ enum level_e map_getLevel(enum map_e map);
 s32 item_adjustByDiffWithHud(enum item_e item, s32 diff);
 }
 
-std::map<RandoItemId, int32_t> jinjoDiffMap = {
-    { RI_JINJO_BLUE, 1 }, { RI_JINJO_GREEN, 2 }, { RI_JINJO_ORANGE, 4 }, { RI_JINJO_PINK, 8 }, { RI_JINJO_YELLOW, 16 },
-};
-
 // TODO: SWAP TO RANDO_SAVE_OPTIONS
 #define CVAR_NAME Rando::StaticData::Options[RO_SHUFFLE_JINJOS].cvar
 #define CVAR CVarGetInteger(CVAR_NAME, 0)
@@ -33,45 +29,44 @@ void Rando::ObjectBehavior::InitJinjoBehavior() {
 
         if (CVAR) {
             for (auto& pool : Rando::Logic::shuffledPool) {
-                if (Rando::StaticData::Checks[pool.randoCheckId].worldId != ev->levelId) {
+                if (!pool.obtained) {
                     continue;
                 }
-
+            
+                if (Rando::StaticData::Checks[pool.shuffleCheckId].worldId != ev->levelId) {
+                    continue;
+                }
+            
                 if (pool.randoItemId >= RI_JINJO_BLUE && pool.randoItemId <= RI_JINJO_YELLOW) {
-                    if (pool.obtained) {
-                        // TODO: Spawn World specific RC for Jinjo Jiggy when 5 are collected anywhere.
-                        item_adjustByDiffWithHud(ITEM_12_JINJOS, jinjoDiffMap.at(pool.randoItemId));
-                    }
+                    // TODO: Spawn World specific RC for Jinjo Jiggy when 5 are collected anywhere.
+                    int32_t jinjoMarkerId = GetJinjoActorMarkerId((actor_e)Rando::StaticData::Items[pool.randoItemId].actorId);
+                    item_adjustByDiffWithHud(ITEM_12_JINJOS, 1 << ((jinjoMarkerId + 6) & 0x1F));
                 }
             }
         }
     })
 
-    COND_VB_SHOULD(VB_OVERRIDE_ITEM_COUNT, EVENT_PRIORITY_NORMAL, true, {
+    COND_VB_SHOULD(VB_SET_JINJO_COUNT, EVENT_PRIORITY_NORMAL, CVAR, {
         f32* position = va_arg(args, f32*);
         // if (!IS_RANDO) {
         //     return;
         // }
 
-        if (CVAR) {
-            int16_t actorPos[3];
-            actorPos[0] = (int16_t)position[0];
-            actorPos[1] = (int16_t)position[1];
-            actorPos[2] = (int16_t)position[2];
+        int16_t actorPos[3];
+        actorPos[0] = (int16_t)position[0];
+        actorPos[1] = (int16_t)position[1];
+        actorPos[2] = (int16_t)position[2];
 
-            RandoCheckId randoCheckId = Rando::StaticData::GetCheckByPosition(actorPos[0], actorPos[1], actorPos[2]);
-            if (randoCheckId == RC_UNKNOWN) {
-                *should = false; 
-                return;
-            }
-
-            Rando::StaticData::RandoShuffledPool shuffledObject = Rando::Logic::GetShuffledObject(randoCheckId);
-            if (shuffledObject.randoCheckId == RC_UNKNOWN) {
-                *should = false;
-                return;
-            }
-
-            *should = true;
+        RandoCheckId randoCheckId = Rando::StaticData::GetCheckByPosition(actorPos[0], actorPos[1], actorPos[2]);
+        if (randoCheckId == RC_UNKNOWN) {
+            return;
         }
+        
+        Rando::StaticData::RandoShuffledPool shuffledObject = Rando::Logic::GetShuffledObject(randoCheckId);
+        if (shuffledObject.randoCheckId == RC_UNKNOWN) {
+            return;
+        }
+        
+        *should = false;
     })
 }

--- a/src/port/Rando/ObjectBehavior/Jinjo.cpp
+++ b/src/port/Rando/ObjectBehavior/Jinjo.cpp
@@ -47,7 +47,7 @@ void Rando::ObjectBehavior::InitJinjoBehavior() {
         }
     })
 
-    COND_VB_SHOULD(VB_OVERRIDE_BUNDLE_SPAWN, EVENT_PRIORITY_NORMAL, true, {
+    COND_VB_SHOULD(VB_OVERRIDE_ITEM_COUNT, EVENT_PRIORITY_NORMAL, true, {
         f32* position = va_arg(args, f32*);
         // if (!IS_RANDO) {
         //     return;

--- a/src/port/Rando/ObjectBehavior/Jinjo.cpp
+++ b/src/port/Rando/ObjectBehavior/Jinjo.cpp
@@ -39,8 +39,9 @@ void Rando::ObjectBehavior::InitJinjoBehavior() {
             
                 if (pool.randoItemId >= RI_JINJO_BLUE && pool.randoItemId <= RI_JINJO_YELLOW) {
                     // TODO: Spawn World specific RC for Jinjo Jiggy when 5 are collected anywhere.
-                    int32_t jinjoMarkerId = GetJinjoActorMarkerId((actor_e)Rando::StaticData::Items[pool.randoItemId].actorId);
-                    item_adjustByDiffWithHud(ITEM_12_JINJOS, 1 << ((jinjoMarkerId + 6) & 0x1F));
+                    // int32_t jinjoMarkerId = GetJinjoActorMarkerId((actor_e)Rando::StaticData::Items[pool.randoItemId].actorId);
+                    int32_t jinjoMarkerId = jinjoDiffMap.at(pool.randoItemId);
+                    item_adjustByDiffWithHud(ITEM_12_JINJOS, jinjoMarkerId);
                 }
             }
         }
@@ -52,21 +53,27 @@ void Rando::ObjectBehavior::InitJinjoBehavior() {
         //     return;
         // }
 
-        int16_t actorPos[3];
-        actorPos[0] = (int16_t)position[0];
-        actorPos[1] = (int16_t)position[1];
-        actorPos[2] = (int16_t)position[2];
-
-        RandoCheckId randoCheckId = Rando::StaticData::GetCheckByPosition(actorPos[0], actorPos[1], actorPos[2]);
-        if (randoCheckId == RC_UNKNOWN) {
-            return;
-        }
-        
-        Rando::StaticData::RandoShuffledPool shuffledObject = Rando::Logic::GetShuffledObject(randoCheckId);
-        if (shuffledObject.randoCheckId == RC_UNKNOWN) {
-            return;
-        }
-        
         *should = false;
+
+        // int16_t actorPos[3];
+        // actorPos[0] = (int16_t)position[0];
+        // actorPos[1] = (int16_t)position[1];
+        // actorPos[2] = (int16_t)position[2];
+        // 
+        // RandoCheckId randoCheckId = Rando::StaticData::GetCheckByPosition(actorPos[0], actorPos[1], actorPos[2]);
+        // if (randoCheckId == RC_UNKNOWN) {
+        //     return;
+        // }
+        // 
+        // Rando::StaticData::RandoShuffledPool shuffledObject = Rando::Logic::GetShuffledObject(randoCheckId);
+        // if (shuffledObject.randoCheckId == RC_UNKNOWN) {
+        //     return;
+        // }
+        // 
+        // if (Rando::StaticData::Checks[shuffledObject.shuffleCheckId].worldId != map_getLevel(gsworld_getMap())) {
+        //     return;
+        // }
+        // 
+        // *should = false;
     })
 }

--- a/src/port/Rando/ObjectBehavior/MusicNote.cpp
+++ b/src/port/Rando/ObjectBehavior/MusicNote.cpp
@@ -29,7 +29,7 @@ void Rando::ObjectBehavior::InitMusicNoteBehavior() {
 
         if (CVAR) {
             for (auto& pool : Rando::Logic::shuffledPool) {
-                if (Rando::StaticData::Checks[pool.randoCheckId].worldId != ev->levelId) {
+                if (Rando::StaticData::Checks[pool.shuffleCheckId].worldId != ev->levelId) {
                     continue;
                 }
             

--- a/src/port/Rando/ObjectBehavior/ObjectBehavior.cpp
+++ b/src/port/Rando/ObjectBehavior/ObjectBehavior.cpp
@@ -20,6 +20,10 @@ Actor* marker_getActor(ActorMarker* thisx);
 bool func_802C9C14(Actor* actor);
 }
 
+std::map<RandoItemId, int32_t> jinjoDiffMap = {
+    { RI_JINJO_BLUE, 1 }, { RI_JINJO_GREEN, 2 }, { RI_JINJO_ORANGE, 4 }, { RI_JINJO_PINK, 8 }, { RI_JINJO_YELLOW, 16 },
+};
+
 // clang-format off
 std::vector<int32_t> actorSpawnWhitelist = {
     ACTOR_2D_MUMBO_TOKEN,

--- a/src/port/Rando/ObjectBehavior/ObjectBehavior.cpp
+++ b/src/port/Rando/ObjectBehavior/ObjectBehavior.cpp
@@ -131,6 +131,8 @@ void Rando::ObjectBehavior::Init() {
         //     return;
         // }
 
+        CustomObject::InitializeSpawnQueue();
+
         // if (IsActorWhitelisted(ev->actorId)) {
         //     LogOutSpawns(ev->actorId, ev->posX, ev->posY, ev->posZ);
         // }

--- a/src/port/Rando/ObjectBehavior/ObjectBehavior.cpp
+++ b/src/port/Rando/ObjectBehavior/ObjectBehavior.cpp
@@ -20,10 +20,6 @@ Actor* marker_getActor(ActorMarker* thisx);
 bool func_802C9C14(Actor* actor);
 }
 
-std::map<RandoItemId, int32_t> jinjoDiffMap = {
-    { RI_JINJO_BLUE, 1 }, { RI_JINJO_GREEN, 2 }, { RI_JINJO_ORANGE, 4 }, { RI_JINJO_PINK, 8 }, { RI_JINJO_YELLOW, 16 },
-};
-
 // clang-format off
 std::vector<int32_t> actorSpawnWhitelist = {
     ACTOR_2D_MUMBO_TOKEN,

--- a/src/port/Rando/ObjectBehavior/ObjectBehavior.cpp
+++ b/src/port/Rando/ObjectBehavior/ObjectBehavior.cpp
@@ -240,6 +240,7 @@ void Rando::ObjectBehavior::Init() {
         }
 
         if (randoItemId != RI_UNKNOWN) {
+            event->cancelled = true;
             CustomObject::ObjectCollected(ev->propId);
             SendCollisionNotification(randoItemId);
         }

--- a/src/port/Rando/ObjectBehavior/ObjectBehavior.cpp
+++ b/src/port/Rando/ObjectBehavior/ObjectBehavior.cpp
@@ -196,17 +196,7 @@ void Rando::ObjectBehavior::Init() {
 
         RandoItemId randoItemId = RI_UNKNOWN;
 
-        if (!ev->propId->markerFlag) {
-            switch (ev->propId->spriteProp.spriteId) {
-                case RP_MUSIC_NOTE:
-                    LogOutCollision(ACTOR_51_MUSIC_NOTE, ev->propId->actorProp.x, ev->propId->actorProp.y,
-                                    ev->propId->actorProp.z);
-                    randoItemId = RI_MUSIC_NOTE;
-                    break;
-                default:
-                    break;
-            }
-        } else {
+        if (ev->propId->markerFlag) {
             Actor* markerActor = marker_getActor(ev->propId->actorProp.marker);
             
             if (markerActor->is_bundle && func_802C9C14(markerActor)) {

--- a/src/port/Rando/ObjectBehavior/ObjectBehavior.cpp
+++ b/src/port/Rando/ObjectBehavior/ObjectBehavior.cpp
@@ -131,8 +131,6 @@ void Rando::ObjectBehavior::Init() {
         //     return;
         // }
 
-        CustomObject::InitializeSpawnQueue();
-
         // if (IsActorWhitelisted(ev->actorId)) {
         //     LogOutSpawns(ev->actorId, ev->posX, ev->posY, ev->posZ);
         // }
@@ -148,6 +146,7 @@ void Rando::ObjectBehavior::Init() {
         }
         
         if (!ShouldOverrideSpawn(randoCheckId)) {
+            CustomObject::InitializeSpawnQueue();
             return;
         }
 

--- a/src/port/Rando/ObjectBehavior/ObjectBehavior.cpp
+++ b/src/port/Rando/ObjectBehavior/ObjectBehavior.cpp
@@ -76,6 +76,16 @@ bool IsActorWhitelisted(int32_t actorId) {
     return false;
 }
 
+int32_t GetJinjoActorMarkerId(actor_e actorId) {
+    for (auto& [marker, actor] : jinjoMarkerMap) {
+        if (actor == actorId) {
+            return marker;
+        }
+    }
+
+    return NULL;
+}
+
 void SendCollisionNotification(RandoItemId randoItemId) {
     std::string prefix = "You collected ";
     prefix += Rando::StaticData::Items[randoItemId].article;

--- a/src/port/Rando/ObjectBehavior/ObjectBehavior.cpp
+++ b/src/port/Rando/ObjectBehavior/ObjectBehavior.cpp
@@ -240,7 +240,9 @@ void Rando::ObjectBehavior::Init() {
         }
 
         if (randoItemId != RI_UNKNOWN) {
-            event->cancelled = true;
+            if (randoItemId == RI_MUSIC_NOTE) {
+                event->cancelled = true;
+            }
             CustomObject::ObjectCollected(ev->propId);
             SendCollisionNotification(randoItemId);
         }

--- a/src/port/Rando/ObjectBehavior/ObjectBehavior.h
+++ b/src/port/Rando/ObjectBehavior/ObjectBehavior.h
@@ -6,7 +6,6 @@
 bool ShouldOverrideSpawn(RandoCheckId randoCheckId);
 void LogOutSpawns(int32_t actorId, int16_t posX, int16_t posY, int16_t posZ);
 int32_t GetJinjoActorMarkerId(actor_e actorId);
-extern std::map<RandoItemId, int32_t> jinjoDiffMap;
 
 namespace Rando {
 

--- a/src/port/Rando/ObjectBehavior/ObjectBehavior.h
+++ b/src/port/Rando/ObjectBehavior/ObjectBehavior.h
@@ -6,6 +6,7 @@
 bool ShouldOverrideSpawn(RandoCheckId randoCheckId);
 void LogOutSpawns(int32_t actorId, int16_t posX, int16_t posY, int16_t posZ);
 int32_t GetJinjoActorMarkerId(actor_e actorId);
+extern std::map<RandoItemId, int32_t> jinjoDiffMap;
 
 namespace Rando {
 

--- a/src/port/Rando/ObjectBehavior/ObjectBehavior.h
+++ b/src/port/Rando/ObjectBehavior/ObjectBehavior.h
@@ -5,6 +5,7 @@
 
 bool ShouldOverrideSpawn(RandoCheckId randoCheckId);
 void LogOutSpawns(int32_t actorId, int16_t posX, int16_t posY, int16_t posZ);
+int32_t GetJinjoActorMarkerId(actor_e actorId);
 
 namespace Rando {
 

--- a/src/port/Rando/StaticData/Checks.cpp
+++ b/src/port/Rando/StaticData/Checks.cpp
@@ -305,5 +305,19 @@ RandoCheckId GetCheckByJiggyId(int32_t jiggyId) {
     return RC_UNKNOWN;
 }
 
+RandoCheckId GetJinjoJiggyCheckByLevelId(int16_t levelId) {
+    for (auto& [randoCheckId, randoStaticCheck] : Checks) {
+        if (randoStaticCheck.randoCheckType != RCTYPE_JIGGY) {
+            continue;
+        }
+
+        if (randoStaticCheck.collectionId == (10 * levelId) - 9) {
+            return randoCheckId;
+        }
+    }
+
+    return RC_UNKNOWN;
+}
+
 } // namespace StaticData
 } // namespace Rando

--- a/src/port/Rando/StaticData/StaticData.h
+++ b/src/port/Rando/StaticData/StaticData.h
@@ -36,6 +36,7 @@ struct RandoStaticCheck {
 
 RandoCheckId GetCheckByPosition(int32_t posX, int32_t posY, int32_t posZ);
 RandoCheckId GetCheckByJiggyId(int32_t jiggyId);
+RandoCheckId GetJinjoJiggyCheckByLevelId(int16_t levelId);
 
 extern std::map<RandoCheckId, RandoStaticCheck> Checks;
 // extern RandoStaticCheck GetShuffledRandoStaticCheck(s16 x, s16 y, s16 z);

--- a/src/port/Rando/StaticData/StaticData.h
+++ b/src/port/Rando/StaticData/StaticData.h
@@ -14,6 +14,7 @@ namespace StaticData {
 
 struct RandoShuffledPool {
     RandoCheckId randoCheckId;
+    RandoCheckId shuffleCheckId;
     RandoItemId randoItemId;
     int32_t randoCollectionId;
     bool isShuffled;

--- a/src/port/enhancements/events/hooks/EventSystem.h
+++ b/src/port/enhancements/events/hooks/EventSystem.h
@@ -45,7 +45,7 @@ typedef enum VBehaviorID {
     VB_OVERRIDE_JIGGY_SPAWN,
     VB_OVERRIDE_PROP_SPAWN,
     VB_OVERRIDE_BUNDLE_SPAWN,
-    VB_OVERRIDE_ITEM_COUNT,
+    VB_SET_JINJO_COUNT,
 } VBehaviorID;
 
 #ifndef __cplusplus

--- a/src/port/enhancements/events/hooks/EventSystem.h
+++ b/src/port/enhancements/events/hooks/EventSystem.h
@@ -45,6 +45,7 @@ typedef enum VBehaviorID {
     VB_OVERRIDE_JIGGY_SPAWN,
     VB_OVERRIDE_PROP_SPAWN,
     VB_OVERRIDE_BUNDLE_SPAWN,
+    VB_OVERRIDE_ITEM_COUNT,
 } VBehaviorID;
 
 #ifndef __cplusplus


### PR DESCRIPTION
Overrides some Object Collision to account for world identity. If you collect an RC for a note or jinjo, the hud and increment counts should only occur if the object collected was for the world you are currently in.