### PR TITLE
Honor boot sequence choice on all reset paths + Torch bump

### DIFF
--- a/assets/yaml/jp/rev0/soundfont.yaml
+++ b/assets/yaml/jp/rev0/soundfont.yaml
@@ -10,9 +10,10 @@ soundfont1ctl:
   symbol: soundfont1ctl
 
 soundfont1tbl:
-  type: BLOB
+  type: BK64:SOUNDFONT_TBL
   offset: 0xDB8E90
-  size: 0x10EA00
+  ctl_offset: 0xDA80A0
+  ctl_size: 0x10DF0
   symbol: soundfont1tbl
 
 soundfont2ctl:
@@ -22,8 +23,9 @@ soundfont2ctl:
   symbol: soundfont2ctl
 
 soundfont2tbl:
-  type: BLOB
+  type: BK64:SOUNDFONT_TBL
   offset: 0xED1840
-  size: 0x6B3F0
+  ctl_offset: 0xEC7890
+  ctl_size: 0x9FB0
   symbol: soundfont2tbl
 

--- a/assets/yaml/pal/rev0/soundfont.yaml
+++ b/assets/yaml/pal/rev0/soundfont.yaml
@@ -10,9 +10,10 @@ soundfont1ctl:
   symbol: soundfont1ctl
 
 soundfont1tbl:
-  type: BLOB
+  type: BK64:SOUNDFONT_TBL
   offset: 0xDB9BE0
-  size: 0x10EA00
+  ctl_offset: 0xDA8DF0
+  ctl_size: 0x10DF0
   symbol: soundfont1tbl
 
 soundfont2ctl:
@@ -22,8 +23,9 @@ soundfont2ctl:
   symbol: soundfont2ctl
 
 soundfont2tbl:
-  type: BLOB
+  type: BK64:SOUNDFONT_TBL
   offset: 0xED2590
-  size: 0x6B3F0
+  ctl_offset: 0xEC85E0
+  ctl_size: 0x9FB0
   symbol: soundfont2tbl
 

--- a/assets/yaml/us/rev0/soundfont.yaml
+++ b/assets/yaml/us/rev0/soundfont.yaml
@@ -10,9 +10,10 @@ soundfont1ctl:
   symbol: soundfont1ctl
 
 soundfont1tbl:
-  type: BLOB
+  type: BK64:SOUNDFONT_TBL
   offset: 0xD954B0
-  size: 0x10EA00
+  ctl_offset: 0xD846C0
+  ctl_size: 0x10DF0
   symbol: soundfont1tbl
 
 soundfont2ctl:
@@ -22,7 +23,8 @@ soundfont2ctl:
   symbol: soundfont2ctl
 
 soundfont2tbl:
-  type: BLOB
+  type: BK64:SOUNDFONT_TBL
   offset: 0xEADE60
-  size: 0x6B3F0
+  ctl_offset: 0xEA3EB0
+  ctl_size: 0x9FB0
   symbol: soundfont2tbl

--- a/assets/yaml/us/rev1/soundfont.yaml
+++ b/assets/yaml/us/rev1/soundfont.yaml
@@ -10,9 +10,10 @@ soundfont1ctl:
   symbol: soundfont1ctl
 
 soundfont1tbl:
-  type: BLOB
+  type: BK64:SOUNDFONT_TBL
   offset: 0xD98A90
-  size: 0x10EA00
+  ctl_offset: 0xD87CA0
+  ctl_size: 0x10DF0
   symbol: soundfont1tbl
 
 soundfont2ctl:
@@ -22,8 +23,9 @@ soundfont2ctl:
   symbol: soundfont2ctl
 
 soundfont2tbl:
-  type: BLOB
+  type: BK64:SOUNDFONT_TBL
   offset: 0xEB1440
-  size: 0x6B3F0
+  ctl_offset: 0xEA7490
+  ctl_size: 0x9FB0
   symbol: soundfont2tbl
 

--- a/src/core2/context/pause_menu.c
+++ b/src/core2/context/pause_menu.c
@@ -1318,7 +1318,8 @@ s32 gcPauseMenu_update(void) {
                 if (!D_80383010.unk3_6) {
                     func_802DC560(0, 0);
                     func_802E412C(1, 0);
-                    transitionToMap(MAP_1F_CS_START_RAREWARE, 0, 1);
+                    // [port] Honor BootSequence so Save & Quit lands at the same place as a fresh boot.
+                    transitionToMap(getDefaultBootMap(), 0, 1);
                     D_80383010.unk3_6 = 1;
                 }
             }

--- a/src/core2/map/cutscene_skip.c
+++ b/src/core2/map/cutscene_skip.c
@@ -1,6 +1,7 @@
 #include <ultra64.h>
 #include "functions.h"
 #include "variables.h"
+#include "core1/core1.h"
 
 extern void player_walkToPosition(f32 *, f32,  void(*)(ActorMarker *), ActorMarker *);
 extern void func_8028F760(s32, f32, f32);
