### PR TITLE
Bring in more fixes and enhancements

### DIFF
--- a/src/CCW/ch/gnawtyboulder.c
+++ b/src/CCW/ch/gnawtyboulder.c
@@ -93,13 +93,11 @@ void chGnawtyBoulder_setNextState(Actor *this, s32 next_state) {
 
 void func_8038D81C(ActorMarker* marker, ActorMarker *other_marker) {
     Actor* actor = marker_getActor(marker);
-#ifdef PORT_FIX
-    // [port] v1.1 fix: rock is indestructible in Spring (prevents sequence break)
-    if (actor->state == 1 && gsworld_getMap() != MAP_43_CCW_SPRING) {
-#else
     if (actor->state == 1) {
-#endif
-        chGnawtyBoulder_setNextState(actor, 2);
+        // [port] v1.1 fix: rock is indestructible in Spring (prevents sequence break)
+        if (gsworld_getMap() != MAP_43_CCW_SPRING || EventSystem_Should(VB_CCW_GNAWTY_SPRING_ROCK, true)) {
+            chGnawtyBoulder_setNextState(actor, 2);
+        }
     }
 }
 

--- a/src/CCW/ch/gnawtyboulder.c
+++ b/src/CCW/ch/gnawtyboulder.c
@@ -95,7 +95,7 @@ void func_8038D81C(ActorMarker* marker, ActorMarker *other_marker) {
     Actor* actor = marker_getActor(marker);
     if (actor->state == 1) {
         // [port] v1.1 fix: rock is indestructible in Spring (prevents sequence break)
-        if (gsworld_getMap() != MAP_43_CCW_SPRING || EventSystem_Should(VB_CCW_GNAWTY_SPRING_ROCK, true)) {
+        if (EventSystem_Should(VB_CCW_GNAWTY_SPRING_ROCK, gsworld_getMap() != MAP_43_CCW_SPRING)) {
             chGnawtyBoulder_setNextState(actor, 2);
         }
     }

--- a/src/CCW/flower.c
+++ b/src/CCW/flower.c
@@ -98,12 +98,10 @@ void CCW_func_80388278(ActorMarker *marker, ActorMarker *other_marker) {
 void func_803882A4(ActorMarker* marker, ActorMarker *other_marker) {
     Actor* actor = marker_getActor(marker);
 
-#ifdef PORT_FIX
     // [port] v1.1 fix: don't allow re-planting flower in Spring after it's already been planted
-    if (gsworld_getMap() == MAP_43_CCW_SPRING && actor->state == 1 && !fileProgressFlag_get(FILEPROG_E3_CCW_FLOWER_SPRING)) {
-#else
-    if (gsworld_getMap() == MAP_43_CCW_SPRING && actor->state == 1) {
-#endif
+    if (gsworld_getMap() == MAP_43_CCW_SPRING && actor->state == 1 &&
+        (!fileProgressFlag_get(FILEPROG_E3_CCW_FLOWER_SPRING) ||
+         EventSystem_Should(VB_CCW_FLOWER_REPLANT, true))) {
         func_80387F64(actor, 2);
     }
 }

--- a/src/CCW/flower.c
+++ b/src/CCW/flower.c
@@ -99,9 +99,9 @@ void func_803882A4(ActorMarker* marker, ActorMarker *other_marker) {
     Actor* actor = marker_getActor(marker);
 
     // [port] v1.1 fix: don't allow re-planting flower in Spring after it's already been planted
-    if (gsworld_getMap() == MAP_43_CCW_SPRING && actor->state == 1 &&
-        (!fileProgressFlag_get(FILEPROG_E3_CCW_FLOWER_SPRING) ||
-         EventSystem_Should(VB_CCW_FLOWER_REPLANT, true))) {
+    if (EventSystem_Should(VB_CCW_FLOWER_REPLANT,
+                           gsworld_getMap() == MAP_43_CCW_SPRING && actor->state == 1 &&
+                               !fileProgressFlag_get(FILEPROG_E3_CCW_FLOWER_SPRING))) {
         func_80387F64(actor, 2);
     }
 }

--- a/src/FINALE/ch/chbossjinjo.c
+++ b/src/FINALE/ch/chbossjinjo.c
@@ -280,11 +280,11 @@ void chBossJinjo_update(Actor *this){
             break; 
 
         case BOSSJINJO_STATE_5_HIT:
-#ifdef PORT_FIX
             // [port] v1.1 fix: stop charge-up sound when Jinjo hits Grunty
             // (prevents infinite sound loop if hit before timed stop fires)
-            func_80324D2C(0.0f, SFX_JINJO_STATUE_POWERUP);
-#endif
+            if (!EventSystem_Should(VB_JINJO_CHARGE_SOUND, true)) {
+                func_80324D2C(0.0f, SFX_JINJO_STATUE_POWERUP);
+            }
             chfinalboss_getPosition(position_finalboss);
             position_finalboss[1] += 100.0f;
             chfinalboss_flyTo(this, position_finalboss, 1200.0f, 3840.0f, 200.0f, 2500.0f, 70.0f);

--- a/src/FINALE/ch/chfinalboss.c
+++ b/src/FINALE/ch/chfinalboss.c
@@ -2020,11 +2020,6 @@ void chfinalboss_collisionPassive(ActorMarker *marker, ActorMarker *other_marker
 
     this = marker_getActor(marker);
     local = (ActorLocal_FinalBoss *)&this->local;
-#ifdef PORT_FIX
-    // [port] v1.1 fix: don't process hits in phase 5+ (prevents pushing defeated Grunty)
-    // Collision still fires (player bounces off), but Grunty ignores the hit.
-    if (local->phase >= 5) return;
-#endif
     switch (local->phase) {
     case 1:
         if (local->hits == 0) {

--- a/src/TTC/ch/clam.c
+++ b/src/TTC/ch/clam.c
@@ -253,11 +253,11 @@ static void __chClam_attackOther(ActorMarker *this_marker, ActorMarker *other_ma
 
     // [port] Match JP: only drop while fewer than 8 eggs / 5 red feathers are on the
     // ground at once, preventing the spawn-overflow crash.
-    if (item_getCount(ITEM_D_EGGS) != 0 && port_yumYumDropAllowed(ACTOR_52_BLUE_EGG, 8)) {
+    if (item_getCount(ITEM_D_EGGS) != 0 && EventSystem_Should(VB_YUMYUM_DROP, true, ACTOR_52_BLUE_EGG, 8)) {
         __chClam_playerDropsItem(BUNDLE_E_YUMYUM_BLUE_EGG, ITEM_D_EGGS);
     }
 
-    if (item_getCount(ITEM_F_RED_FEATHER) != 0 && port_yumYumDropAllowed(ACTOR_129_RED_FEATHER, 5)) {
+    if (item_getCount(ITEM_F_RED_FEATHER) != 0 && EventSystem_Should(VB_YUMYUM_DROP, true, ACTOR_129_RED_FEATHER, 5)) {
         __chClam_playerDropsItem(BUNDLE_F_YUMYUM_RED_FEATHER, ITEM_F_RED_FEATHER);
     }
 }

--- a/src/TTC/ch/clam.c
+++ b/src/TTC/ch/clam.c
@@ -3,6 +3,7 @@
 #include "functions.h"
 #include "variables.h"
 #include "bk_math.h"
+#include "port/patches/Patches.h"
 
 extern Actor *spawnQueue_bundle_f32(s32, s32, s32, s32);
 extern ActorProp * func_80320EB0(ActorMarker *, f32, s32);
@@ -242,12 +243,6 @@ static void __chClam_playerDropsItem(enum bundle_e bundle_id, enum item_e item_i
     item_dec(item_id);
 }
 
-// [port] Track total items dropped on ground to prevent spawn overflow crash.
-// Resets on map reload (static in overlay code). Conservative — if player picks up
-// dropped items the counter doesn't decrement, but that just means fewer future drops.
-static s32 s_droppedEggs = 0;
-static s32 s_droppedFeathers = 0;
-
 static void __chClam_attackOther(ActorMarker *this_marker, ActorMarker *other_marker){
 
     if(baiFrame_getState() == 3) return;
@@ -256,18 +251,14 @@ static void __chClam_attackOther(ActorMarker *this_marker, ActorMarker *other_ma
         mapSpecificFlags_set(TTC_SPECIFIC_FLAG_5_CLAM_FIRST_MEET_TEXT_SHOWN, true);
     }
 
-    if (item_getCount(ITEM_D_EGGS) != 0) {
-        if (s_droppedEggs < 8) {
-            __chClam_playerDropsItem(BUNDLE_E_YUMYUM_BLUE_EGG, ITEM_D_EGGS);
-            s_droppedEggs++;
-        }
+    // [port] Match JP: only drop while fewer than 8 eggs / 5 red feathers are on the
+    // ground at once, preventing the spawn-overflow crash.
+    if (item_getCount(ITEM_D_EGGS) != 0 && port_yumYumDropAllowed(ACTOR_52_BLUE_EGG, 8)) {
+        __chClam_playerDropsItem(BUNDLE_E_YUMYUM_BLUE_EGG, ITEM_D_EGGS);
     }
 
-    if (item_getCount(ITEM_F_RED_FEATHER) != 0) {
-        if (s_droppedFeathers < 5) {
-            __chClam_playerDropsItem(BUNDLE_F_YUMYUM_RED_FEATHER, ITEM_F_RED_FEATHER);
-            s_droppedFeathers++;
-        }
+    if (item_getCount(ITEM_F_RED_FEATHER) != 0 && port_yumYumDropAllowed(ACTOR_129_RED_FEATHER, 5)) {
+        __chClam_playerDropsItem(BUNDLE_F_YUMYUM_RED_FEATHER, ITEM_F_RED_FEATHER);
     }
 }
 

--- a/src/core1/viewport.c
+++ b/src/core1/viewport.c
@@ -194,6 +194,8 @@ void viewport_setPosition_f3(f32 x, f32 y, f32 z) {
 
 void viewport_setRotation_vec3f(f32 src[3]) {
     ml_vec3f_copy(sViewportRotation, src);
+    // [port] Nudge static-camera yaw on configured maps when in widescreen.
+    port_camera_applyWsYawFix(sViewportRotation);
 }
 
 void viewport_setRotation_f3(f32 pitch, f32 yaw, f32 roll) {

--- a/src/core2/ba/ba_modelselect.c
+++ b/src/core2/ba/ba_modelselect.c
@@ -43,7 +43,7 @@ s32 func_802985F0(void){
                 case MAP_88_CS_SPIRAL_MOUNTAIN_6:
                 case MAP_89_CS_INTRO_BANJOS_HOUSE_2:
                 case MAP_8A_CS_INTRO_BANJOS_HOUSE_3:
-                    if (port_shouldForceHighPolyBanjo()) {
+                    if (port_shouldDisableLOD()) {
                         return ASSET_34E_MODEL_BANJOKAZOOIE_HIGH_POLY;
                     }
                     return ASSET_34D_MODEL_BANJOKAZOOIE_LOW_POLY;
@@ -63,7 +63,7 @@ s32 func_802985F0(void){
                 case MAP_45_CCW_AUTUMN:
                 case MAP_46_CCW_WINTER:
                 case MAP_56_UNUSED:
-                    if (port_shouldForceHighPolyBanjo()) {
+                    if (port_shouldDisableLOD()) {
                         return ASSET_34E_MODEL_BANJOKAZOOIE_HIGH_POLY;
                     }
                     return ASSET_34D_MODEL_BANJOKAZOOIE_LOW_POLY;

--- a/src/core2/ba/ba_recoil.c
+++ b/src/core2/ba/ba_recoil.c
@@ -146,13 +146,13 @@ void func_80294BDC(void) {
             }
         }
         if (gsworld_getMap() == MAP_C_MM_TICKERS_TOWER) {
-#ifdef PORT_FIX
             // [port] v1.1 fix: instant slide on all slopes in termite mound
             // (v1.0 doubled the rate, v1.1 makes it immediate)
-            sp28 = 100.0f;
-#else
-            sp28 *= 2.0;
-#endif
+            if (EventSystem_Should(VB_TERMITE_MOUND_SLOPES, true)) {
+                sp28 *= 2.0;
+            } else {
+                sp28 = 100.0f;
+            }
         }
         if ((sp24 & 0x50) && !player_inWater()) {
             D_8037C2E4 = ml_min_f((sp28 * sp30) + D_8037C2E4, 1.0f);

--- a/src/core2/bs/player_spawn.c
+++ b/src/core2/bs/player_spawn.c
@@ -276,13 +276,11 @@ void func_8029B5EC(void){
 }
 
 void func_8029B62C(void){
-#ifdef PORT_FIX
     // [port] v1.1 fix: don't trigger game over during Boggy's race — just reload the map
-    if(item_empty(ITEM_16_LIFE) && maSlalom_isActive()){
+    if(item_empty(ITEM_16_LIFE) && maSlalom_isActive() && !EventSystem_Should(VB_BOGGY_RACE_GAME_OVER, true)){
         func_802E4048(gVoidOutReturnLocation[0], gVoidOutReturnLocation[1], 1);
         return;
     }
-#endif
     if(item_empty(ITEM_16_LIFE)){
         if(!fileProgressFlag_get(FILEPROG_BD_ENTER_LAIR_CUTSCENE) || fileProgressFlag_get(FILEPROG_A6_FURNACE_FUN_COMPLETE)){
             func_8025A430(-1, 0x7D0, 3);
@@ -849,16 +847,10 @@ s32 func_8029C9C0(s32 arg0){
     if(bakey_pressed(BUTTON_A))
         arg0 = bs_getTypeOfJump();
 
-#ifdef PORT_FIX
     // [port] v1.1 fix: check sliding first so claw swipe can't trigger during a slide
-    if(player_isSliding())
-        arg0 = BS_SLIDE;
-    else if(bakey_pressed(BUTTON_B) && can_claw())
+    if(bakey_pressed(BUTTON_B) && can_claw() &&
+       (EventSystem_Should(VB_CLAW_SWIPE_SLIDE, true) || !player_isSliding()))
         arg0 = BS_CLAW;
-#else
-    if(bakey_pressed(BUTTON_B) && can_claw())
-        arg0 = BS_CLAW;
-#endif
 
     if(bakey_held(BUTTON_Z) && bainput_should_beak_barge())
         arg0 = BS_BBARGE;
@@ -866,10 +858,8 @@ s32 func_8029C9C0(s32 arg0){
     if(bainput_should_look_first_person_camera())
         arg0 = badrone_look();
 
-#ifndef PORT_FIX
     if(player_isSliding())
         arg0  = BS_SLIDE;
-#endif
 
     return arg0;
 }

--- a/src/core2/ch/mumbotoken.c
+++ b/src/core2/ch/mumbotoken.c
@@ -51,7 +51,7 @@ enum mumbotoken_e func_802E0A90(Actor *this){
     else{
         ret = func_80306DBC(id) - 199;
         // [port] Fix duplicate mumbo token IDs (from BanjoRecomp)
-        ret = port_fixMumboTokenId(ret, pos, map_id);
+        CALL_EVENT(OnMumboTokenIdResolve, &ret, pos, map_id);
         return ret;
     }
 }

--- a/src/core2/dialog/binload.c
+++ b/src/core2/dialog/binload.c
@@ -63,7 +63,7 @@ char *dialogBin_get(enum asset_e text_id) {
     if(sp1C);
     var_v0 = s_dialogBin.ptr + var_a0;
     s_dialogBin.index = text_id;
-    port_fixCongaDialog(text_id, var_v0);
+    CALL_EVENT(OnDialogLoaded, text_id, var_v0);
     return var_v0;
 }
 

--- a/src/core2/dialog/binload.c
+++ b/src/core2/dialog/binload.c
@@ -2,6 +2,7 @@
 #include "functions.h"
 #include "variables.h"
 #include "structs.h"
+#include "port/patches/Patches.h"
 
 extern int ResourceMgr_GetDialogLanguageCount(void);
 
@@ -62,6 +63,7 @@ char *dialogBin_get(enum asset_e text_id) {
     if(sp1C);
     var_v0 = s_dialogBin.ptr + var_a0;
     s_dialogBin.index = text_id;
+    port_fixCongaDialog(text_id, var_v0);
     return var_v0;
 }
 

--- a/src/core2/gamestate.c
+++ b/src/core2/gamestate.c
@@ -86,9 +86,7 @@ s32 item_adjustByDiff(enum item_e item, s32 diff, s32 no_hud){
    // sp20;
 
     sp34 = ((fileProgressFlag_get(FILEPROG_B9_DOUBLE_HEALTH))? 2 : 1);
-    D_80385F30[ITEM_15_HEALTH_TOTAL] = port_shouldAllowAllHoneycombExtensions()
-        ? MIN(sp34*9, D_80385F30[ITEM_15_HEALTH_TOTAL])
-        : MIN(sp34*8, D_80385F30[ITEM_15_HEALTH_TOTAL]);
+    D_80385F30[ITEM_15_HEALTH_TOTAL] = MIN(sp34*8, D_80385F30[ITEM_15_HEALTH_TOTAL]);
     D_80385F30[ITEM_14_HEALTH]= MIN(D_80385F30[ITEM_15_HEALTH_TOTAL], D_80385F30[ITEM_14_HEALTH]);
     D_80385F30[ITEM_17_AIR] = MIN(3600, D_80385F30[ITEM_17_AIR]);
     D_80385F30[ITEM_25_MUMBO_TOKEN_TOTAL] = D_80385F30[ITEM_1C_MUMBO_TOKEN];
@@ -560,13 +558,9 @@ void func_8034789C(void) {
     sp1C = honeycombscore_get_total();
     D_80385F30[ITEM_13_EMPTY_HONEYCOMB] = sp1C % 6;
     if (fileProgressFlag_get(FILEPROG_B9_DOUBLE_HEALTH)) {
-        D_80385F30[ITEM_15_HEALTH_TOTAL] = port_shouldAllowAllHoneycombExtensions()
-            ? 18
-            : 16;
+        D_80385F30[ITEM_15_HEALTH_TOTAL] = 16;
     } else {
-        D_80385F30[ITEM_15_HEALTH_TOTAL] = port_shouldAllowAllHoneycombExtensions()
-            ? 5 + (sp1C / 6)
-            : 5 + MIN(3, (sp1C / 6));
+        D_80385F30[ITEM_15_HEALTH_TOTAL] = 5 + MIN(3, (sp1C / 6));
     }
     if (volatileFlag_get(VOLATILE_FLAG_94_SANDCASTLE_INFINITE_HEALTH)) {
         temp_v0 = D_80385F30[ITEM_15_HEALTH_TOTAL];

--- a/src/core2/model/render.c
+++ b/src/core2/model/render.c
@@ -864,10 +864,14 @@ void modelRender_geoCmd_LOADDL2(Gfx **gfx, Mtx **mtx, struct bk_geo_cmd_s *arg2)
 void modelRender_geoCmd_LOD(Gfx **gfx, Mtx **mtx, struct bk_geo_cmd_s *arg2){
     GeoCmd8 *cmd = (GeoCmd8 *)arg2;
     f32 dist;
-    
+
     if(cmd->subgeo_offset_1C){
-        mlMtx_apply_vec3f(transformed_pos, cmd->unk10);
-        dist = gu_sqrtf(transformed_pos[0]*transformed_pos[0] + transformed_pos[1]*transformed_pos[1] + transformed_pos[2]*transformed_pos[2]);
+        if(port_shouldDisableLOD()){
+            dist = 1.0f;
+        } else {
+            mlMtx_apply_vec3f(transformed_pos, cmd->unk10);
+            dist = gu_sqrtf(transformed_pos[0]*transformed_pos[0] + transformed_pos[1]*transformed_pos[1] + transformed_pos[2]*transformed_pos[2]);
+        }
         if(cmd->min_C < dist && dist <= cmd->max_8){
             modelRender_executeGeoCmds(gfx, mtx, (BKGeoCmd*)((u8*)cmd + cmd->subgeo_offset_1C));
         }

--- a/src/core2/sfx/source.c
+++ b/src/core2/sfx/source.c
@@ -304,7 +304,8 @@ s32 func_8030D10C(u8 indx){
             if(tmp_v0 < 100)
                 sp24 = 1;
             func_8030D004(ptr->unk40, func_8030D038(ptr, tmp_v0));
-            func_8030CF9C(ptr->unk40, func_8030CDE4(ptr));
+            func_8030CF9C(ptr->unk40,
+                          EventSystem_Should(VB_POSITIONAL_SFX_PAN, true, &ptr->sfx_uid) ? func_8030CDE4(ptr) : 0x40);
         }else{//L8030D288
             if(sfxsource_isFlagSet(ptr, SFX_SRC_FLAG_3_UNKOWN)){
                 tmp_v0 = func_8030D038(ptr, ptr->sample_rate);

--- a/src/port/Engine.cpp
+++ b/src/port/Engine.cpp
@@ -1293,6 +1293,12 @@ void GameEngine::ProcessGfxCommands(Gfx* commands) {
     static std::vector<std::unordered_map<Mtx*, MtxF>> mtx_replacements;
     int target_fps = (int)AdaptiveFps_Cap((uint32_t)GameEngine::Instance->GetInterpolationFPS());
 
+    // [port] Some music-synced cutscenes cap interpolation at native 30
+    int fpsCap = port_getInterpolationFpsCap();
+    if (fpsCap > 0 && target_fps > fpsCap) {
+        target_fps = fpsCap;
+    }
+
     // Game-logic VI per tick: gVIsPerFrame (=2 -> 30 Hz) normally; demo
     // replay and cutscene stutter raise it for slow N64 frames.
     int viPerTick = port_getDemoViCount();

--- a/src/port/Network/Anchor/DummyPlayer.cpp
+++ b/src/port/Network/Anchor/DummyPlayer.cpp
@@ -215,7 +215,7 @@ s32 DummyPlayer::dummy_func_802985F0(void) {
             return ASSET_356_MODEL_BANJO_WISHYWASHY;
         case TRANSFORM_1_BANJO: // 80298654
         default:
-            if (port_shouldForceHighPolyBanjo()) {
+            if (port_shouldDisableLOD()) {
                 return ASSET_34E_MODEL_BANJOKAZOOIE_HIGH_POLY;
             }
             return ASSET_34D_MODEL_BANJOKAZOOIE_LOW_POLY;

--- a/src/port/enhancements/events/PortEnhancements.cpp
+++ b/src/port/enhancements/events/PortEnhancements.cpp
@@ -18,6 +18,7 @@ void PortEnhancements_Register() {
     REGISTER_EVENT(FrameDrawEnd);
     REGISTER_EVENT(VanillaBehavior);
     REGISTER_EVENT(OnMapLoad);
+    REGISTER_EVENT(OnDialogLoaded);
     REGISTER_EVENT(ViewportFrustumUpdate);
     REGISTER_EVENT(OnActorTick);
     REGISTER_EVENT(OnPropTick);
@@ -36,6 +37,7 @@ void PortEnhancements_Register() {
     REGISTER_EVENT(OnGruntyJinjonatorComplete);
     REGISTER_EVENT(OnIntroCutsceneCheck);
     REGISTER_EVENT(OnMumboTokenUpdate);
+    REGISTER_EVENT(OnMumboTokenIdResolve);
     REGISTER_EVENT(OnNametagDraw);
     REGISTER_EVENT(OnPlayerAnimChange);
     REGISTER_EVENT(OnPlayerAnimReset);

--- a/src/port/enhancements/events/hooks/Events.h
+++ b/src/port/enhancements/events/hooks/Events.h
@@ -20,6 +20,7 @@ typedef enum VBehaviorID {
     VB_BOGGY_RACE_GAME_OVER,
     VB_JINJO_CHARGE_SOUND,
     VB_POSITIONAL_SFX_PAN,
+    VB_YUMYUM_DROP,
 } VBehaviorID;
 
 DEFINE_EVENT(VanillaBehavior, VBehaviorID id; bool* should; va_list * originalArgs;);

--- a/src/port/enhancements/events/hooks/Events.h
+++ b/src/port/enhancements/events/hooks/Events.h
@@ -19,6 +19,7 @@ typedef enum VBehaviorID {
     VB_CLAW_SWIPE_SLIDE,
     VB_BOGGY_RACE_GAME_OVER,
     VB_JINJO_CHARGE_SOUND,
+    VB_POSITIONAL_SFX_PAN,
 } VBehaviorID;
 
 DEFINE_EVENT(VanillaBehavior, VBehaviorID id; bool* should; va_list * originalArgs;);

--- a/src/port/enhancements/events/hooks/Events.h
+++ b/src/port/enhancements/events/hooks/Events.h
@@ -13,6 +13,12 @@ typedef enum VBehaviorID {
     VB_GRUNTY_DEFEATED_FLAG_BOSS,
     VB_PLAY_JIGGY_DANCE,
     VB_VOID_OUT_GAME_OVER,
+    VB_CCW_GNAWTY_SPRING_ROCK,
+    VB_CCW_FLOWER_REPLANT,
+    VB_TERMITE_MOUND_SLOPES,
+    VB_CLAW_SWIPE_SLIDE,
+    VB_BOGGY_RACE_GAME_OVER,
+    VB_JINJO_CHARGE_SOUND,
 } VBehaviorID;
 
 DEFINE_EVENT(VanillaBehavior, VBehaviorID id; bool* should; va_list * originalArgs;);

--- a/src/port/enhancements/events/hooks/list/BehaviorEvent.h
+++ b/src/port/enhancements/events/hooks/list/BehaviorEvent.h
@@ -19,6 +19,7 @@ DEFINE_EVENT(OnFurnaceFunDialog, s32* lifeThreshold;)
 DEFINE_EVENT(OnGruntyJinjonatorComplete)
 DEFINE_EVENT(OnIntroCutsceneCheck, bool* skipIntro;)
 DEFINE_EVENT(OnMumboTokenUpdate, Actor* actor;)
+DEFINE_EVENT(OnMumboTokenIdResolve, s32* tokenId; s32* position; s32 mapId;)
 DEFINE_EVENT(OnPlayerAnimChange, AssetID anim_id; f32 duration; AnimControl control; f32 start_position;
              f32 subrange_end; bool smooth;)
 DEFINE_EVENT(OnPlayerAnimReset)

--- a/src/port/enhancements/events/hooks/list/EngineEvent.h
+++ b/src/port/enhancements/events/hooks/list/EngineEvent.h
@@ -17,6 +17,8 @@ DEFINE_EVENT(FrameDrawEnd);
 
 DEFINE_EVENT(OnMapLoad, GameMap prevMap; GameMap nextMap; s32 exit;);
 
+DEFINE_EVENT(OnDialogLoaded, s32 textId; char* text;);
+
 DEFINE_EVENT(ViewportFrustumUpdate, float* frustumX; float* frustumY;);
 
 DEFINE_EVENT(OnActorTick, Actor* actor;);

--- a/src/port/enhancements/fixes/GameFixes.cpp
+++ b/src/port/enhancements/fixes/GameFixes.cpp
@@ -15,55 +15,19 @@ extern "C" {
 enum map_e gsworld_getMap(void);
 }
 
-// Mumbo token duplicate ID fix
-extern "C" int port_fixMumboTokenId(int ret, int pos[3], int map_id) {
-    // Token in MMM Inside Loggo shares ID 0x3D with another token
-    if (CVarGetInteger(CVAR_ENHANCEMENT("Fixes.MumboTokenMMM"), 0)) {
-        if (ret == 0x3D && pos[0] == 424 && pos[1] == 170 && pos[2] == 304 && map_id == MAP_8D_MMM_INSIDE_LOGGO) {
-            return 0x74;
-        }
-    }
-    // Token in CCW Spring shares ID 0x5E with another token
-    if (CVarGetInteger(CVAR_ENHANCEMENT("Fixes.MumboTokenCCW"), 0)) {
-        if (ret == 0x5E && pos[0] == -2649 && pos[1] == 0 && pos[2] == -395 && map_id == MAP_43_CCW_SPRING) {
-            return 0x5D;
-        }
-    }
-    return ret;
-}
-
-// Yum-Yum overflow crash: cap dropped collectibles to JP's limit of N on the ground
-// at once. Always on (a crash guard, not a toggle). Counts live actors.
-extern "C" int port_yumYumDropAllowed(int actorId, int maxOnGround) {
-    return actorArray_actorCount((enum actor_e)actorId) < maxOnGround;
-}
-
-// Spelling: "Congo" -> "Conga"
-extern "C" void port_fixCongaDialog(int textId, char* text) {
-    if (!CVarGetInteger(CVAR_ENHANCEMENT("Fixes.CongaText"), 0)) {
-        return;
-    }
-    if (textId != ASSET_B3E_DIALOG_CONGA_MEET_AS_TERMITE || text == NULL) {
-        return;
-    }
-    for (int i = 0; i < 120; i++) {
-        if (memcmp(text + i, "CONGO", 5) == 0) {
-            text[i + 4] = 'A';
-            break;
-        }
-    }
-}
-
 #define CVAR_VOID_OUT CVAR_ENHANCEMENT("Fixes.VoidOutGameOver")
 #define CVAR_FF_DIALOG CVAR_ENHANCEMENT("Fixes.FurnaceFunDialog")
 #define CVAR_GRUNTY_FLAG CVAR_ENHANCEMENT("Fixes.GruntyDefeatedFlag")
 #define CVAR_TOKEN_GV CVAR_ENHANCEMENT("Fixes.MumboTokenGV")
+#define CVAR_TOKEN_MMM CVAR_ENHANCEMENT("Fixes.MumboTokenMMM")
+#define CVAR_TOKEN_CCW CVAR_ENHANCEMENT("Fixes.MumboTokenCCW")
 #define CVAR_GNAWTY_ROCK CVAR_ENHANCEMENT("Fixes.GnawtySpringRock")
 #define CVAR_FLOWER_REPLANT CVAR_ENHANCEMENT("Fixes.CCWFlowerReplant")
 #define CVAR_TERMITE_SLOPES CVAR_ENHANCEMENT("Fixes.TermiteMoundSlopes")
 #define CVAR_CLAW_SLIDE CVAR_ENHANCEMENT("Fixes.ClawSwipeSlide")
 #define CVAR_BOGGY_RACE CVAR_ENHANCEMENT("Fixes.BoggyRaceGameOver")
 #define CVAR_JINJO_SOUND CVAR_ENHANCEMENT("Fixes.JinjoChargeSound")
+#define CVAR_CONGA_TEXT CVAR_ENHANCEMENT("Fixes.CongaText")
 
 void RegisterVoidOutGameOver_Init() {
     COND_VB_SHOULD(VB_VOID_OUT_GAME_OVER, EVENT_PRIORITY_NORMAL, CVarGetInteger(CVAR_VOID_OUT, 0),
@@ -134,6 +98,50 @@ void RegisterJinjoChargeSound_Init() {
                    { *should = false; });
 }
 
+// Yum-Yum overflow crash guard: cap dropped collectibles to JP's on-ground limit. Always on
+// (structural crash fix, not a toggle); varargs carry (actorId, maxOnGround) from the decomp.
+void RegisterYumYumDrop_Init() {
+    REGISTER_VB_SHOULD(VB_YUMYUM_DROP, EVENT_PRIORITY_NORMAL, {
+        int actorId = va_arg(args, int);
+        int maxOnGround = va_arg(args, int);
+        *should = actorArray_actorCount((enum actor_e)actorId) < maxOnGround;
+    });
+}
+
+// Spelling: "Congo" -> "Conga" when the Conga-as-termite dialog bin loads.
+void RegisterCongaDialog_Init() {
+    COND_HOOK(OnDialogLoaded, EVENT_PRIORITY_NORMAL, CVarGetInteger(CVAR_CONGA_TEXT, 0), [](IEvent* event) {
+        auto* ev = reinterpret_cast<OnDialogLoaded*>(event);
+        if (ev->textId != ASSET_B3E_DIALOG_CONGA_MEET_AS_TERMITE || ev->text == nullptr) {
+            return;
+        }
+        for (int i = 0; i < 120; i++) {
+            if (memcmp(ev->text + i, "CONGO", 5) == 0) {
+                ev->text[i + 4] = 'A';
+                break;
+            }
+        }
+    });
+}
+
+// Mumbo token duplicate-id fix: rewrite the resolved id for the two tokens that share an id.
+void RegisterMumboTokenIdResolve_Init() {
+    COND_HOOK(OnMumboTokenIdResolve, EVENT_PRIORITY_NORMAL,
+              CVarGetInteger(CVAR_TOKEN_MMM, 0) || CVarGetInteger(CVAR_TOKEN_CCW, 0), [](IEvent* event) {
+                  auto* ev = reinterpret_cast<OnMumboTokenIdResolve*>(event);
+                  // MMM Inside Loggo token shares id 0x3D with another token.
+                  if (CVarGetInteger(CVAR_TOKEN_MMM, 0) && *ev->tokenId == 0x3D && ev->position[0] == 424 &&
+                      ev->position[1] == 170 && ev->position[2] == 304 && ev->mapId == MAP_8D_MMM_INSIDE_LOGGO) {
+                      *ev->tokenId = 0x74;
+                  }
+                  // CCW Spring token shares id 0x5E with another token.
+                  if (CVarGetInteger(CVAR_TOKEN_CCW, 0) && *ev->tokenId == 0x5E && ev->position[0] == -2649 &&
+                      ev->position[1] == 0 && ev->position[2] == -395 && ev->mapId == MAP_43_CCW_SPRING) {
+                      *ev->tokenId = 0x5D;
+                  }
+              });
+}
+
 static RegisterShipInitFunc initVoidOutFunc(RegisterVoidOutGameOver_Init, { CVAR_VOID_OUT });
 static RegisterShipInitFunc initFurnaceFunDialogFunc(RegisterFurnaceFunDialog_Init, { CVAR_FF_DIALOG });
 static RegisterShipInitFunc initGruntyDefeatedFlagFunc(RegisterGruntyDefeatedFlag_Init, { CVAR_GRUNTY_FLAG });
@@ -144,3 +152,7 @@ static RegisterShipInitFunc initTermiteMoundSlopesFunc(RegisterTermiteMoundSlope
 static RegisterShipInitFunc initClawSwipeSlideFunc(RegisterClawSwipeSlide_Init, { CVAR_CLAW_SLIDE });
 static RegisterShipInitFunc initBoggyRaceGameOverFunc(RegisterBoggyRaceGameOver_Init, { CVAR_BOGGY_RACE });
 static RegisterShipInitFunc initJinjoChargeSoundFunc(RegisterJinjoChargeSound_Init, { CVAR_JINJO_SOUND });
+static RegisterShipInitFunc initYumYumDropFunc(RegisterYumYumDrop_Init);
+static RegisterShipInitFunc initCongaDialogFunc(RegisterCongaDialog_Init, { CVAR_CONGA_TEXT });
+static RegisterShipInitFunc initMumboTokenIdResolveFunc(RegisterMumboTokenIdResolve_Init,
+                                                        { CVAR_TOKEN_MMM, CVAR_TOKEN_CCW });

--- a/src/port/enhancements/fixes/GameFixes.cpp
+++ b/src/port/enhancements/fixes/GameFixes.cpp
@@ -37,6 +37,12 @@ extern "C" int port_shouldAllowAllHoneycombExtensions(void) {
     return CVarGetInteger(CVAR_ENHANCEMENT("AllHoneycombExtensions"), 0);
 }
 
+// Yum-Yum overflow crash: cap dropped collectibles to JP's limit of N on the ground
+// at once. Always on (a crash guard, not a toggle). Counts live actors.
+extern "C" int port_yumYumDropAllowed(int actorId, int maxOnGround) {
+    return actorArray_actorCount((enum actor_e) actorId) < maxOnGround;
+}
+
 // Spelling: "Congo" -> "Conga"
 extern "C" void port_fixCongaDialog(int textId, char* text) {
     if (!CVarGetInteger(CVAR_ENHANCEMENT("Fixes.CongaText"), 0)) {

--- a/src/port/enhancements/fixes/GameFixes.cpp
+++ b/src/port/enhancements/fixes/GameFixes.cpp
@@ -32,11 +32,6 @@ extern "C" int port_fixMumboTokenId(int ret, int pos[3], int map_id) {
     return ret;
 }
 
-// Honeycomb health cap removal
-extern "C" int port_shouldAllowAllHoneycombExtensions(void) {
-    return CVarGetInteger(CVAR_ENHANCEMENT("AllHoneycombExtensions"), 0);
-}
-
 // Yum-Yum overflow crash: cap dropped collectibles to JP's limit of N on the ground
 // at once. Always on (a crash guard, not a toggle). Counts live actors.
 extern "C" int port_yumYumDropAllowed(int actorId, int maxOnGround) {

--- a/src/port/enhancements/fixes/GameFixes.cpp
+++ b/src/port/enhancements/fixes/GameFixes.cpp
@@ -100,14 +100,14 @@ void RegisterMumboTokenGV_Init() {
 
 // CCW Gnawty rock: indestructible in Spring (v1.1).
 void RegisterGnawtySpringRock_Init() {
-    COND_VB_SHOULD(VB_CCW_GNAWTY_SPRING_ROCK, EVENT_PRIORITY_NORMAL, CVarGetInteger(CVAR_GNAWTY_ROCK, 0),
-                   { *should = false; });
+    COND_VB_SHOULD(VB_CCW_GNAWTY_SPRING_ROCK, EVENT_PRIORITY_NORMAL, !CVarGetInteger(CVAR_GNAWTY_ROCK, 0),
+                   { *should = true; });
 }
 
-// CCW flower: prevent the re-plant softlock (v1.1).
+// CCW flower: prevent the re-plant softlock (v1.1). Default on to prevent softlock.
 void RegisterCCWFlowerReplant_Init() {
-    COND_VB_SHOULD(VB_CCW_FLOWER_REPLANT, EVENT_PRIORITY_NORMAL, CVarGetInteger(CVAR_FLOWER_REPLANT, 0),
-                   { *should = false; });
+    COND_VB_SHOULD(VB_CCW_FLOWER_REPLANT, EVENT_PRIORITY_NORMAL, !CVarGetInteger(CVAR_FLOWER_REPLANT, 1),
+                   { *should = true; });
 }
 
 // Termite mound: instant slide on slopes (v1.1).
@@ -124,7 +124,7 @@ void RegisterClawSwipeSlide_Init() {
 
 // Boggy race: reload instead of game over at 0 lives (v1.1).
 void RegisterBoggyRaceGameOver_Init() {
-    COND_VB_SHOULD(VB_BOGGY_RACE_GAME_OVER, EVENT_PRIORITY_NORMAL, CVarGetInteger(CVAR_BOGGY_RACE, 0),
+    COND_VB_SHOULD(VB_BOGGY_RACE_GAME_OVER, EVENT_PRIORITY_NORMAL, CVarGetInteger(CVAR_BOGGY_RACE, 1),
                    { *should = false; });
 }
 

--- a/src/port/enhancements/fixes/GameFixes.cpp
+++ b/src/port/enhancements/fixes/GameFixes.cpp
@@ -40,6 +40,12 @@ extern "C" int port_shouldAllowAllHoneycombExtensions(void) {
 #define CVAR_FF_DIALOG CVAR_ENHANCEMENT("Fixes.FurnaceFunDialog")
 #define CVAR_GRUNTY_FLAG CVAR_ENHANCEMENT("Fixes.GruntyDefeatedFlag")
 #define CVAR_TOKEN_GV CVAR_ENHANCEMENT("Fixes.MumboTokenGV")
+#define CVAR_GNAWTY_ROCK CVAR_ENHANCEMENT("Fixes.GnawtySpringRock")
+#define CVAR_FLOWER_REPLANT CVAR_ENHANCEMENT("Fixes.CCWFlowerReplant")
+#define CVAR_TERMITE_SLOPES CVAR_ENHANCEMENT("Fixes.TermiteMoundSlopes")
+#define CVAR_CLAW_SLIDE CVAR_ENHANCEMENT("Fixes.ClawSwipeSlide")
+#define CVAR_BOGGY_RACE CVAR_ENHANCEMENT("Fixes.BoggyRaceGameOver")
+#define CVAR_JINJO_SOUND CVAR_ENHANCEMENT("Fixes.JinjoChargeSound")
 
 void RegisterVoidOutGameOver_Init() {
     COND_VB_SHOULD(VB_VOID_OUT_GAME_OVER, EVENT_PRIORITY_NORMAL, CVarGetInteger(CVAR_VOID_OUT, 0),
@@ -74,7 +80,49 @@ void RegisterMumboTokenGV_Init() {
     });
 }
 
+// CCW Gnawty rock: indestructible in Spring (v1.1).
+void RegisterGnawtySpringRock_Init() {
+    COND_VB_SHOULD(VB_CCW_GNAWTY_SPRING_ROCK, EVENT_PRIORITY_NORMAL, CVarGetInteger(CVAR_GNAWTY_ROCK, 0),
+                   { *should = false; });
+}
+
+// CCW flower: prevent the re-plant softlock (v1.1).
+void RegisterCCWFlowerReplant_Init() {
+    COND_VB_SHOULD(VB_CCW_FLOWER_REPLANT, EVENT_PRIORITY_NORMAL, CVarGetInteger(CVAR_FLOWER_REPLANT, 0),
+                   { *should = false; });
+}
+
+// Termite mound: instant slide on slopes (v1.1).
+void RegisterTermiteMoundSlopes_Init() {
+    COND_VB_SHOULD(VB_TERMITE_MOUND_SLOPES, EVENT_PRIORITY_NORMAL, CVarGetInteger(CVAR_TERMITE_SLOPES, 0),
+                   { *should = false; });
+}
+
+// Claw swipe: suppress claw during a slide (v1.1).
+void RegisterClawSwipeSlide_Init() {
+    COND_VB_SHOULD(VB_CLAW_SWIPE_SLIDE, EVENT_PRIORITY_NORMAL, CVarGetInteger(CVAR_CLAW_SLIDE, 0),
+                   { *should = false; });
+}
+
+// Boggy race: reload instead of game over at 0 lives (v1.1).
+void RegisterBoggyRaceGameOver_Init() {
+    COND_VB_SHOULD(VB_BOGGY_RACE_GAME_OVER, EVENT_PRIORITY_NORMAL, CVarGetInteger(CVAR_BOGGY_RACE, 0),
+                   { *should = false; });
+}
+
+// Grunty fight: stop the Jinjo charge-up sound on hit (v1.1).
+void RegisterJinjoChargeSound_Init() {
+    COND_VB_SHOULD(VB_JINJO_CHARGE_SOUND, EVENT_PRIORITY_NORMAL, CVarGetInteger(CVAR_JINJO_SOUND, 0),
+                   { *should = false; });
+}
+
 static RegisterShipInitFunc initVoidOutFunc(RegisterVoidOutGameOver_Init, { CVAR_VOID_OUT });
 static RegisterShipInitFunc initFurnaceFunDialogFunc(RegisterFurnaceFunDialog_Init, { CVAR_FF_DIALOG });
 static RegisterShipInitFunc initGruntyDefeatedFlagFunc(RegisterGruntyDefeatedFlag_Init, { CVAR_GRUNTY_FLAG });
 static RegisterShipInitFunc initMumboTokenGVFunc(RegisterMumboTokenGV_Init, { CVAR_TOKEN_GV });
+static RegisterShipInitFunc initGnawtySpringRockFunc(RegisterGnawtySpringRock_Init, { CVAR_GNAWTY_ROCK });
+static RegisterShipInitFunc initCCWFlowerReplantFunc(RegisterCCWFlowerReplant_Init, { CVAR_FLOWER_REPLANT });
+static RegisterShipInitFunc initTermiteMoundSlopesFunc(RegisterTermiteMoundSlopes_Init, { CVAR_TERMITE_SLOPES });
+static RegisterShipInitFunc initClawSwipeSlideFunc(RegisterClawSwipeSlide_Init, { CVAR_CLAW_SLIDE });
+static RegisterShipInitFunc initBoggyRaceGameOverFunc(RegisterBoggyRaceGameOver_Init, { CVAR_BOGGY_RACE });
+static RegisterShipInitFunc initJinjoChargeSoundFunc(RegisterJinjoChargeSound_Init, { CVAR_JINJO_SOUND });

--- a/src/port/enhancements/fixes/GameFixes.cpp
+++ b/src/port/enhancements/fixes/GameFixes.cpp
@@ -35,7 +35,7 @@ extern "C" int port_fixMumboTokenId(int ret, int pos[3], int map_id) {
 // Yum-Yum overflow crash: cap dropped collectibles to JP's limit of N on the ground
 // at once. Always on (a crash guard, not a toggle). Counts live actors.
 extern "C" int port_yumYumDropAllowed(int actorId, int maxOnGround) {
-    return actorArray_actorCount((enum actor_e) actorId) < maxOnGround;
+    return actorArray_actorCount((enum actor_e)actorId) < maxOnGround;
 }
 
 // Spelling: "Congo" -> "Conga"

--- a/src/port/enhancements/fixes/GameFixes.cpp
+++ b/src/port/enhancements/fixes/GameFixes.cpp
@@ -3,6 +3,7 @@
 // Port functions and event listeners for various bug fixes and corrections.
 
 #include <libultraship/bridge.h>
+#include <cstring>
 #include "port/ui/cvar_prefixes.h"
 #include "port/enhancements/events/hooks/Events.h"
 #include "port/ShipInit.hpp"
@@ -34,6 +35,22 @@ extern "C" int port_fixMumboTokenId(int ret, int pos[3], int map_id) {
 // Honeycomb health cap removal
 extern "C" int port_shouldAllowAllHoneycombExtensions(void) {
     return CVarGetInteger(CVAR_ENHANCEMENT("AllHoneycombExtensions"), 0);
+}
+
+// Spelling: "Congo" -> "Conga"
+extern "C" void port_fixCongaDialog(int textId, char* text) {
+    if (!CVarGetInteger(CVAR_ENHANCEMENT("Fixes.CongaText"), 0)) {
+        return;
+    }
+    if (textId != ASSET_B3E_DIALOG_CONGA_MEET_AS_TERMITE || text == NULL) {
+        return;
+    }
+    for (int i = 0; i < 120; i++) {
+        if (memcmp(text + i, "CONGO", 5) == 0) {
+            text[i + 4] = 'A';
+            break;
+        }
+    }
 }
 
 #define CVAR_VOID_OUT CVAR_ENHANCEMENT("Fixes.VoidOutGameOver")

--- a/src/port/enhancements/gameplay/Honeyback.cpp
+++ b/src/port/enhancements/gameplay/Honeyback.cpp
@@ -1,0 +1,72 @@
+// Backports Banjo-Tooie's Honeyback reward. Once all 24 empty honeycombs are
+// collected, health gradually refills one honeycomb at a time, starting a short
+// while after the last damage was taken.
+
+#include <libultraship/bridge.h>
+#include "port/ui/cvar_prefixes.h"
+#include "port/enhancements/events/hooks/Events.h"
+#include "port/ShipInit.hpp"
+
+extern "C" {
+#include "enums.h"
+#include "functions.h"
+}
+
+#define CVAR_NAME CVAR_ENHANCEMENT("Gameplay.Honeyback")
+
+// GameFrameUpdate fires once per 30 Hz game tick.
+static const int TICKS_PER_SECOND = 30;
+static const int ALL_HONEYCOMBS = 24;
+// Matches Tooie's HONEYBACK cheat: ~2s after the last damage, then 1 health about every 3s.
+static const int DAMAGE_DELAY_TICKS = 2 * TICKS_PER_SECOND;
+static const int REGEN_PERIOD_TICKS = 3 * TICKS_PER_SECOND;
+
+static int sPrevHealth = -1;
+static int sDamageDelay = 0;
+static int sRegenTimer = 0;
+
+void RegisterHoneyback_Init() {
+    COND_HOOK(GameFrameUpdate, EVENT_PRIORITY_NORMAL, CVarGetInteger(CVAR_NAME, 0), [](IEvent* event) {
+        if (honeycombscore_get_total() < ALL_HONEYCOMBS) {
+            sPrevHealth = -1;
+            sDamageDelay = 0;
+            sRegenTimer = 0;
+            return;
+        }
+
+        const int cur = item_getCount(ITEM_14_HEALTH);
+        const int max = item_getCount(ITEM_15_HEALTH_TOTAL);
+
+        // Re-arm tracking on the first eligible tick (or after a reload).
+        if (sPrevHealth < 0) {
+            sPrevHealth = cur;
+        }
+
+        // Took damage since last tick: hold off regen for a few seconds.
+        if (cur < sPrevHealth) {
+            sDamageDelay = DAMAGE_DELAY_TICKS;
+            sRegenTimer = 0;
+        }
+        sPrevHealth = cur;
+
+        // Don't revive the player, and do nothing when already full.
+        if (cur <= 0 || cur >= max) {
+            sRegenTimer = 0;
+            return;
+        }
+
+        if (sDamageDelay > 0) {
+            sDamageDelay--;
+            return;
+        }
+
+        if (++sRegenTimer >= REGEN_PERIOD_TICKS) {
+            sRegenTimer = 0;
+            item_adjustByDiffWithHud(ITEM_14_HEALTH, 1);
+            coMusicPlayer_playMusic(COMUSIC_16_HONEYCOMB_COLLECTED, 28000);
+            sPrevHealth = item_getCount(ITEM_14_HEALTH);
+        }
+    });
+}
+
+static RegisterShipInitFunc initFunc(RegisterHoneyback_Init, { CVAR_NAME });

--- a/src/port/enhancements/gameplay/Honeyback.cpp
+++ b/src/port/enhancements/gameplay/Honeyback.cpp
@@ -10,6 +10,7 @@
 extern "C" {
 #include "enums.h"
 #include "functions.h"
+#include "gc/gctransition.h"
 }
 
 #define CVAR_NAME CVAR_ENHANCEMENT("Gameplay.Honeyback")
@@ -27,7 +28,8 @@ static int sRegenTimer = 0;
 
 void RegisterHoneyback_Init() {
     COND_HOOK(GameFrameUpdate, EVENT_PRIORITY_NORMAL, CVarGetInteger(CVAR_NAME, 0), [](IEvent* event) {
-        if (honeycombscore_get_total() < ALL_HONEYCOMBS) {
+        if (getGameMode() != GAME_MODE_3_NORMAL || gctransition_active() || gcdialog_hasCurrentTextId() ||
+            honeycombscore_get_total() < ALL_HONEYCOMBS) {
             sPrevHealth = -1;
             sDamageDelay = 0;
             sRegenTimer = 0;

--- a/src/port/patches/CameraPatches.cpp
+++ b/src/port/patches/CameraPatches.cpp
@@ -86,6 +86,7 @@ static void updateCutsceneAspect(int32_t mapId) {
 // Widescreen yaw fix — per-frame yaw adjustment for certain static cameras in widescreen mode
 
 #define CVAR_WS_CAMERA_FIX CVAR_ENHANCEMENT("Fix.WidescreenCamera")
+#define CVAR_CENTER_SFX CVAR_ENHANCEMENT("Fixes.CenterSfx")
 
 struct WsYawFix {
     int32_t map;
@@ -120,6 +121,19 @@ extern "C" void port_camera_applyWsYawFix(float rotation[3]) {
 }
 
 // Event listeners
+
+// Center the pan for the looping SFX — TeeHee (0x3F4) and Sir Slush (0x3F5). On N64 these play
+// hard-panned by camera angle (which the port reproduces faithfully), but isolated almost entirely
+// in one channel they can read as a thin "bleating" warble. When enabled, this gate makes source.c
+// skip the camera-relative pan (func_8030CDE4) and center these two sounds (0x40). Opt-in/default off.
+void RegisterCenterSfx_Init() {
+    COND_VB_SHOULD(VB_POSITIONAL_SFX_PAN, EVENT_PRIORITY_NORMAL, CVarGetInteger(CVAR_CENTER_SFX, 0), {
+        int16_t uid = *va_arg(args, int16_t*);
+        if (uid == 0x3F4 || uid == 0x3F5)
+            *should = false;
+    });
+}
+
 void RegisterCutsceneAspect() {
     ResetCutsceneAspect();
     COND_HOOK(OnMapLoad, EVENT_PRIORITY_NORMAL, CVarGetInteger(CVAR_CUTSCENE_ASPECT, 0), [](IEvent* event) {
@@ -158,5 +172,6 @@ void RegisterCameraPatches_Init() {
     });
 }
 
+static RegisterShipInitFunc centerSfxInitFunc(RegisterCenterSfx_Init, { CVAR_CENTER_SFX });
 static RegisterShipInitFunc cutsceneAspectInitFunc(RegisterCutsceneAspect, { CVAR_CUTSCENE_ASPECT });
 static RegisterShipInitFunc staticCamInitFunc(RegisterCameraPatches_Init);

--- a/src/port/patches/CameraPatches.cpp
+++ b/src/port/patches/CameraPatches.cpp
@@ -125,9 +125,9 @@ extern "C" void port_camera_applyWsYawFix(float rotation[3]) {
 // Center the pan for the looping SFX — TeeHee (0x3F4) and Sir Slush (0x3F5). On N64 these play
 // hard-panned by camera angle (which the port reproduces faithfully), but isolated almost entirely
 // in one channel they can read as a thin "bleating" warble. When enabled, this gate makes source.c
-// skip the camera-relative pan (func_8030CDE4) and center these two sounds (0x40). Opt-in/default off.
+// skip the camera-relative pan (func_8030CDE4) and center these two sounds (0x40). Default on.
 void RegisterCenterSfx_Init() {
-    COND_VB_SHOULD(VB_POSITIONAL_SFX_PAN, EVENT_PRIORITY_NORMAL, CVarGetInteger(CVAR_CENTER_SFX, 0), {
+    COND_VB_SHOULD(VB_POSITIONAL_SFX_PAN, EVENT_PRIORITY_NORMAL, CVarGetInteger(CVAR_CENTER_SFX, 1), {
         int16_t uid = *va_arg(args, int16_t*);
         if (uid == 0x3F4 || uid == 0x3F5)
             *should = false;

--- a/src/port/patches/FramePacingPatches.cpp
+++ b/src/port/patches/FramePacingPatches.cpp
@@ -123,6 +123,19 @@ int port_getCutsceneExtraVis(void) {
     return extra;
 }
 
+int port_getInterpolationFpsCap(void) {
+    if (!CVarGetInteger(CVAR_CUTSCENE_SYNC, 1))
+        return 0;
+
+    switch (gsworld_getMap()) {
+        // [port] Cap concert to 30 fps
+        case MAP_1E_CS_START_NINTENDO:
+            return 30;
+        default:
+            return 0;
+    }
+}
+
 } // extern "C"
 
 void RegisterFramePacingPatches_Init() {

--- a/src/port/patches/GraphicsPatches.cpp
+++ b/src/port/patches/GraphicsPatches.cpp
@@ -14,7 +14,7 @@ int port_getDrawDistanceLevel(void) {
     return level;
 }
 
-int port_shouldForceHighPolyBanjo(void) {
-    return CVarGetInteger(CVAR_ENHANCEMENT("Graphics.AlwaysHighPolyBanjo"), 0);
+int port_shouldDisableLOD(void) {
+    return CVarGetInteger(CVAR_ENHANCEMENT("Graphics.DisableLOD"), 0);
 }
 }

--- a/src/port/patches/Patches.h
+++ b/src/port/patches/Patches.h
@@ -70,12 +70,6 @@ void port_mirror_clearExclude(void);
 int port_mirror_bakeCounterScale(void);
 void port_mirror_patchTextActors(void);
 
-// Fixes (GameFixes.cpp)
-
-int port_fixMumboTokenId(int ret, int pos[3], int map_id);
-int port_yumYumDropAllowed(int actorId, int maxOnGround);
-void port_fixCongaDialog(int textId, char* text);
-
 // Localization (LocalizedText.cpp)
 
 void port_localizeParade(int paradeId, void** table, uint8_t* count);

--- a/src/port/patches/Patches.h
+++ b/src/port/patches/Patches.h
@@ -72,7 +72,6 @@ void port_mirror_patchTextActors(void);
 // Fixes (GameFixes.cpp)
 
 int port_fixMumboTokenId(int ret, int pos[3], int map_id);
-int port_shouldAllowAllHoneycombExtensions(void);
 int port_yumYumDropAllowed(int actorId, int maxOnGround);
 void port_fixCongaDialog(int textId, char* text);
 

--- a/src/port/patches/Patches.h
+++ b/src/port/patches/Patches.h
@@ -73,6 +73,7 @@ void port_mirror_patchTextActors(void);
 
 int port_fixMumboTokenId(int ret, int pos[3], int map_id);
 int port_shouldAllowAllHoneycombExtensions(void);
+int port_yumYumDropAllowed(int actorId, int maxOnGround);
 void port_fixCongaDialog(int textId, char* text);
 
 // Localization (LocalizedText.cpp)

--- a/src/port/patches/Patches.h
+++ b/src/port/patches/Patches.h
@@ -13,6 +13,7 @@ int port_getDemoViCount(void);
 void port_setDemoViCount(int viCount);
 int port_getDemoDisplayViCount(int rawViCount);
 int port_getCutsceneExtraVis(void);
+int port_getInterpolationFpsCap(void);
 
 // Framebuffer (FramebufferPatches.cpp)
 

--- a/src/port/patches/Patches.h
+++ b/src/port/patches/Patches.h
@@ -73,6 +73,7 @@ void port_mirror_patchTextActors(void);
 
 int port_fixMumboTokenId(int ret, int pos[3], int map_id);
 int port_shouldAllowAllHoneycombExtensions(void);
+void port_fixCongaDialog(int textId, char* text);
 
 // Localization (LocalizedText.cpp)
 

--- a/src/port/patches/Patches.h
+++ b/src/port/patches/Patches.h
@@ -51,7 +51,7 @@ float port_getRumbleScale(void);
 // Graphics (GraphicsPatches.cpp)
 
 int port_getDrawDistanceLevel(void);
-int port_shouldForceHighPolyBanjo(void);
+int port_shouldDisableLOD(void);
 
 // Mirror (MirrorPatches.cpp)
 

--- a/src/port/ui/LighthouseMenuEnhancements.cpp
+++ b/src/port/ui/LighthouseMenuEnhancements.cpp
@@ -120,6 +120,37 @@ void LighthouseMenu::AddMenuEnhancements() {
         .Options(CheckboxOptions().Tooltip("Delays the Grunty Defeated flag until after the Jinjonator attacks, "
                                            "preventing a false win if the player dies before the hit lands."));
 
+    AddWidget(path, "Fix CCW Gnawty Rock (Spring)", WIDGET_CVAR_CHECKBOX)
+        .CVar(CVAR_ENHANCEMENT("Fixes.GnawtySpringRock"))
+        .RaceDisable(false)
+        .Options(CheckboxOptions().Tooltip("Makes Gnawty's rock indestructible in CCW Spring."));
+
+    AddWidget(path, "Fix CCW Flower Replant Softlock", WIDGET_CVAR_CHECKBOX)
+        .CVar(CVAR_ENHANCEMENT("Fixes.CCWFlowerReplant"))
+        .RaceDisable(false)
+        .Options(CheckboxOptions().Tooltip("Prevents re-planting the CCW Spring flower after it's already planted."));
+
+    AddWidget(path, "Fix Termite Mound Slopes", WIDGET_CVAR_CHECKBOX)
+        .CVar(CVAR_ENHANCEMENT("Fixes.TermiteMoundSlopes"))
+        .RaceDisable(false)
+        .Options(CheckboxOptions().Tooltip("Makes slopes in the Mumbo's Mountain termite mound slide instantly."));
+
+    AddWidget(path, "Fix Early Claw Swipe During Slide", WIDGET_CVAR_CHECKBOX)
+        .CVar(CVAR_ENHANCEMENT("Fixes.ClawSwipeSlide"))
+        .RaceDisable(false)
+        .Options(CheckboxOptions().Tooltip("Prevents a claw swipe from triggering mid-slide."));
+
+    AddWidget(path, "Fix Boggy Race Game Over", WIDGET_CVAR_CHECKBOX)
+        .CVar(CVAR_ENHANCEMENT("Fixes.BoggyRaceGameOver"))
+        .RaceDisable(false)
+        .Options(CheckboxOptions().Tooltip("Losing Boggy's race with no extra lives reloads the race instead of "
+                                           "triggering a game over."));
+
+    AddWidget(path, "Fix Grunty Jinjo Charge Sound", WIDGET_CVAR_CHECKBOX)
+        .CVar(CVAR_ENHANCEMENT("Fixes.JinjoChargeSound"))
+        .RaceDisable(false)
+        .Options(CheckboxOptions().Tooltip("Stops the Jinjo charge-up sound the instant it hits Grunty."));
+
     AddWidget(path, "Fix Cutscene Audio Sync", WIDGET_CVAR_CHECKBOX)
         .CVar(CVAR_ENHANCEMENT("Fix.CutsceneSync"))
         .RaceDisable(false)

--- a/src/port/ui/LighthouseMenuEnhancements.cpp
+++ b/src/port/ui/LighthouseMenuEnhancements.cpp
@@ -193,13 +193,12 @@ void LighthouseMenu::AddMenuEnhancements() {
         .RaceDisable(false)
         .Options(CheckboxOptions().Tooltip("Unlocks all Stop N' Swop items when loading a 100% save file."));
 
-    // TODO: All Honeycomb Extensions allows 9 honeycomb health bars instead of the 8 cap,
-    // but in 4:3 mode they overlap with the notes sprite in HUD
-    AddWidget(path, "All Honeycomb Extensions", WIDGET_CVAR_CHECKBOX)
-        .CVar(CVAR_ENHANCEMENT("AllHoneycombExtensions"))
+    AddWidget(path, "Honeyback Health Regen", WIDGET_CVAR_CHECKBOX)
+        .CVar(CVAR_ENHANCEMENT("Gameplay.Honeyback"))
         .RaceDisable(false)
         .Options(CheckboxOptions().Tooltip(
-            "Removes the 3-extension health cap, allowing all 24 honeycombs to grant health bars."));
+            "Backports Banjo-Tooie's Honeyback: once all 24 empty honeycombs are collected, your health "
+            "slowly refills one honeycomb at a time after a short pause when you stop taking damage."));
 
     AddWidget(path, "Extra Time For GV Water Pyramid", WIDGET_CVAR_CHECKBOX)
         .CVar(CVAR_ENHANCEMENT("Gameplay.WaterPyramidTimer"))

--- a/src/port/ui/LighthouseMenuEnhancements.cpp
+++ b/src/port/ui/LighthouseMenuEnhancements.cpp
@@ -56,8 +56,7 @@ void LighthouseMenu::AddMenuEnhancements() {
     AddWidget(path, "Disable LOD", WIDGET_CVAR_CHECKBOX)
         .CVar(CVAR_ENHANCEMENT("Graphics.DisableLOD"))
         .RaceDisable(false)
-        .Options(CheckboxOptions().Tooltip(
-            "Forces maximum model detail everywhere."));
+        .Options(CheckboxOptions().Tooltip("Forces maximum model detail everywhere."));
 
     AddWidget(path, "Original Aspect Ratio In Cutscenes", WIDGET_CVAR_CHECKBOX)
         .CVar(CVAR_ENHANCEMENT("Graphics.CutsceneAspect"))

--- a/src/port/ui/LighthouseMenuEnhancements.cpp
+++ b/src/port/ui/LighthouseMenuEnhancements.cpp
@@ -168,6 +168,12 @@ void LighthouseMenu::AddMenuEnhancements() {
         .Options(CheckboxOptions().Tooltip("Adjusts static camera angles in widescreen to prevent skybox "
                                            "exposure at the edges of the screen."));
 
+    AddWidget(path, "Center Enemy SFX", WIDGET_CVAR_CHECKBOX)
+        .CVar(CVAR_ENHANCEMENT("Fixes.CenterSfx"))
+        .RaceDisable(false)
+        .Options(CheckboxOptions().Tooltip(
+            "Centers the TeeHee and Sir Slush sound effects so they sound similar to N64 at distance."));
+
     // Enhancements -> Restorations
     path = { "Enhancements", "Restorations", SECTION_COLUMN_1 };
     AddSidebarEntry("Enhancements", path.sidebarName, 1);

--- a/src/port/ui/LighthouseMenuEnhancements.cpp
+++ b/src/port/ui/LighthouseMenuEnhancements.cpp
@@ -151,6 +151,11 @@ void LighthouseMenu::AddMenuEnhancements() {
         .RaceDisable(false)
         .Options(CheckboxOptions().Tooltip("Stops the Jinjo charge-up sound the instant it hits Grunty."));
 
+    AddWidget(path, "Fix Conga's Name", WIDGET_CVAR_CHECKBOX)
+        .CVar(CVAR_ENHANCEMENT("Fixes.CongaText"))
+        .RaceDisable(false)
+        .Options(CheckboxOptions().Tooltip("Corrects a spelling error when meeting Conga as a termite."));
+
     AddWidget(path, "Fix Cutscene Audio Sync", WIDGET_CVAR_CHECKBOX)
         .CVar(CVAR_ENHANCEMENT("Fix.CutsceneSync"))
         .RaceDisable(false)

--- a/src/port/ui/LighthouseMenuEnhancements.cpp
+++ b/src/port/ui/LighthouseMenuEnhancements.cpp
@@ -128,7 +128,8 @@ void LighthouseMenu::AddMenuEnhancements() {
     AddWidget(path, "Fix CCW Flower Replant Softlock", WIDGET_CVAR_CHECKBOX)
         .CVar(CVAR_ENHANCEMENT("Fixes.CCWFlowerReplant"))
         .RaceDisable(false)
-        .Options(CheckboxOptions().Tooltip("Prevents re-planting the CCW Spring flower after it's already planted."));
+        .Options(CheckboxOptions().DefaultValue(true).Tooltip(
+            "Prevents re-planting the CCW Spring flower after it's already planted."));
 
     AddWidget(path, "Fix Termite Mound Slopes", WIDGET_CVAR_CHECKBOX)
         .CVar(CVAR_ENHANCEMENT("Fixes.TermiteMoundSlopes"))
@@ -143,8 +144,9 @@ void LighthouseMenu::AddMenuEnhancements() {
     AddWidget(path, "Fix Boggy Race Game Over", WIDGET_CVAR_CHECKBOX)
         .CVar(CVAR_ENHANCEMENT("Fixes.BoggyRaceGameOver"))
         .RaceDisable(false)
-        .Options(CheckboxOptions().Tooltip("Losing Boggy's race with no extra lives reloads the race instead of "
-                                           "triggering a game over."));
+        .Options(CheckboxOptions().DefaultValue(true).Tooltip(
+            "Losing Boggy's race with no extra lives reloads the race instead of "
+            "triggering a game over."));
 
     AddWidget(path, "Fix Grunty Jinjo Charge Sound", WIDGET_CVAR_CHECKBOX)
         .CVar(CVAR_ENHANCEMENT("Fixes.JinjoChargeSound"))
@@ -171,7 +173,7 @@ void LighthouseMenu::AddMenuEnhancements() {
     AddWidget(path, "Center Enemy SFX", WIDGET_CVAR_CHECKBOX)
         .CVar(CVAR_ENHANCEMENT("Fixes.CenterSfx"))
         .RaceDisable(false)
-        .Options(CheckboxOptions().Tooltip(
+        .Options(CheckboxOptions().DefaultValue(true).Tooltip(
             "Centers the TeeHee and Sir Slush sound effects so they sound similar to N64 at distance."));
 
     // Enhancements -> Restorations

--- a/src/port/ui/LighthouseMenuEnhancements.cpp
+++ b/src/port/ui/LighthouseMenuEnhancements.cpp
@@ -53,14 +53,15 @@ void LighthouseMenu::AddMenuEnhancements() {
                      })
                      .DefaultIndex(0));
 
-    AddWidget(path, "Always High Poly Banjo", WIDGET_CVAR_CHECKBOX)
-        .CVar(CVAR_ENHANCEMENT("Graphics.AlwaysHighPolyBanjo"))
+    AddWidget(path, "Disable LOD", WIDGET_CVAR_CHECKBOX)
+        .CVar(CVAR_ENHANCEMENT("Graphics.DisableLOD"))
         .RaceDisable(false)
-        .Options(CheckboxOptions().Tooltip("Makes Banjo always use the high-polygon model, even in low-detail modes."));
+        .Options(CheckboxOptions().Tooltip(
+            "Forces maximum model detail everywhere."));
 
     AddWidget(path, "Original Aspect Ratio In Cutscenes", WIDGET_CVAR_CHECKBOX)
         .CVar(CVAR_ENHANCEMENT("Graphics.CutsceneAspect"))
-        .Options(CheckboxOptions().Tooltip("Force game to show original aspect ratio during cutscenes to avoid seeing "
+        .Options(CheckboxOptions().Tooltip("Forces game to show original aspect ratio during cutscenes to avoid seeing "
                                            "unfinished edges of scene geometry."));
 
     // Enhancements -> Modes


### PR DESCRIPTION
Addresses the following issues:

#65, #66, #67, #68, #70, #72, #73, #74, #78, and #107

The remaining are deferred. Model collision is asset-side and needs a team plan of approach if we want to have code-side fixes. Pushing and bouncing Grunty in the final fight had a marker that on further analysis was a no-op, so it was removed and I have not been able to trace the proper collision path for Grunty's phase 4.