### PR TITLE
[RANDO] Add Starting Loadout Options

### DIFF
--- a/src/port/Rando/LighthouseMenuRando.cpp
+++ b/src/port/Rando/LighthouseMenuRando.cpp
@@ -6,6 +6,7 @@
 #include "port/ui/UIWidgets.hpp"
 
 #include "port/Rando/CustomObject/CustomObject.h"
+#include "port/Rando/Logic/Logic.h"
 
 extern "C" {
 #include "variables.h"
@@ -56,7 +57,99 @@ void LighthouseMenu::AddMenuRando() {
     AddWidget(path, "Shuffle Music Notes", WIDGET_CVAR_CHECKBOX)
         .CVar(Rando::StaticData::Options[RO_SHUFFLE_MUSIC_NOTES].cvar)
         .Options(CheckboxOptions().Tooltip("Shuffles Music Notes into the Pool."));
-    
+
+    // Rando - Starting Loadout
+    AddSidebarEntry("Rando", "Starting Loadout", 1);
+    path = { "Rando", "Starting Loadout", SECTION_COLUMN_1 };
+
+    AddWidget(path, "Starting Abilities", WIDGET_SEPARATOR_TEXT);
+
+    AddWidget(path, "Abilities", WIDGET_CUSTOM)
+        .CustomFunction([](WidgetInfo& info) {
+            std::string abilityToolTip;
+            bool defaultValue = false;
+
+            ImGui::PushID(SECTION_COLUMN_1);
+            if (UIWidgets::Button("Enable All", UIWidgets::ButtonOptions().Color(UIWidgets::Colors::Green).Size(ImVec2(ImGui::GetContentRegionAvail().x * 0.5f, 0)))) {
+                for (auto& [abilityId, abilityInfo] : abilityLoadoutMap) {
+                    if (abilityId == ABILITY_A_HOLD_A_JUMP_HIGHER) {
+                        continue;
+                    }
+                    CVarSetInteger(abilityInfo.second, true);
+                }
+                Ship::Context::GetInstance()->GetWindow()->GetGui()->SaveConsoleVariablesNextFrame();
+            }
+            ImGui::SameLine();
+            if (UIWidgets::Button("Disable All", UIWidgets::ButtonOptions().Color(UIWidgets::Colors::Red))) {
+                for (auto& [abilityId, abilityInfo] : abilityLoadoutMap) {
+                    if (abilityId == ABILITY_A_HOLD_A_JUMP_HIGHER) {
+                        continue;
+                    }
+                    CVarSetInteger(abilityInfo.second, false);
+                }
+                Ship::Context::GetInstance()->GetWindow()->GetGui()->SaveConsoleVariablesNextFrame();
+            }
+            ImGui::PopID();
+
+            if (ImGui::BeginTable("Abilities Table", 3, ImGuiTableFlags_SizingStretchSame)) {
+                ImGui::TableNextColumn();
+
+                for (auto& [abilityId, abilityInfo] : abilityLoadoutMap) {
+                    abilityToolTip = std::format("Start with {} unlocked.", abilityInfo.first);
+                    defaultValue = abilityId == ABILITY_A_HOLD_A_JUMP_HIGHER ? true : false;
+
+                    ImGui::BeginDisabled(abilityId == ABILITY_A_HOLD_A_JUMP_HIGHER);
+                    UIWidgets::CVarCheckbox(abilityInfo.first, abilityInfo.second,
+                                            UIWidgets::CheckboxOptions()
+                                                .Color(WIDGET_COLOR)
+                                                .Tooltip(abilityToolTip.c_str())
+                                                .DefaultValue(defaultValue));
+                    ImGui::EndDisabled();
+                    ImGui::TableNextColumn();
+                }
+                ImGui::EndTable();
+            }
+        });
+
+    AddWidget(path, "Starting Consumables", WIDGET_SEPARATOR_TEXT);
+
+    AddWidget(path, "Consumables", WIDGET_CUSTOM).CustomFunction([](WidgetInfo& info) {
+        std::string itemToolTip;
+        bool defaultValue = false;
+
+        ImGui::PushID(SECTION_COLUMN_2);
+        if (UIWidgets::Button("Enable All", UIWidgets::ButtonOptions()
+                                                .Color(UIWidgets::Colors::Green)
+                                                .Size(ImVec2(ImGui::GetContentRegionAvail().x * 0.5f, 0)))) {
+            for (auto& [itemId, itemInfo] : itemLoadoutMap) {
+                CVarSetInteger(itemInfo.second, true);
+            }
+            Ship::Context::GetInstance()->GetWindow()->GetGui()->SaveConsoleVariablesNextFrame();
+        }
+        ImGui::SameLine();
+        if (UIWidgets::Button("Disable All", UIWidgets::ButtonOptions().Color(UIWidgets::Colors::Red))) {
+            for (auto& [itemId, itemInfo] : itemLoadoutMap) {
+                CVarSetInteger(itemInfo.second, false);
+            }
+            Ship::Context::GetInstance()->GetWindow()->GetGui()->SaveConsoleVariablesNextFrame();
+        }
+        ImGui::PopID();
+
+        if (ImGui::BeginTable("Items Table", 3, ImGuiTableFlags_SizingStretchSame)) {
+            ImGui::TableNextColumn();
+
+            for (auto& [itemId, itemInfo] : itemLoadoutMap) {
+                itemToolTip = std::format("Start with max {}.", itemInfo.first);
+
+                UIWidgets::CVarCheckbox(itemInfo.first, itemInfo.second,
+                                        UIWidgets::CheckboxOptions().Color(WIDGET_COLOR).Tooltip(itemToolTip.c_str()));
+                ImGui::TableNextColumn();
+            }
+            ImGui::EndTable();
+        }
+
+    });
+
     // Rando - Junk Options
     AddSidebarEntry("Rando", "Junk Options", 1);
     path = { "Rando", "Junk Options", SECTION_COLUMN_1 };

--- a/src/port/Rando/Logic/GenerateSaveData.cpp
+++ b/src/port/Rando/Logic/GenerateSaveData.cpp
@@ -1,9 +1,47 @@
 #include "Logic.h"
 #include "port/ui/Notification.h"
 #include <libultraship/bridge/consolevariablebridge.h>
+#include "port/ui/cvar_prefixes.h"
 #include "port/enhancements/events/hooks/Events.h"
 
-#include "spdlog/spdlog.h"
+#include "port/save/Types.h"
+
+extern "C" {
+void ability_setLearned(s32 move, s32 val);
+void ability_setHasUsed(enum ability_e move);
+
+void item_setMaxCount(s32 item);
+}
+
+// clang-format off
+std::map<ability_e, std::pair<const char*, const char*>> abilityLoadoutMap = {
+    { ABILITY_0_BARGE,              { "Beak Barge",     CVAR_RANDOMIZER_SETTING("Loadout.Abilities.BeakBarge") } },
+    { ABILITY_1_BEAK_BOMB,          { "Beak Bomb",      CVAR_RANDOMIZER_SETTING("Loadout.Abilities.BeakBomb") } },
+    { ABILITY_2_BEAK_BUSTER,        { "Beak Buster",    CVAR_RANDOMIZER_SETTING("Loadout.Abilities.BeakBuster") } },
+    { ABILITY_3_CAMERA_CONTROL,     { "Camera Control", CVAR_RANDOMIZER_SETTING("Loadout.Abilities.CameraControl") } },
+    { ABILITY_4_CLAW_SWIPE,         { "Claw Swipe",     CVAR_RANDOMIZER_SETTING("Loadout.Abilities.ClawSwipe") } },
+    { ABILITY_5_CLIMB,              { "Climb",          CVAR_RANDOMIZER_SETTING("Loadout.Abilities.Climb") } },
+    { ABILITY_6_EGGS,               { "Eggs",           CVAR_RANDOMIZER_SETTING("Loadout.Abilities.Eggs") } },
+    { ABILITY_7_FEATHERY_FLAP,      { "Feathery Flap",  CVAR_RANDOMIZER_SETTING("Loadout.Abilities.FeatheryFlap") } },
+    { ABILITY_8_FLAP_FLIP,          { "Flap Flip",      CVAR_RANDOMIZER_SETTING("Loadout.Abilities.FlapFlip") } },
+    { ABILITY_9_FLIGHT,             { "Flight",         CVAR_RANDOMIZER_SETTING("Loadout.Abilities.Flight") } },
+    { ABILITY_A_HOLD_A_JUMP_HIGHER, { "Jump Higher",    CVAR_RANDOMIZER_SETTING("Loadout.Abilities.JumpHigher") } },
+    { ABILITY_B_RATATAT_RAP,        { "Rat-a-tat Rap",  CVAR_RANDOMIZER_SETTING("Loadout.Abilities.RatatatRap") } },
+    { ABILITY_C_ROLL,               { "Roll",           CVAR_RANDOMIZER_SETTING("Loadout.Abilities.Roll") } },
+    { ABILITY_D_SHOCK_JUMP,         { "Shock Jump",     CVAR_RANDOMIZER_SETTING("Loadout.Abilities.ShockJump") } },
+    { ABILITY_E_WADING_BOOTS,       { "Wading Boots",   CVAR_RANDOMIZER_SETTING("Loadout.Abilities.WadingBoots") } },
+    { ABILITY_F_DIVE,               { "Dive",           CVAR_RANDOMIZER_SETTING("Loadout.Abilities.Dive") } },
+    { ABILITY_10_TALON_TROT,        { "Talon Trot",     CVAR_RANDOMIZER_SETTING("Loadout.Abilities.TalonTrot") } },
+    { ABILITY_11_TURBO_TALON,       { "Turbo Talon",    CVAR_RANDOMIZER_SETTING("Loadout.Abilities.TurboTalon") } },
+    { ABILITY_12_WONDERWING,        { "Wonderwing",     CVAR_RANDOMIZER_SETTING("Loadout.Abilities.Wonderwing") } },
+};
+
+std::map<item_e, std::pair<const char*, const char*>> itemLoadoutMap = {
+    { ITEM_D_EGGS,          { "Blue Eggs",      CVAR_RANDOMIZER_SETTING("Loadout.Items.BlueEggs") } },
+    { ITEM_F_RED_FEATHER,   { "Red Feathers",   CVAR_RANDOMIZER_SETTING("Loadout.Items.RedFeathers") } },
+    { ITEM_10_GOLD_FEATHER, { "Gold Feathers",  CVAR_RANDOMIZER_SETTING("Loadout.Items.GoldFeathers") } },
+};
+    // clang-format on
 
 void Rando::Logic::InitializeSaveData(SaveData* saveData) {
     // RandoSaveCheck - Initialize
@@ -44,5 +82,19 @@ void Rando::Logic::GenerateSaveData(SaveData* saveData) {
         };
 
         saveData->shipSaveData.randoSaveData.randoSaveCheck[object.randoCheckId] = randoSaveCheck;
+    }
+}
+
+void Rando::Logic::GrantStartingLoadout() {
+    for (auto& [ability, abilityInfo] : abilityLoadoutMap) {
+        if (ability == ABILITY_A_HOLD_A_JUMP_HIGHER || CVarGetInteger(abilityInfo.second, 0)) {
+            ability_setLearned(ability, true);
+            ability_setHasUsed(ability);
+        }
+    }
+    for (auto& [item, itemInfo] : itemLoadoutMap) {
+        if (CVarGetInteger(itemInfo.second, 0)) {
+            item_setMaxCount(item);
+        }
     }
 }

--- a/src/port/Rando/Logic/Logic.h
+++ b/src/port/Rando/Logic/Logic.h
@@ -14,6 +14,9 @@ s32 __transformation_getCost(enum transformation_e trans_id);
 s32 _puzzleCost(s32 index);
 }
 
