### PR TITLE
Move frustum into event listener

### DIFF
--- a/src/core1/viewport.c
+++ b/src/core1/viewport.c
@@ -224,20 +224,13 @@ void viewport_unused_pushVpScaleAndTranslation(f32 scale_x, f32 scale_y, f32 tra
 }
 
 void viewport_update(void) {
-    // [port] Compute frustum plane normals from the actual FOV and aspect ratio.
-    f32 halfFovYRad = (sViewportFOVy * 0.5f) * (M_PI / 180.0f);
-    f32 halfFovXRad = atanf(tanf(halfFovYRad) * sViewportAspect);
-    // Scale to match the vanilla magnitude (100.0 unnormalized length)
-    f32 mag = sqrtf(89.21774f * 89.21774f + 45.168514f * 45.168514f);
-    f32 frustumX = sinf(halfFovXRad) * mag;
-    f32 frustumZ = cosf(halfFovXRad) * mag;
-    func_80256E24(sViewportFrustumPlanes[0], sViewportRotation[0], sViewportRotation[1], -frustumX, 0.0f, frustumZ);
-    func_80256E24(sViewportFrustumPlanes[1], sViewportRotation[0], sViewportRotation[1], frustumX, 0.0f, frustumZ);
-    // [port] Pad top/bottom planes slightly to reduce pop-in during vertical cam movement.
-    f32 frustumY = 93.9692611694336f * 1.15f;
-    f32 frustumZv = 34.20201110839844f;
-    func_80256E24(sViewportFrustumPlanes[2], sViewportRotation[0], sViewportRotation[1], 0.0f, frustumY, frustumZv);
-    func_80256E24(sViewportFrustumPlanes[3], sViewportRotation[0], sViewportRotation[1], 0.0f, -frustumY, frustumZv);
+    f32 frustumX = 89.21774f;
+    f32 frustumY = 93.9692611694336f;
+    CALL_EVENT(ViewportFrustumUpdate, &frustumX, &frustumY);
+    func_80256E24(sViewportFrustumPlanes[0], sViewportRotation[0], sViewportRotation[1], -frustumX, 0.0f, 45.168514251708984f);
+    func_80256E24(sViewportFrustumPlanes[1], sViewportRotation[0], sViewportRotation[1], frustumX, 0.0f, 45.168514251708984f);
+    func_80256E24(sViewportFrustumPlanes[2], sViewportRotation[0], sViewportRotation[1], 0.0f, frustumY, 34.20201110839844f);
+    func_80256E24(sViewportFrustumPlanes[3], sViewportRotation[0], sViewportRotation[1], 0.0f, -frustumY, 34.20201110839844f);
 
     ml_vec3f_normalize(sViewportFrustumPlanes[0]);
     ml_vec3f_normalize(sViewportFrustumPlanes[1]);

--- a/src/port/enhancements/cheats/Cheats.cpp
+++ b/src/port/enhancements/cheats/Cheats.cpp
@@ -121,16 +121,17 @@ void RegisterInfiniteGoldFeathers_Init() {
 
 // Infinite Boots & Sneakers — Keeps boots and sneakers from expiring
 void RegisterBootsAndSneakersTimer_Init() {
-    COND_HOOK(GameFrameUpdate, EVENT_PRIORITY_NORMAL, CVarGetInteger(CVAR_INFINITE_BOOTS_SNEAKERS, 0), [](IEvent* event) {
-        // STATE_TIMER_2_LONGLEG - Trot Shoes (boots)
-        if (stateTimer_isActive(STATE_TIMER_2_LONGLEG)) {
-            stateTimer_set(STATE_TIMER_2_LONGLEG, 999.0f);
-        }
-        // STATE_TIMER_3_TURBO_TALON - Sneakers
-        if (stateTimer_isActive(STATE_TIMER_3_TURBO_TALON)) {
-            stateTimer_set(STATE_TIMER_3_TURBO_TALON, 999.0f);
-        }
-    });
+    COND_HOOK(GameFrameUpdate, EVENT_PRIORITY_NORMAL, CVarGetInteger(CVAR_INFINITE_BOOTS_SNEAKERS, 0),
+              [](IEvent* event) {
+                  // STATE_TIMER_2_LONGLEG - Trot Shoes (boots)
+                  if (stateTimer_isActive(STATE_TIMER_2_LONGLEG)) {
+                      stateTimer_set(STATE_TIMER_2_LONGLEG, 999.0f);
+                  }
+                  // STATE_TIMER_3_TURBO_TALON - Sneakers
+                  if (stateTimer_isActive(STATE_TIMER_3_TURBO_TALON)) {
+                      stateTimer_set(STATE_TIMER_3_TURBO_TALON, 999.0f);
+                  }
+              });
 }
 
 // D-pad Talon Trot Cycling — toggle between Normal <-> Boots <-> Sneakers with D-pad
@@ -274,7 +275,8 @@ static RegisterShipInitFunc initInfiniteRedFeathersFunc(RegisterInfiniteRedFeath
                                                         { CVAR_INFINITE_RED_FEATHERS });
 static RegisterShipInitFunc initInfiniteGoldFeathersFunc(RegisterInfiniteGoldFeathers_Init,
                                                          { CVAR_INFINITE_GOLD_FEATHERS });
-static RegisterShipInitFunc initBootsAndSneakersTimerFunc(RegisterBootsAndSneakersTimer_Init, { CVAR_INFINITE_BOOTS_SNEAKERS });
+static RegisterShipInitFunc initBootsAndSneakersTimerFunc(RegisterBootsAndSneakersTimer_Init,
+                                                          { CVAR_INFINITE_BOOTS_SNEAKERS });
 static RegisterShipInitFunc initBootCycleFunc(RegisterTalonTrotCycle_Init, { CVAR_TALON_TROT_CYCLE });
 static RegisterShipInitFunc initLevitateFunc(RegisterLevitate_Init, { CVAR_LEVITATE });
 static RegisterShipInitFunc initCycleTransformFunc(RegisterCycleTransform_Init, { CVAR_CYCLE_TRANSFORM });

--- a/src/port/enhancements/events/PortEnhancements.cpp
+++ b/src/port/enhancements/events/PortEnhancements.cpp
@@ -18,6 +18,7 @@ void PortEnhancements_Register() {
     REGISTER_EVENT(FrameDrawEnd);
     REGISTER_EVENT(VanillaBehavior);
     REGISTER_EVENT(OnMapLoad);
+    REGISTER_EVENT(ViewportFrustumUpdate);
     REGISTER_EVENT(OnActorTick);
     REGISTER_EVENT(OnPropTick);
     REGISTER_EVENT(OnSpritePropTick);

--- a/src/port/enhancements/events/hooks/list/EngineEvent.h
+++ b/src/port/enhancements/events/hooks/list/EngineEvent.h
@@ -8,6 +8,8 @@ DEFINE_EVENT(FrameDrawEnd);
 
 DEFINE_EVENT(OnMapLoad, int32_t mapId;);
 
+DEFINE_EVENT(ViewportFrustumUpdate, float* frustumX; float* frustumY;);
+
 DEFINE_EVENT(OnActorTick, Actor* actor;);
 DEFINE_EVENT(OnPropTick, ActorMarker* marker; float* position;);
 DEFINE_EVENT(OnSpritePropTick, int32_t assetId; float* position;);

--- a/src/port/patches/CameraPatches.cpp
+++ b/src/port/patches/CameraPatches.cpp
@@ -20,6 +20,17 @@ enum level_e map_getLevel(enum map_e map);
 enum map_e gsworld_getMap(void);
 }
 
+#include <cmath>
+
+#ifndef M_PI
+#define M_PI 3.14159265358979323846
+#endif
+
+extern "C" {
+extern float sViewportFOVy;
+extern float sViewportAspect;
+}
+
 // Cutscene aspect lock — force 4:3 during cutscene maps
 
 #define CVAR_AR_ENABLED CVAR_PREFIX_ADVANCED_RESOLUTION ".Enabled"
@@ -123,6 +134,27 @@ void RegisterCameraPatches_Init() {
                    { sLastStaticCameraNode = *va_arg(args, int32_t*); });
 
     COND_VB_SHOULD(VB_STATIC_CAMERA_EXIT, EVENT_PRIORITY_NORMAL, true, { sLastStaticCameraNode = -1; });
+
+    // Bigger frustum — widen the side planes from the actual FOV and aspect
+    // ratio, and pad the top/bottom planes to mask vertical cam pop-in.
+    // Bail in replayed-input modes (attract demo, Bottles bonus, SnS picture):
+    // those recordings are deterministic against the vanilla cull set, and any
+    // frustum change shifts which actors tick and desyncs the playback.
+    REGISTER_LISTENER(ViewportFrustumUpdate, EVENT_PRIORITY_NORMAL, [](IEvent* event) {
+        s32 mode = getGameMode();
+        if (mode == GAME_MODE_7_ATTRACT_DEMO || mode == GAME_MODE_8_BOTTLES_BONUS || mode == GAME_MODE_A_SNS_PICTURE) {
+            return;
+        }
+        auto* ev = (ViewportFrustumUpdate*)event;
+        // Vanilla side-plane length (sqrt(89.21774^2 + 45.168514^2) ~= 100). Recompute
+        // the X component from the actual horizontal half-FOV; leave the literal Z
+        // at the original 45.168514251708984 in viewport.c — the plane normal is
+        // re-normalized after construction, so widening just X tilts the plane outward.
+        float halfFovYRad = (sViewportFOVy * 0.5f) * (float)(M_PI / 180.0);
+        float halfFovXRad = std::atan(std::tan(halfFovYRad) * sViewportAspect);
+        *ev->frustumX = std::sin(halfFovXRad) * 100.0f;
+        *ev->frustumY = 93.9692611694336f * 1.15f;
+    });
 }
 
 static RegisterShipInitFunc cutsceneAspectInitFunc(RegisterCutsceneAspect, { CVAR_CUTSCENE_ASPECT });

--- a/src/port/ui/LighthouseMenuEnhancements.cpp
+++ b/src/port/ui/LighthouseMenuEnhancements.cpp
@@ -272,7 +272,6 @@ void LighthouseMenu::AddMenuEnhancements() {
         .RaceDisable(false)
         .Options(CheckboxOptions().Tooltip(
             "Disables Mumbo untransforming you when going too far and skips his warning dialog."));
-
 }
 
 } // namespace LighthouseGui


### PR DESCRIPTION
Commit a9192b0fd313c71b2d9a77f0c4f601d491eccd9c made frustum changes to accommodate the port's default `320x240` window vs the game's `292x216` vanilla window. The frustum changes desynced attract demos and invaded the decomp function too much.

Revert the function to decomp state and use an event listener instead.