@@ -64,7 +65,8 @@ bool cutscene_skipGameOverCutsceneCheck(void) {
             mapSpecificFlags_set(0xC, true);
             func_802DC528(0, 0);
             timedFunc_set_2(11.0f, (GenFunction_2)func_802DC560, 0, 0);
-            timedFunc_set_3(12.0f, (GenFunction_3)transitionToMap, MAP_1F_CS_START_RAREWARE, 0, 1);
+            // [port] Honor BootSequence so Save & Quit lands at the same place as a fresh boot.
+            timedFunc_set_3(12.0f, (GenFunction_3)transitionToMap, getDefaultBootMap(), 0, 1);
         } else {
             timedFuncQueue_flush();
         }
@@ -98,12 +100,13 @@ s32 cutscenetrigger_update(void){
     cutscenetrigger_check(MAP_7B_CS_INTRO_GL_DINGPOT_1,       1, MAP_81_CS_INTRO_GL_DINGPOT_2,    -1, NULL);
     cutscenetrigger_check(MAP_81_CS_INTRO_GL_DINGPOT_2,       0, MAP_7D_CS_SPIRAL_MOUNTAIN_1,     -1, NULL);
     cutscenetrigger_check(MAP_82_CS_ENTERING_GL_MACHINE_ROOM, 0, MAP_69_GL_MM_LOBBY,            0x12, cutscene_skipEnterLairCutsceneCheck);
-    cutscenetrigger_check(MAP_83_CS_GAME_OVER_MACHINE_ROOM,   0, MAP_1F_CS_START_RAREWARE,        -1, cutscene_skipGameOverCutsceneCheck);
+    // [port] Honor BootSequence so post-cutscene transitions match a fresh boot.
+    cutscenetrigger_check(MAP_83_CS_GAME_OVER_MACHINE_ROOM,   0, getDefaultBootMap(),             -1, cutscene_skipGameOverCutsceneCheck);
     cutscenetrigger_check(MAP_87_CS_SPIRAL_MOUNTAIN_5,        0, MAP_88_CS_SPIRAL_MOUNTAIN_6,     -1, NULL);
     cutscenetrigger_check(MAP_94_CS_INTRO_SPIRAL_7,           0, MAP_8E_GL_FURNACE_FUN,            4, NULL);
     cutscenetrigger_check(MAP_88_CS_SPIRAL_MOUNTAIN_6,        1, MAP_96_CS_END_BEACH_1,           -1, NULL);
-    cutscenetrigger_check(MAP_98_CS_END_SPIRAL_MOUNTAIN_1,    0, MAP_1F_CS_START_RAREWARE,        -1, NULL);
-    cutscenetrigger_check(MAP_99_CS_END_SPIRAL_MOUNTAIN_2,    0, MAP_1F_CS_START_RAREWARE,        -1, NULL);
+    cutscenetrigger_check(MAP_98_CS_END_SPIRAL_MOUNTAIN_1,    0, getDefaultBootMap(),             -1, NULL);
+    cutscenetrigger_check(MAP_99_CS_END_SPIRAL_MOUNTAIN_2,    0, getDefaultBootMap(),             -1, NULL);
     cutscenetrigger_check(MAP_20_CS_END_NOT_100,              0, MAP_98_CS_END_SPIRAL_MOUNTAIN_1, -1, NULL);
     cutscenetrigger_check(MAP_95_CS_END_ALL_100,              0, MAP_99_CS_END_SPIRAL_MOUNTAIN_2, -1, NULL);
     cutscenetrigger_check(MAP_97_CS_END_BEACH_2,              0, MAP_99_CS_END_SPIRAL_MOUNTAIN_2, -1, cutscene_skipBeachCutsceneCheck);

--- a/src/port/ShipUtils.cpp
+++ b/src/port/ShipUtils.cpp
@@ -2,6 +2,7 @@
 #include "save/SaveManager.h"
 #include "save/Types.h"
 #include "Engine.h"
+#include "GameConfig.h"
 #include <chrono>
 #include <cstdarg>
 #include <cstdio>
@@ -247,6 +248,10 @@ const char* port_mapName(int map_id) {
 }
 
 int port_getBootSequence(void) {
+    // Romhacks always boot to file select; their intros aren't compatible with the
+    // vanilla cutscene/demo path.
+    if (port_isRomhack())
+        return 2; // BOOTSEQUENCE_FILESELECT
     return CVarGetInteger(CVAR_SETTING("BootSequence"), 0);
 }
 


### PR DESCRIPTION
Resolves #49 

Torch bump addresses two issues:
- `GFX_#` entries, when exported, could exceed miniz's file-in-zip limit. Since these exported files aren't used outside of parsing, don't export them.
- Banjo's Backpack sometimes makes use of spare data after the vanilla soundfont table. Originally we ignored this and as a result some audio in romhacks would produce garbled noise. Now we have a soundfont factory that walks the table and gets the correct size for export.