+extern std::map<ability_e, std::pair<const char*, const char*>> abilityLoadoutMap;
+extern std::map<item_e, std::pair<const char*, const char*>> itemLoadoutMap;
+
 namespace Rando {
 
 namespace Logic {
@@ -23,6 +26,7 @@ void GenerateShufflePool();
 void GeneratePoolFromSaveData(SaveData* saveData);
 void InitializeSaveData(SaveData* saveData);
 void GenerateSaveData(SaveData* saveData);
+void GrantStartingLoadout();
 
 inline bool IsCheckShuffled(RandoCheckId randoCheckId) {
     bool isShuffled = false;

--- a/src/port/Rando/MiscBehavior/OnFileLoad.cpp
+++ b/src/port/Rando/MiscBehavior/OnFileLoad.cpp
@@ -36,6 +36,7 @@ void Rando::MiscBehavior::OnFileLoad() {
         if (CVarGetInteger("gRandoSettings.Enable", 0)) {
             Rando::Logic::GenerateShufflePool();
             Rando::Logic::InitializeSaveData(saveData);
+            Rando::Logic::GrantStartingLoadout();
             saveData->shipSaveData.fileType = FILE_TYPE_SAVE_RANDO;
         }
     });


### PR DESCRIPTION
Adds options to start with specific abilities and consumables, Hold A to Jump Higher is locked out and will always be granted to the player upon starting a new file.