### PR TITLE
[RANDO] Save File Persistance

### DIFF
--- a/include/save.h
+++ b/include/save.h
@@ -1,13 +1,15 @@
 #ifndef __SAVE_H__
 #define __SAVE_H__
 
+#include "port/Rando/Types.h"
+
 typedef enum {
     FILE_TYPE_SAVE_VANILLA,
     FILE_TYPE_SAVE_RANDO,
 } FileType;
 
 typedef struct {
-    bool isRando;
+    RandoSaveCheck randoSaveCheck[RC_MAX];
 } RandoSaveData;
 
 typedef struct {

--- a/include/save.h
+++ b/include/save.h
@@ -10,6 +10,7 @@ typedef enum {
 
 typedef struct {
     RandoSaveCheck randoSaveCheck[RC_MAX];
+    RandoSaveOption randoSaveOption[RO_MAX];
 } RandoSaveData;
 
 typedef struct {

--- a/src/core2/fileselect.c
+++ b/src/core2/fileselect.c
@@ -15,13 +15,14 @@ int __gameFile_8033CD90(s32 filenum){
     s32 tmp_v1;
     void *save_data_ptr;
     save_data_ptr = &gameFile_saveData[filenum];
-    i = 3;
-    do{
-        tmp_v1 = savedata_8033CA2C(filenum, save_data_ptr);
-        if(!tmp_v1)
-            break;
-        i--;
-    }while(i != 0);
+    tmp_v1 = savedata_8033CA2C(filenum, save_data_ptr);
+    // i = 3;
+    // do{
+    //     tmp_v1 = savedata_8033CA2C(filenum, save_data_ptr);
+    //     if(!tmp_v1)
+    //         break;
+    //     i--;
+    // }while(i != 0);
     if(tmp_v1)
         savedata_clear(save_data_ptr);
     return tmp_v1;

--- a/src/port/Rando/CheckTracker/CheckTracker.cpp
+++ b/src/port/Rando/CheckTracker/CheckTracker.cpp
@@ -220,10 +220,14 @@ void CheckTrackerWindow::Draw() {
         checkTrackerBG.w = ImGui::IsWindowDocked() ? 1.0f : CVAR_CHECK_TRACKER_OPACITY;
         ImGui::SetWindowFontScale(checkTrackerScale);
 
-        if (ImGui::BeginChild("CheckTrackerChild")) {
-            DrawCheckTrackerList();
-            expandState = expandToggle;
-            ImGui::EndChild();
+        if (gsworld_getMap() == MAP_91_FILE_SELECT) {
+            ImGui::TextColored(UIWidgets::ColorValues.at(UIWidgets::Colors::Orange), "No Rando File Selected...");
+        } else {
+            if (ImGui::BeginChild("CheckTrackerChild")) {
+                DrawCheckTrackerList();
+                expandState = expandToggle;
+                ImGui::EndChild();
+            }
         }
     }
 

--- a/src/port/Rando/CheckTracker/CheckTracker.cpp
+++ b/src/port/Rando/CheckTracker/CheckTracker.cpp
@@ -154,8 +154,6 @@ void DrawCheckTrackerList() {
                         continue;
                     }
 
-                    
-
                     ImVec4 checkTextColor = entry.obtained ? VecFromRGBA8(CVAR_COLLECTED_COLOR)
                                                            : UIWidgets::ColorValues.at(UIWidgets::Colors::White);
                     ImVec4 itemTextColor = entry.obtained ? VecFromRGBA8(CVAR_ITEM_COLOR)

--- a/src/port/Rando/Logic/GeneratePools.cpp
+++ b/src/port/Rando/Logic/GeneratePools.cpp
@@ -99,6 +99,7 @@ void GenerateShufflePool() {
 
     for (int i = 0; i < checkPool.size(); i++) {
         Rando::StaticData::RandoShuffledPool randoShuffleEntry = {
+            .name = Rando::StaticData::Checks[checkPool[i]].name,
             .randoCheckId = checkPool[i],
             .shuffleCheckId = std::get<2>(itemPool[i]),
             .randoItemId = Rando::StaticData::GetRandoItemByActorId(std::get<0>(itemPool[i])),
@@ -116,6 +117,7 @@ void GenerateShufflePool() {
 
         for (int a = 0; a < abilityCheckPool.size(); a++) {
             Rando::StaticData::RandoShuffledPool randoShuffleEntry = {
+                .name = Rando::StaticData::Checks[abilityCheckPool[a]].name,
                 .randoCheckId = abilityCheckPool[a],
                 .shuffleCheckId = std::get<2>(abilityItemPool[a]),
                 .randoItemId = Rando::StaticData::GetRandoItemByActorId(std::get<0>(abilityItemPool[a])),
@@ -135,6 +137,7 @@ void GeneratePoolFromSaveData(SaveData* saveData) {
         RandoSaveCheck randoSaveCheck = saveData->shipSaveData.randoSaveData.randoSaveCheck[i];
 
         Rando::StaticData::RandoShuffledPool shuffledObject = {
+            .name = Rando::StaticData::Checks[(RandoCheckId)i].name,
             .randoCheckId = (RandoCheckId)i,
             .shuffleCheckId = randoSaveCheck.shuffledCheckId,
             .randoItemId = randoSaveCheck.randoItemId,

--- a/src/port/Rando/Logic/GeneratePools.cpp
+++ b/src/port/Rando/Logic/GeneratePools.cpp
@@ -130,6 +130,23 @@ void GenerateShufflePool() {
     }
 }
 
+void GeneratePoolFromSaveData(SaveData* saveData) {
+    for (int i = RC_UNKNOWN; i < RC_MAX; i++) {
+        RandoSaveCheck randoSaveCheck = saveData->shipSaveData.randoSaveData.randoSaveCheck[i];
+
+        Rando::StaticData::RandoShuffledPool shuffledObject = {
+            .randoCheckId = (RandoCheckId)i,
+            .shuffleCheckId = randoSaveCheck.shuffledCheckId,
+            .randoItemId = randoSaveCheck.randoItemId,
+            .isShuffled = randoSaveCheck.isShuffled,
+            .obtained = randoSaveCheck.obtained,
+            .skipped = randoSaveCheck.skipped,
+        };
+
+        Rando::Logic::shuffledPool.push_back(shuffledObject);
+    }
+}
+
 
 } // namespace Logic
 

--- a/src/port/Rando/Logic/GenerateSaveData.cpp
+++ b/src/port/Rando/Logic/GenerateSaveData.cpp
@@ -9,6 +9,7 @@ void Rando::Logic::InitializeSaveData(SaveData* saveData) {
     // RandoSaveCheck - Initialize
     for (auto& [randoCheckId, randoStaticCheck] : Rando::StaticData::Checks) {
         RandoSaveCheck randoSaveCheck = {
+            .name = randoStaticCheck.name,
             .randoItemId = Rando::StaticData::GetRandoItemByActorId((actor_e)randoStaticCheck.actorId),
             .shuffledCheckId = randoCheckId,
             .randoCollectionId = randoStaticCheck.collectionId,
@@ -24,6 +25,7 @@ void Rando::Logic::InitializeSaveData(SaveData* saveData) {
 void Rando::Logic::GenerateSaveData(SaveData* saveData) {
     for (auto& object : Rando::Logic::shuffledPool) {
         RandoSaveCheck randoSaveCheck = {
+            .name = object.name,
             .randoItemId = object.randoItemId,
             .shuffledCheckId = object.shuffleCheckId,
             .randoCollectionId = object.randoCollectionId,

--- a/src/port/Rando/Logic/GenerateSaveData.cpp
+++ b/src/port/Rando/Logic/GenerateSaveData.cpp
@@ -20,6 +20,15 @@ void Rando::Logic::InitializeSaveData(SaveData* saveData) {
 
         saveData->shipSaveData.randoSaveData.randoSaveCheck[randoCheckId] = randoSaveCheck;
     }
+
+    for (auto& [randoOptionId, randoStaticOption] : Rando::StaticData::Options) {
+        RandoSaveOption randoSaveOption = {
+            .name = randoStaticOption.name,
+            .optionValue = CVarGetInteger(randoStaticOption.cvar, randoStaticOption.defaultValue),
+        };
+
+        saveData->shipSaveData.randoSaveData.randoSaveOption[randoOptionId] = randoSaveOption;
+    }
 }
 
 void Rando::Logic::GenerateSaveData(SaveData* saveData) {

--- a/src/port/Rando/Logic/GenerateSaveData.cpp
+++ b/src/port/Rando/Logic/GenerateSaveData.cpp
@@ -1,0 +1,37 @@
+#include "Logic.h"
+#include "port/ui/Notification.h"
+#include <libultraship/bridge/consolevariablebridge.h>
+#include "port/enhancements/events/hooks/Events.h"
+
+#include "spdlog/spdlog.h"
+
+void Rando::Logic::InitializeSaveData(SaveData* saveData) {
+    // RandoSaveCheck - Initialize
+    for (auto& [randoCheckId, randoStaticCheck] : Rando::StaticData::Checks) {
+        RandoSaveCheck randoSaveCheck = {
+            .randoItemId = Rando::StaticData::GetRandoItemByActorId((actor_e)randoStaticCheck.actorId),
+            .shuffledCheckId = randoCheckId,
+            .randoCollectionId = randoStaticCheck.collectionId,
+            .isShuffled = false,
+            .obtained = false,
+            .skipped = false,
+        };
+
+        saveData->shipSaveData.randoSaveData.randoSaveCheck[randoCheckId] = randoSaveCheck;
+    }
+}
+
+void Rando::Logic::GenerateSaveData(SaveData* saveData) {
+    for (auto& object : Rando::Logic::shuffledPool) {
+        RandoSaveCheck randoSaveCheck = {
+            .randoItemId = object.randoItemId,
+            .shuffledCheckId = object.shuffleCheckId,
+            .randoCollectionId = object.randoCollectionId,
+            .isShuffled = object.isShuffled,
+            .obtained = object.obtained,
+            .skipped = object.skipped,
+        };
+
+        saveData->shipSaveData.randoSaveData.randoSaveCheck[object.randoCheckId] = randoSaveCheck;
+    }
+}

--- a/src/port/Rando/Logic/Logic.h
+++ b/src/port/Rando/Logic/Logic.h
@@ -20,6 +20,9 @@ namespace Logic {
 extern std::vector<Rando::StaticData::RandoShuffledPool> shuffledPool;
 
 void GenerateShufflePool();
+void GeneratePoolFromSaveData(SaveData* saveData);
+void InitializeSaveData(SaveData* saveData);
+void GenerateSaveData(SaveData* saveData);
 
 inline bool IsCheckShuffled(RandoCheckId randoCheckId) {
     bool isShuffled = false;

--- a/src/port/Rando/MiscBehavior/OnFileLoad.cpp
+++ b/src/port/Rando/MiscBehavior/OnFileLoad.cpp
@@ -18,7 +18,6 @@ void Rando::MiscBehavior::OnFileLoad() {
     REGISTER_LISTENER(OnGameLoad, EVENT_PRIORITY_NORMAL, [](IEvent* event) {
         OnGameLoad* ev = (OnGameLoad*)event;
         selectedFileNum = ev->fileNum;
-        SPDLOG_INFO("Load Selected File: {}", std::to_string(selectedFileNum));
     });
 
     REGISTER_LISTENER(OnSaveLoad, EVENT_PRIORITY_NORMAL, [](IEvent* event) {
@@ -28,11 +27,15 @@ void Rando::MiscBehavior::OnFileLoad() {
         Rando::Logic::shuffledPool.clear();
 
         if (saveData->magic != 0) {
+            if (saveData->shipSaveData.fileType == FILE_TYPE_SAVE_RANDO) {
+                Rando::Logic::GeneratePoolFromSaveData(saveData);
+            }
             return;
         }
         
         if (CVarGetInteger("gRandoSettings.Enable", 0)) {
             Rando::Logic::GenerateShufflePool();
+            Rando::Logic::InitializeSaveData(saveData);
             saveData->shipSaveData.fileType = FILE_TYPE_SAVE_RANDO;
         }
     });
@@ -41,6 +44,5 @@ void Rando::MiscBehavior::OnFileLoad() {
         OnSaveFileLoad* ev = (OnSaveFileLoad*)event;
 
         selectedFileNum = DEFAULT_FILE_NUM;
-        SPDLOG_INFO("Reset Selected File: {}", std::to_string(selectedFileNum));
     });
 }

--- a/src/port/Rando/ObjectBehavior/Bundle.cpp
+++ b/src/port/Rando/ObjectBehavior/Bundle.cpp
@@ -23,6 +23,10 @@ void Rando::ObjectBehavior::InitBundleBehavior() {
 		f32* position = va_arg(args, f32*);
         Actor** actor = va_arg(args, Actor**);
 
+        if (!IS_RANDO) {
+            return;
+        }
+
         int32_t spawnPosition[3];
         spawnPosition[0] = (int32_t)position[0];
         spawnPosition[1] = (int32_t)position[1];

--- a/src/port/Rando/ObjectBehavior/Jiggy.cpp
+++ b/src/port/Rando/ObjectBehavior/Jiggy.cpp
@@ -8,51 +8,51 @@
 #include "port/enhancements/events/PortEnhancements.h"
 #include "port/enhancements/events/hooks/Events.h"
 
-// TODO: SWAP TO RANDO_SAVE_OPTIONS
-#define CVAR_NAME Rando::StaticData::Options[RO_SHUFFLE_JIGGIES].cvar
-#define CVAR CVarGetInteger(CVAR_NAME, 0)
+#define OPTION_ENABLED RANDO_SAVE_OPTIONS[RO_SHUFFLE_JIGGIES].optionValue
 
 void Rando::ObjectBehavior::InitJiggyBehavior() {
-    COND_VB_SHOULD(VB_OVERRIDE_JIGGY_SPAWN, EVENT_PRIORITY_NORMAL, true, {
+    COND_VB_SHOULD(VB_OVERRIDE_JIGGY_SPAWN, EVENT_PRIORITY_NORMAL, OPTION_ENABLED, {
 		jiggy_e jiggyId = va_arg(args, jiggy_e);
         f32* position = va_arg(args, f32*);
 
         //LogOutSpawns(jiggyId, position[0], position[1], position[2]);
 
-        if (CVAR) {
-            RandoCheckId randoCheckId = Rando::StaticData::GetCheckByJiggyId(jiggyId);
-            
-            if (randoCheckId == RC_UNKNOWN) {
-                return;
-            }
-            
-            Rando::StaticData::RandoShuffledPool shuffledObject;
-            shuffledObject.randoCheckId = RC_UNKNOWN;
-            
-            shuffledObject = Rando::Logic::GetShuffledObject(randoCheckId);
-            if (shuffledObject.randoCheckId == RC_UNKNOWN) {
-                return;
-            }
-
-            actor_e randoActorId = GetActorIdByShuffledObjectState(shuffledObject);
-
-            if (randoActorId == ACTOR_1_UNKNOWN) {
-                return;
-            }
-
-            int32_t spawnPosition[3];
-            spawnPosition[0] = (int32_t)position[0];
-            spawnPosition[1] = (int32_t)position[1];
-            spawnPosition[2] = (int32_t)position[2];
-            
-            Actor* newCustomActor = CustomObject::SpawnCustomActor(randoActorId, spawnPosition);
-            newCustomActor = CustomObject::SetCustomActorParameters(newCustomActor, randoCheckId);
-            CustomObject::AddToCustomActorMap(randoCheckId, newCustomActor);
-            
-            ApplyCustomActorPhysics(randoCheckId, newCustomActor, false);
-            
-            CustomObject::InitializeSpawnQueue();
-            *should = true;
+        if (!IS_RANDO && !OPTION_ENABLED) {
+            return;
         }
+
+        RandoCheckId randoCheckId = Rando::StaticData::GetCheckByJiggyId(jiggyId);
+        
+        if (randoCheckId == RC_UNKNOWN) {
+            return;
+        }
+        
+        Rando::StaticData::RandoShuffledPool shuffledObject;
+        shuffledObject.randoCheckId = RC_UNKNOWN;
+        
+        shuffledObject = Rando::Logic::GetShuffledObject(randoCheckId);
+        if (shuffledObject.randoCheckId == RC_UNKNOWN) {
+            return;
+        }
+
+        actor_e randoActorId = GetActorIdByShuffledObjectState(shuffledObject);
+
+        if (randoActorId == ACTOR_1_UNKNOWN) {
+            return;
+        }
+
+        int32_t spawnPosition[3];
+        spawnPosition[0] = (int32_t)position[0];
+        spawnPosition[1] = (int32_t)position[1];
+        spawnPosition[2] = (int32_t)position[2];
+        
+        Actor* newCustomActor = CustomObject::SpawnCustomActor(randoActorId, spawnPosition);
+        newCustomActor = CustomObject::SetCustomActorParameters(newCustomActor, randoCheckId);
+        CustomObject::AddToCustomActorMap(randoCheckId, newCustomActor);
+        
+        ApplyCustomActorPhysics(randoCheckId, newCustomActor, false);
+        
+        CustomObject::InitializeSpawnQueue();
+        *should = true;
 	})
 }

--- a/src/port/Rando/ObjectBehavior/Jinjo.cpp
+++ b/src/port/Rando/ObjectBehavior/Jinjo.cpp
@@ -15,64 +15,39 @@ enum level_e map_getLevel(enum map_e map);
 s32 item_adjustByDiffWithHud(enum item_e item, s32 diff);
 }
 
-// TODO: SWAP TO RANDO_SAVE_OPTIONS
-#define CVAR_NAME Rando::StaticData::Options[RO_SHUFFLE_JINJOS].cvar
-#define CVAR CVarGetInteger(CVAR_NAME, 0)
+#define OPTION_ENABLED RANDO_SAVE_OPTIONS[RO_SHUFFLE_JINJOS].optionValue
 
 void Rando::ObjectBehavior::InitJinjoBehavior() {
     REGISTER_LISTENER(OnSetJiggyList, EVENT_PRIORITY_NORMAL, [](IEvent* event) {
         OnSetJiggyList* ev = (OnSetJiggyList*)event;
 
-        if (!IS_RANDO) {
+        if (!IS_RANDO && !OPTION_ENABLED) {
             return;
         }
 
-        if (CVAR) {
-            for (auto& pool : Rando::Logic::shuffledPool) {
-                if (!pool.obtained) {
-                    continue;
-                }
-            
-                if (Rando::StaticData::Checks[pool.shuffleCheckId].worldId != ev->levelId) {
-                    continue;
-                }
-            
-                if (pool.randoItemId >= RI_JINJO_BLUE && pool.randoItemId <= RI_JINJO_YELLOW) {
-                    int32_t jinjoMarkerId = GetJinjoActorMarkerId((actor_e)Rando::StaticData::Items[pool.randoItemId].actorId);
-                    item_adjustByDiffWithHud(ITEM_12_JINJOS, (1 << ((jinjoMarkerId + 6) & 0x1F)));
-                }
+        for (auto& pool : Rando::Logic::shuffledPool) {
+            if (!pool.obtained) {
+                continue;
+            }
+        
+            if (Rando::StaticData::Checks[pool.shuffleCheckId].worldId != ev->levelId) {
+                continue;
+            }
+        
+            if (pool.randoItemId >= RI_JINJO_BLUE && pool.randoItemId <= RI_JINJO_YELLOW) {
+                int32_t jinjoMarkerId = GetJinjoActorMarkerId((actor_e)Rando::StaticData::Items[pool.randoItemId].actorId);
+                item_adjustByDiffWithHud(ITEM_12_JINJOS, (1 << ((jinjoMarkerId + 6) & 0x1F)));
             }
         }
     })
 
-    COND_VB_SHOULD(VB_SET_JINJO_COUNT, EVENT_PRIORITY_NORMAL, CVAR, {
+    COND_VB_SHOULD(VB_SET_JINJO_COUNT, EVENT_PRIORITY_NORMAL, OPTION_ENABLED, {
         f32* position = va_arg(args, f32*);
 
-        if (!IS_RANDO) {
+        if (!IS_RANDO && !OPTION_ENABLED) {
             return;
         }
 
         *should = false;
-
-        // int16_t actorPos[3];
-        // actorPos[0] = (int16_t)position[0];
-        // actorPos[1] = (int16_t)position[1];
-        // actorPos[2] = (int16_t)position[2];
-        // 
-        // RandoCheckId randoCheckId = Rando::StaticData::GetCheckByPosition(actorPos[0], actorPos[1], actorPos[2]);
-        // if (randoCheckId == RC_UNKNOWN) {
-        //     return;
-        // }
-        // 
-        // Rando::StaticData::RandoShuffledPool shuffledObject = Rando::Logic::GetShuffledObject(randoCheckId);
-        // if (shuffledObject.randoCheckId == RC_UNKNOWN) {
-        //     return;
-        // }
-        // 
-        // if (Rando::StaticData::Checks[shuffledObject.shuffleCheckId].worldId != map_getLevel(gsworld_getMap())) {
-        //     return;
-        // }
-        // 
-        // *should = false;
     })
 }

--- a/src/port/Rando/Rando.h
+++ b/src/port/Rando/Rando.h
@@ -19,10 +19,10 @@ extern int16_t selectedFileNum;
     (selectedFileNum == DEFAULT_FILE_NUM ? false : gameFile_saveData[selectedFileNum].shipSaveData.fileType == \
      FILE_TYPE_SAVE_RANDO)
 
-#define RANDO_SAVE_CHECKS gameFile_saveData[selectedFileNum].shipSaveData.randoSaveData.randoSaveChecks
+#define RANDO_SAVE_CHECKS gameFile_saveData[selectedFileNum].shipSaveData.randoSaveData.randoSaveCheck
+#define RANDO_SAVE_OPTIONS gameFile_saveData[selectedFileNum].shipSaveData.randoSaveData.randoSaveOption
 
 // #define RANDO_SAVE_ENTRANCES(fileNum) gSaveBuffer.files[fileNum]->shipSaveData.randoSaveData.randoSaveEntrances
-// #define RANDO_SAVE_OPTIONS(fileNum) gSaveBuffer.files[fileNum]->shipSaveData.randoSaveData.randoSaveOptions
 // #define RANDO_EVENTS gSaveContext.save.shipSaveInfo.rando.randoEvents
 // #define RANDO_STARTING_ITEMS gSaveContext.save.shipSaveInfo.rando.randoStartingItems
 

--- a/src/port/Rando/Rando.h
+++ b/src/port/Rando/Rando.h
@@ -11,19 +11,20 @@ extern "C" {
 extern SaveData gameFile_saveData[4];
 }
 
+extern int16_t selectedFileNum;
+
 #define DEFAULT_FILE_NUM -1
 
 #define IS_RANDO                                                                                               \
     (selectedFileNum == DEFAULT_FILE_NUM ? false : gameFile_saveData[selectedFileNum].shipSaveData.fileType == \
      FILE_TYPE_SAVE_RANDO)
 
-// #define RANDO_SAVE_CHECKS(fileNum) gSaveBuffer.files[fileNum]->shipSaveData.randoSaveData.randoSaveChecks
+#define RANDO_SAVE_CHECKS gameFile_saveData[selectedFileNum].shipSaveData.randoSaveData.randoSaveChecks
+
 // #define RANDO_SAVE_ENTRANCES(fileNum) gSaveBuffer.files[fileNum]->shipSaveData.randoSaveData.randoSaveEntrances
 // #define RANDO_SAVE_OPTIONS(fileNum) gSaveBuffer.files[fileNum]->shipSaveData.randoSaveData.randoSaveOptions
 // #define RANDO_EVENTS gSaveContext.save.shipSaveInfo.rando.randoEvents
 // #define RANDO_STARTING_ITEMS gSaveContext.save.shipSaveInfo.rando.randoStartingItems
-
-extern int16_t selectedFileNum;
 
 namespace Rando {
 

--- a/src/port/Rando/StaticData/StaticData.h
+++ b/src/port/Rando/StaticData/StaticData.h
@@ -13,6 +13,7 @@ namespace Rando {
 namespace StaticData {
 
 struct RandoShuffledPool {
+    const char* name;
     RandoCheckId randoCheckId;
     RandoCheckId shuffleCheckId;
     RandoItemId randoItemId;

--- a/src/port/Rando/Types.h
+++ b/src/port/Rando/Types.h
@@ -1063,4 +1063,9 @@ typedef struct RandoSaveCheck {
     bool skipped;
 } RandoSaveCheck;
 
+typedef struct RandoSaveOption {
+    const char* name;
+    int32_t optionValue;
+} RandoSaveOption;
+
 #endif // RANDO_TYPES_H

--- a/src/port/Rando/Types.h
+++ b/src/port/Rando/Types.h
@@ -1054,6 +1054,7 @@ typedef enum {
 // } RandoInf;
 
 typedef struct RandoSaveCheck {
+    const char* name;
     RandoItemId randoItemId;
     RandoCheckId shuffledCheckId;
     int32_t randoCollectionId;

--- a/src/port/Rando/Types.h
+++ b/src/port/Rando/Types.h
@@ -1053,4 +1053,13 @@ typedef enum {
 //     RANDO_INF_MAX,
 // } RandoInf;
 
+typedef struct RandoSaveCheck {
+    RandoItemId randoItemId;
+    RandoCheckId shuffledCheckId;
+    int32_t randoCollectionId;
+    bool isShuffled;
+    bool obtained;
+    bool skipped;
+} RandoSaveCheck;
+
 #endif // RANDO_TYPES_H

--- a/src/port/save/SaveManager.cpp
+++ b/src/port/save/SaveManager.cpp
@@ -306,12 +306,19 @@ ordered_json Convert_SaveDataToJSON(SaveData* saveData, int32_t fileNum) {
         Rando::Logic::GenerateSaveData(saveData);
     
         for (int i = RC_UNKNOWN; i < RC_MAX; i++) {
-            json randoSaveChecks = nlohmann::json::object();
+            json jsonSaveChecks = nlohmann::json::object();
             RandoSaveCheck randoSaveCheck = saveData->shipSaveData.randoSaveData.randoSaveCheck[i];
-            RandoSaveCheck_to_json(randoSaveChecks, randoSaveCheck);
+            RandoSaveCheck_to_json(jsonSaveChecks, randoSaveCheck);
     
-            shipRando["randoSaveCheck"][randoSaveCheck.name] = randoSaveChecks;
+            shipRando["randoSaveCheck"][randoSaveCheck.name] = jsonSaveChecks;
         }
+
+        for (int o = RO_LOGIC; o < RO_MAX; o++) {
+            RandoSaveOption randoSaveOption = saveData->shipSaveData.randoSaveData.randoSaveOption[o];
+
+            shipRando["randoSaveOption"][randoSaveOption.name] = randoSaveOption.optionValue;
+        }
+
         ship["rando"] = shipRando;
     }
 
@@ -513,10 +520,19 @@ SaveData* Convert_JSONToSaveData(int32_t fileNum) {
         json rando = j["ship"]["rando"];
     
         for (int i = RC_UNKNOWN; i < RC_MAX; i++) {
-            json jsonRandoSaveChecks = rando["randoSaveCheck"][Rando::StaticData::Checks[(RandoCheckId)i].name];
-            RandoSaveCheck randoSaveCheck = RandoSaveCheck_from_json(jsonRandoSaveChecks, randoSaveCheck);
+            json jsonSaveChecks = rando["randoSaveCheck"][Rando::StaticData::Checks[(RandoCheckId)i].name];
+            RandoSaveCheck randoSaveCheck = RandoSaveCheck_from_json(jsonSaveChecks, randoSaveCheck);
     
             saveData->shipSaveData.randoSaveData.randoSaveCheck[i] = randoSaveCheck;
+        }
+
+        for (int o = RO_LOGIC; o < RO_MAX; o++) {
+            RandoSaveOption randoSaveOption = {
+                .name = Rando::StaticData::Options[(RandoOptionId)o].name,
+                .optionValue = rando["randoSaveOption"][Rando::StaticData::Options[(RandoOptionId)o].name],
+            };
+
+            saveData->shipSaveData.randoSaveData.randoSaveOption[o] = randoSaveOption;
         }
     }
 

--- a/src/port/save/SaveManager.cpp
+++ b/src/port/save/SaveManager.cpp
@@ -12,6 +12,8 @@
 #include "save.h"
 #include "Types.h"
 
+#include "port/Rando/Logic/Logic.h"
+
 extern "C" {
 #include "core1/sns.h"
 
@@ -63,6 +65,28 @@ static void BitfieldSetNBits(uint8_t* array, int startIndex, int numBits, int va
     for (int i = 0; i < numBits; i++) {
         BitfieldSetBit(array, startIndex + i, (1 << i) & value);
     }
+}
+
+nlohmann::json RandoSaveCheck_to_json(json& j, const RandoSaveCheck& randoSaveCheck) {
+    return nlohmann::json{
+        { "randoItemId", randoSaveCheck.randoItemId },
+        { "shuffledCheckId", randoSaveCheck.shuffledCheckId },
+        { "randoCollectionId", randoSaveCheck.randoCollectionId },
+        { "shuffled", randoSaveCheck.isShuffled },
+        { "obtained", randoSaveCheck.obtained },
+        { "skipped", randoSaveCheck.skipped },
+    };
+}
+
+RandoSaveCheck RandoSaveCheck_from_json(const json& j, RandoSaveCheck& randoSaveCheck) {
+    j.at("randoItemId").get_to(randoSaveCheck.randoItemId);
+    j.at("shuffledCheckId").get_to(randoSaveCheck.shuffledCheckId);
+    j.at("randoCollectionId").get_to(randoSaveCheck.randoCollectionId);
+    j.at("shuffled").get_to(randoSaveCheck.isShuffled);
+    j.at("obtained").get_to(randoSaveCheck.obtained);
+    j.at("skipped").get_to(randoSaveCheck.skipped);
+
+    return randoSaveCheck;
 }
 
 std::string CollapsedJSONArray(ordered_json jsonFile) {
@@ -245,8 +269,22 @@ ordered_json Convert_SaveDataToJSON(SaveData* saveData, int32_t fileNum) {
     ordered_json ship = ordered_json::object();
     ordered_json shipRando = ordered_json::object();
 
+    
+
     ship["fileType"] = static_cast<int>(saveData->shipSaveData.fileType);
-    ship["randoSaveData"] = shipRando;
+
+    if (saveData->shipSaveData.fileType == FILE_TYPE_SAVE_RANDO) {
+        Rando::Logic::GenerateSaveData(saveData);
+
+        for (int i = RC_UNKNOWN; i < RC_MAX; i++) {
+            json randoSaveChecks = nlohmann::json::object();
+            RandoSaveCheck randoSaveCheck = saveData->shipSaveData.randoSaveData.randoSaveCheck[i];
+            randoSaveChecks = RandoSaveCheck_to_json(randoSaveChecks, randoSaveCheck);
+
+            shipRando["randoSaveCheck"][Rando::StaticData::Checks[(RandoCheckId)i].name] = randoSaveChecks;
+        }
+        ship["rando"] = shipRando;
+    }
 
     j["ship"] = ship;
 
@@ -442,6 +480,17 @@ SaveData* Convert_JSONToSaveData(int32_t fileNum) {
     // Ship Save Data
     saveData->shipSaveData.fileType = j["ship"]["fileType"];
 
+    if (j["ship"]["fileType"].get<int>() == FILE_TYPE_SAVE_RANDO) {
+        json rando = j["ship"]["rando"];
+
+        for (int i = RC_UNKNOWN; i < RC_MAX; i++) {
+            json jsonRandoSaveChecks = rando["randoSaveCheck"][Rando::StaticData::Checks[(RandoCheckId)i].name];
+            RandoSaveCheck randoSaveCheck = RandoSaveCheck_from_json(jsonRandoSaveChecks, randoSaveCheck);
+
+            saveData->shipSaveData.randoSaveData.randoSaveCheck[i] = randoSaveCheck;
+        }
+    }
+
     return saveData;
 }
 
@@ -580,7 +629,7 @@ void SaveManager_Init() {
         OnSaveClear* ev = (OnSaveClear*)event;
         SaveData* saveData = (SaveData*)ev->result;
 
-        FileType fileType = saveData->shipSaveData.fileType; // Retain File Type during Save Process
+        ShipSaveData ship = saveData->shipSaveData; // Retain ShipSaveData during Save Process
 
         u8* savedata = (u8*)saveData;
         int i;
@@ -589,7 +638,7 @@ void SaveManager_Init() {
         }
 
         saveData = (SaveData*)savedata;
-        saveData->shipSaveData.fileType = fileType;
+        saveData->shipSaveData = ship;
 
         event->Cancelled = true;
     });

--- a/src/port/save/SaveManager.cpp
+++ b/src/port/save/SaveManager.cpp
@@ -67,15 +67,13 @@ static void BitfieldSetNBits(uint8_t* array, int startIndex, int numBits, int va
     }
 }
 
-nlohmann::json RandoSaveCheck_to_json(json& j, const RandoSaveCheck& randoSaveCheck) {
-    return nlohmann::json{
-        { "randoItemId", randoSaveCheck.randoItemId },
-        { "shuffledCheckId", randoSaveCheck.shuffledCheckId },
-        { "randoCollectionId", randoSaveCheck.randoCollectionId },
-        { "shuffled", randoSaveCheck.isShuffled },
-        { "obtained", randoSaveCheck.obtained },
-        { "skipped", randoSaveCheck.skipped },
-    };
+void RandoSaveCheck_to_json(nlohmann::json& j, const RandoSaveCheck& randoSaveCheck) {
+    j["randoItemId"] = randoSaveCheck.randoItemId;
+    j["shuffledCheckId"] = randoSaveCheck.shuffledCheckId;
+    j["randoCollectionId"] = randoSaveCheck.randoCollectionId;
+    j["shuffled"] = randoSaveCheck.isShuffled;
+    j["obtained"] = randoSaveCheck.obtained;
+    j["skipped"] = randoSaveCheck.skipped;
 }
 
 RandoSaveCheck RandoSaveCheck_from_json(const json& j, RandoSaveCheck& randoSaveCheck) {
@@ -89,13 +87,44 @@ RandoSaveCheck RandoSaveCheck_from_json(const json& j, RandoSaveCheck& randoSave
     return randoSaveCheck;
 }
 
-std::string CollapsedJSONArray(ordered_json jsonFile) {
-    std::string jsonString = jsonFile.dump(4);
-    jsonString = std::regex_replace(jsonString, std::regex(R"(\[\s+([01,\s]+?)\s+\])"), "[$1]");
-    jsonString = std::regex_replace(jsonString, std::regex(R"(\s+([01]))"), " $1");
-    jsonString = std::regex_replace(jsonString, std::regex(R"(\s+\])"), "]");
+std::string CollapsedJSONArray(const nlohmann::ordered_json& jsonFile) {
+    std::string source = jsonFile.dump(4);
+    std::string result;
+    result.reserve(source.length());
 
-    return jsonString;
+    bool isCollapsed = false;
+
+    for (size_t i = 0; i < source.length(); ++i) {
+        char c = source[i];
+
+        if (c == '[') {
+            size_t next = source.find_first_not_of(" \n\r\t", i + 1);
+            if (next != std::string::npos && (isdigit(source[next]) || source[next] == ']')) {
+                isCollapsed = true;
+                result += c;
+                continue;
+            }
+        }
+
+        if (isCollapsed) {
+            if (isspace(c)) {
+                continue;
+            }
+
+            if (c == ']') {
+                isCollapsed = false;
+                result += c;
+            } else if (c == ',') {
+                result += ", ";
+            } else {
+                result += c;
+            }
+        } else {
+            result += c;
+        }
+    }
+
+    return result;
 }
 
 ordered_json Convert_SaveDataToJSON(SaveData* saveData, int32_t fileNum) {
@@ -275,13 +304,13 @@ ordered_json Convert_SaveDataToJSON(SaveData* saveData, int32_t fileNum) {
 
     if (saveData->shipSaveData.fileType == FILE_TYPE_SAVE_RANDO) {
         Rando::Logic::GenerateSaveData(saveData);
-
+    
         for (int i = RC_UNKNOWN; i < RC_MAX; i++) {
             json randoSaveChecks = nlohmann::json::object();
             RandoSaveCheck randoSaveCheck = saveData->shipSaveData.randoSaveData.randoSaveCheck[i];
-            randoSaveChecks = RandoSaveCheck_to_json(randoSaveChecks, randoSaveCheck);
-
-            shipRando["randoSaveCheck"][Rando::StaticData::Checks[(RandoCheckId)i].name] = randoSaveChecks;
+            RandoSaveCheck_to_json(randoSaveChecks, randoSaveCheck);
+    
+            shipRando["randoSaveCheck"][randoSaveCheck.name] = randoSaveChecks;
         }
         ship["rando"] = shipRando;
     }
@@ -482,11 +511,11 @@ SaveData* Convert_JSONToSaveData(int32_t fileNum) {
 
     if (j["ship"]["fileType"].get<int>() == FILE_TYPE_SAVE_RANDO) {
         json rando = j["ship"]["rando"];
-
+    
         for (int i = RC_UNKNOWN; i < RC_MAX; i++) {
             json jsonRandoSaveChecks = rando["randoSaveCheck"][Rando::StaticData::Checks[(RandoCheckId)i].name];
             RandoSaveCheck randoSaveCheck = RandoSaveCheck_from_json(jsonRandoSaveChecks, randoSaveCheck);
-
+    
             saveData->shipSaveData.randoSaveData.randoSaveCheck[i] = randoSaveCheck;
         }
     }
@@ -536,19 +565,6 @@ static void LoadGlobalData() {
     }
 }
 
-void SaveManager_LoadAll() {
-    for (int i = 0; i < 3; i++) {
-        SaveData* loadSave = Convert_JSONToSaveData(i);
-        if (loadSave->slotIndex != 0) {
-            loadSave->magic = SAVE_MAGIC;
-        }
-        gameFile_saveData[i] = *(loadSave);
-        delete loadSave;
-    }
-
-    LoadGlobalData();
-}
-
 static void SaveGlobalData() {
     ordered_json j = ordered_json::object();
 
@@ -580,7 +596,7 @@ static void SaveGlobalData() {
 }
 
 void SaveManager_Init() {
-    SaveManager_LoadAll();
+    LoadGlobalData();
 
     // Ensure global.json exists
     std::string globalPath = SaveManager_GetSavePath("global.json");


### PR DESCRIPTION
All Rando Check and Option data now stored in the save file. This enables persistent saves across play sessions.

Additional I reworked the Regex for Collapsing Arrays in the JSON as Randos large footprint was causing significant process delays (2-3 seconds) when saving data.

Corrected an oversight where we were loading all save slots 3 times on boot. 
- fileselect.c was doing this in its vanilla code. I commented out that code, this may need to be hooked and cancelled later.
- our SaveManager_LoadAll() function loaded each file once. I removed this altogether as it wasnt necessary.
- the vanilla code was loading all save slots upon entry into the file select screen, i left this intact and all saving and loading looked to be fully operational while only performing those disk read/writes once.