### PR TITLE
Compile fixes after decomp pass 4

### DIFF
--- a/include/functions.h
+++ b/include/functions.h
@@ -2470,7 +2470,7 @@ void func_80315110(Gfx **gfx, Mtx **mtx, Vtx **vtx);
 void func_803151D0(Gfx **gfx, Mtx **mtx, Vtx **vtx);
 
 // --- core2/spline_pathfollow.c ---
-bool func_80344040(Actor *self);
+void func_80344040(Actor *self);
 int func_80343D50(Actor *self, s32 arg1, s32 arg2, s32 arg3);
 s32 func_80341C78(s32 arg0[3]);
 s32 func_80341D5C(s32 arg0[3], s32 arg1[3]);
@@ -2870,6 +2870,7 @@ void func_8030D8A8(s32 arg0, s32 arg);
 void func_8030D8DC(void);
 void func_8030DCCC(u8, s32);
 void sfxSource_setCallbackByIndex(u8 indx, void (*arg1)(u8));
+void sfxSource_triggerCallbackByIndex(u8 indx);
 void func_8030DFB4(u8 indx, s32 arg1);
 
 // --- core2/sfx/streamctrl.c ---

--- a/include/functions.h
+++ b/include/functions.h
@@ -145,7 +145,7 @@ BKCollisionTriangle *func_802457C4(f32 arg0[3], f32 arg1[3], f32 arg2, f32 arg3,
 // --- core2/actor_array.c ---
 BKModelBin *func_803257B4(ActorMarker *marker);
 Actor *actorArray_findActorFromMarkerId(enum marker_e marker_id);
-void *actors_appendToSavestate(void *begin, uintptr_t end);
+void *actors_appendToSavestate(void *begin, void *end);
 Actor * __actor_spawnWithYaw_s32(enum actor_e id, s32 pos[3], s32 yaw);
 Actor * spawn_child_actor(enum actor_e id, Actor ** parent);
 Actor *actorArray_findActorFromActorId(enum actor_e);

--- a/include/model.h
+++ b/include/model.h
@@ -444,7 +444,7 @@ BKCameraAreaList *modelbin_getCameraAreaList(BKModelBin *self);
 
 void model_copyFramebufferToTextures(BKModelBin *self);
 
-void *textureList_getDataPtr(BKTextureList *self);
+u8 *textureList_getDataPtr(BKTextureList *self);
 BKTextureInfo *textureList_getTextureInfo(BKTextureList *self, s32 index);
 s32 textureInfo_getBitDepth(BKTextureInfo *self);
 s32 textureInfo_getType(BKTextureInfo *self);

--- a/lib/libultra/include/PR/libaudio.h
+++ b/lib/libultra/include/PR/libaudio.h
@@ -123,7 +123,7 @@ typedef ALDMAproc (*ALDMANew)(void *state);
 
 void    alCopy(void *src, void *dest, s32 len);
 
-typedef struct {
+typedef struct ALHeap {
     u8          *base;
     u8          *cur;
     s32         len;

--- a/src/CCW/ch/grublinhood.c
+++ b/src/CCW/ch/grublinhood.c
@@ -107,7 +107,7 @@ void __chgrublinhood_initialize(Actor *this){
     local->foundPlayerSampleRate = 25000;
     local->unkC_28 = 1;
     local->hitFunction = humanoidBaddie_ow;
-    local->dieFunction = __chgrublinhood_die;
+    local->dieFunction = (void (*)(ActorMarker *, ActorMarker *)) __chgrublinhood_die;
     local->unk0 = 5.0f;
     local->unk4 = 8.0f;
     local->foundPlayerVolume = 1.0f;

--- a/src/GV/ch/mummum.c
+++ b/src/GV/ch/mummum.c
@@ -82,8 +82,8 @@ void chMumMum_initialize(Actor *this) {
     local->exitInvulnerableStateSampleRate = 20000;
     local->exitInvulnerableStateVolume = 1.0f;
     local->unkC_28 = true;
-    local->hitFunction = chMumMum_setInvulnerableState;
-    local->dieFunction = chMumMum_die;
+    local->hitFunction = (void (*)(ActorMarker *, ActorMarker *)) chMumMum_setInvulnerableState;
+    local->dieFunction = (void (*)(ActorMarker *, ActorMarker *)) chMumMum_die;
     this->unk154 |= 0x08000000;
 }
 

--- a/src/GV/ch/sarcophagus.c
+++ b/src/GV/ch/sarcophagus.c
@@ -3,7 +3,6 @@
 #include "functions.h"
 #include "variables.h"
 
-extern void dustEmitter_emit(f32[3], s32[4], s32[4], s32, f32, f32, s32, s32, s32);
 
 
 void chSarcophagus_update(Actor *this);
@@ -44,7 +43,7 @@ void GV_func_803894B0(Actor *this){
 }
 
 void func_80389518(Actor *this){
-    dustEmitter_emit(this->unk1C, D_80390E88, D_80390E78, 0, 
+    dustEmitter_emit(this->unk1C, (f32 *)D_80390E88, D_80390E78, 0, 
         0.55f, 50.0f, 0xDC, 0x168, 0
     );
 }

--- a/src/LAIR/actor_spawninit.c
+++ b/src/LAIR/actor_spawninit.c
@@ -13,7 +13,6 @@ extern void func_802D3CE8(Actor *);
 extern void func_802D3D54(Actor *);
 extern void func_802D3D74(Actor *this);
 extern void func_802D4830(Actor *, s32, f32);
-extern void dustEmitter_emit(f32[3], f32[3], s32[4], s32, f32, f32, s32, s32, s32);
 extern void func_80324CFC(f32, enum comusic_e, s32);
 extern int  actor_animationIsAt(Actor *, f32);
 extern void subaddie_set_state_with_direction(Actor *, s32, f32, s32);

--- a/src/MMM/actor_spawninit.c
+++ b/src/MMM/actor_spawninit.c
@@ -36,7 +36,6 @@ extern ActorInfo D_80372C3C;
 
 extern void core1_7090_initSfxSource(s32, s32, s32, f32);
 extern void func_8025AE0C(s32, f32);
-extern void dustEmitter_emit(f32[3], f32[3], s32[4], s32, f32, f32, s32, s32, s32);
 extern BKCollisionTriangle *func_80309B48(f32[3], f32[3], f32[3], u32);
 
 void func_802D3D54(Actor *this);

--- a/src/MMM/ch/limbo.c
+++ b/src/MMM/ch/limbo.c
@@ -78,8 +78,8 @@ static void _chskeleton_init(Actor *this) {
     local->exitInvulnerableStateSampleRate = 32000;
     local->exitInvulnerableStateVolume = 1.0f;
     local->unkC_28 = true;
-    local->hitFunction = humanoidBaddie_enterInvulnerableState;
-    local->dieFunction = chskeleton_despawn;
+    local->hitFunction = (void (*)(ActorMarker *, ActorMarker *)) humanoidBaddie_enterInvulnerableState;
+    local->dieFunction = (void (*)(ActorMarker *, ActorMarker *)) chskeleton_despawn;
 
 }
 

--- a/src/RBB/ch/seaman_grublin.c
+++ b/src/RBB/ch/seaman_grublin.c
@@ -58,7 +58,7 @@ void chSeamanGrublin_initialize(Actor *this) {
     local->foundPlayerVolume = 1.0f;
     local->unkC_28 = true;
     local->hitFunction = humanoidBaddie_ow;
-    local->dieFunction = chSeamanGrublin_die;
+    local->dieFunction = (void (*)(ActorMarker *, ActorMarker *)) chSeamanGrublin_die;
     local->damageVolume = 1.5f;
 }
 

--- a/src/TTC/ch/lockup.c
+++ b/src/TTC/ch/lockup.c
@@ -3,7 +3,6 @@
 #include "functions.h"
 #include "variables.h"
 
-extern void dustEmitter_emit(f32[3], s32[4], s32[4], s32, f32, f32, s32, s32, s32);
 
 typedef struct {
     s32 closed_ticks_counter;
@@ -152,7 +151,7 @@ static void __chLockup_updateFunc(Actor *this){
                 __chLockup_close(this);
                 for(i = 5; i < 0xe; i++){
                     vec3fArray_get_vec3f(this->marker->unk44, i, this->unk1C);
-                    dustEmitter_emit(this->unk1C, sLockup_CloseVelocity, sLockup_CloseColor, 1, 0.4f, 50.0f, 0xb4, 0xa0, 0);
+                    dustEmitter_emit(this->unk1C, (f32 *)sLockup_CloseVelocity, sLockup_CloseColor, 1, 0.4f, 50.0f, 0xb4, 0xa0, 0);
                 }
             }
             break;

--- a/src/core1/ucode.c
+++ b/src/core1/ucode.c
@@ -12,6 +12,7 @@ static s32 sDMEMdword;
 static s32 sStatus;
 
 void ucode_load(void) {
+#if 0 // [port] N64 RSP/PI hardware boot-integrity check
     sDMEMdword = *(vu32 *)(uintptr_t)PHYS_TO_K1(SP_DMEM_START) ^ 0xFFFFFFFF;
     sStatus = sDMEMdword ? 0x01 : 0x00;
 
@@ -21,12 +22,15 @@ void ucode_load(void) {
     if (sStatus == 0) {
         piMgr_read(sUcodeData, PHYS_TO_K1(PI_DOM1_ADDR2 + IPL3FONT_ROM_ADDR), UCODE_SIZE);
     }
+#endif
 }
 
 void ucode_stub1(void) {}
 
 void ucode_stub2(void) {
+#if 0 // [port] dummy PI read
     osPiReadIo(0, NULL);
+#endif
 }
 
 s32 ucode_stub3(void) {

--- a/src/core2/actor_array.c
+++ b/src/core2/actor_array.c
@@ -12,7 +12,6 @@ extern f32 GameEngine_GetAspectRatio(void);
 #define DIST_SQ_VEC3F(v1, v2) ((v1[0] - v2[0])*(v1[0] - v2[0]) + (v1[1] - v2[1])*(v1[1] - v2[1]) + (v1[2] - v2[2])*(v1[2] - v2[2]))
 
 extern void func_802D7124(Actor *, f32);
-extern void dustEmitter_emit(f32[3], s32[4], s32[4], s32, f32, f32, s32, s32, s32);
 
 
 extern f32 modelRender_func_8033A244(f32);

--- a/src/core2/ba/ba_marker.c
+++ b/src/core2/ba/ba_marker.c
@@ -20,7 +20,6 @@ extern void func_80291634(ActorMarker *, ActorMarker *);
 extern void func_80291610(ActorMarker *, ActorMarker *);
 extern Actor *baModel_80291AAC(ActorMarker *marker, Gfx **gfx, Mtx **mtx, Vtx **vtx);
 extern void baMarker_8028D7B8(s32 arg0, ActorMarker *arg1, CollisionParams *collision_flags);
-extern void dustEmitter_emit(f32[3], s32, s32[4], s32, f32, f32, s32,s32,s32);
 extern int func_80320ED8(ActorMarker *, f32, s32);
 extern NodeProp *cubeList_findNodePropByActorIdAndPosition_s32(enum actor_e actor_id, s32 position[3]);
 

--- a/src/core2/fx/effect_debris.c
+++ b/src/core2/fx/effect_debris.c
@@ -5,7 +5,6 @@
 #include <bk_math.h>
 #include "port/interpolation/FrameInterpolation.h"
 
-extern void dustEmitter_emit(f32[3], f32[3], s32[4], s32, f32, f32, s32, s32, s32);
 
 typedef struct struct_24_s{
     s32 unk0;

--- a/src/core2/fx/effect_sparkleemit.c
+++ b/src/core2/fx/effect_sparkleemit.c
@@ -2,7 +2,6 @@
 #include "functions.h"
 #include "variables.h"
 
-extern void dustEmitter_emit(f32[3], f32[3], s32[4], s32, f32, f32, s32, s32, s32);
 
 typedef struct{
     s32 unk0;

--- a/src/core2/model/render.c
+++ b/src/core2/model/render.c
@@ -26,7 +26,6 @@ typedef struct{
     Actor *unk4;
 } Struct_Core2_B1400_1;
 
-typedef void (*BKGeoCmdFunc)(Gfx **, Mtx **, void *);
 
 typedef struct {
     s32 cmd_0;
@@ -137,22 +136,22 @@ typedef struct {
 
 
 
-void modelRender_geoCmd_Unk0(Gfx **, Mtx **, void *);
-void modelRender_geoCmd_SORT(Gfx **, Mtx **, void *);
-void modelRender_geoCmd_BONE(Gfx **, Mtx **, void *);
-void modelRender_geoCmd_LOADDL(Gfx **, Mtx **, void *);
-void modelRender_geoCmd_NOP(Gfx **, Mtx **, void *);
-void modelRender_geoCmd_SKINNING(Gfx **, Mtx **, void *);
-void modelRender_geoCmd_CALL(Gfx **, Mtx **, void *);
-void modelRender_geoCmd_LOADDL2(Gfx **, Mtx **, void *);
-void modelRender_geoCmd_NOP(Gfx **, Mtx **, void *);
-void modelRender_geoCmd_TEXWRAP(Gfx **, Mtx **, void *);
-void modelRender_geoCmd_LOD(Gfx **, Mtx **, void *);
-void modelRender_geoCmd_REFPOINT(Gfx **, Mtx **, void *);
-void modelRender_geoCmd_SELECTOR(Gfx **, Mtx **, void *);
-void modelRender_geoCmd_DRAWDIST(Gfx **, Mtx **, void *);
-void modelRender_geoCmd_UnkE(Gfx **, Mtx **, void *);
-void modelRender_geoCmd_CAMERA(Gfx **, Mtx **, void *);
+void modelRender_geoCmd_Unk0(Gfx **, Mtx **, struct bk_geo_cmd_s *);
+void modelRender_geoCmd_SORT(Gfx **, Mtx **, struct bk_geo_cmd_s *);
+void modelRender_geoCmd_BONE(Gfx **, Mtx **, struct bk_geo_cmd_s *);
+void modelRender_geoCmd_LOADDL(Gfx **, Mtx **, struct bk_geo_cmd_s *);
+void modelRender_geoCmd_NOP(Gfx **, Mtx **, struct bk_geo_cmd_s *);
+void modelRender_geoCmd_SKINNING(Gfx **, Mtx **, struct bk_geo_cmd_s *);
+void modelRender_geoCmd_CALL(Gfx **, Mtx **, struct bk_geo_cmd_s *);
+void modelRender_geoCmd_LOADDL2(Gfx **, Mtx **, struct bk_geo_cmd_s *);
+void modelRender_geoCmd_NOP(Gfx **, Mtx **, struct bk_geo_cmd_s *);
+void modelRender_geoCmd_TEXWRAP(Gfx **, Mtx **, struct bk_geo_cmd_s *);
+void modelRender_geoCmd_LOD(Gfx **, Mtx **, struct bk_geo_cmd_s *);
+void modelRender_geoCmd_REFPOINT(Gfx **, Mtx **, struct bk_geo_cmd_s *);
+void modelRender_geoCmd_SELECTOR(Gfx **, Mtx **, struct bk_geo_cmd_s *);
+void modelRender_geoCmd_DRAWDIST(Gfx **, Mtx **, struct bk_geo_cmd_s *);
+void modelRender_geoCmd_UnkE(Gfx **, Mtx **, struct bk_geo_cmd_s *);
+void modelRender_geoCmd_CAMERA(Gfx **, Mtx **, struct bk_geo_cmd_s *);
 void modelRender_executeGeoCmds(Gfx **, Mtx **, BKGeoCmd *);
 void func_8033A45C(s32 arg0, s32 arg1);
 
@@ -700,12 +699,12 @@ void modelRender_reset(void){
 }
 
 //empty cmd, 
-void modelRender_geoCmd_NOP(Gfx **gfx, Mtx **mtx, void *arg2){
+void modelRender_geoCmd_NOP(Gfx **gfx, Mtx **mtx, struct bk_geo_cmd_s *arg2){
     return;
 }
 
 //cmd0_???
-void modelRender_geoCmd_Unk0(Gfx **gfx, Mtx **mtx, void *arg2){
+void modelRender_geoCmd_Unk0(Gfx **gfx, Mtx **mtx, struct bk_geo_cmd_s *arg2){
     GeoCmd0 *cmd = (GeoCmd0 *)arg2;
     f32 sp30[3];
 
@@ -727,7 +726,7 @@ void modelRender_geoCmd_Unk0(Gfx **gfx, Mtx **mtx, void *arg2){
 }
 
 //cmd1_SORT
-void modelRender_geoCmd_SORT(Gfx **gfx, Mtx **mtx, void *arg2){
+void modelRender_geoCmd_SORT(Gfx **gfx, Mtx **mtx, struct bk_geo_cmd_s *arg2){
     GeoCmd1 *cmd = (GeoCmd1 *)arg2;
     f32 f14;
     s32 tmp_v0;
@@ -774,7 +773,7 @@ void modelRender_geoCmd_SORT(Gfx **gfx, Mtx **mtx, void *arg2){
 }
 
 //cmd10_???
-void modelRender_geoCmd_TEXWRAP(Gfx **gfx, Mtx **mtx, void *arg2){
+void modelRender_geoCmd_TEXWRAP(Gfx **gfx, Mtx **mtx, struct bk_geo_cmd_s *arg2){
     GeoCmd10 *cmd = (GeoCmd10 *)arg2;
 
     switch(cmd->unk8){
@@ -788,7 +787,7 @@ void modelRender_geoCmd_TEXWRAP(Gfx **gfx, Mtx **mtx, void *arg2){
 }
 
 //cmd2_BONE
-void modelRender_geoCmd_BONE(Gfx **gfx, Mtx **mtx, void *arg2){
+void modelRender_geoCmd_BONE(Gfx **gfx, Mtx **mtx, struct bk_geo_cmd_s *arg2){
     GeoCmd2 *cmd = (GeoCmd2 *)arg2;
 
     // [port] Stable per-bone scope. Without it, any op-count shift in the
@@ -816,7 +815,7 @@ void modelRender_geoCmd_BONE(Gfx **gfx, Mtx **mtx, void *arg2){
 }
 
 //cmd3_LOAD_DL
-void modelRender_geoCmd_LOADDL(Gfx **gfx, Mtx **mtx, void *arg2){
+void modelRender_geoCmd_LOADDL(Gfx **gfx, Mtx **mtx, struct bk_geo_cmd_s *arg2){
     GeoCmd3 *cmd = (GeoCmd3 *)arg2;
     Gfx *vptr;
 
@@ -827,7 +826,7 @@ void modelRender_geoCmd_LOADDL(Gfx **gfx, Mtx **mtx, void *arg2){
 }
 
 //Cmd5_SKINNING
-void modelRender_geoCmd_SKINNING(Gfx **gfx, Mtx **mtx, void *arg2){
+void modelRender_geoCmd_SKINNING(Gfx **gfx, Mtx **mtx, struct bk_geo_cmd_s *arg2){
     GeoCmd5 *cmd = (GeoCmd5 *)arg2;
     int i;
 
@@ -849,20 +848,20 @@ void modelRender_geoCmd_SKINNING(Gfx **gfx, Mtx **mtx, void *arg2){
 }
 
 //Cmd6_???
-void modelRender_geoCmd_CALL(Gfx **gfx, Mtx **mtx, void *arg2){
+void modelRender_geoCmd_CALL(Gfx **gfx, Mtx **mtx, struct bk_geo_cmd_s *arg2){
     GeoCmd6 *cmd = (GeoCmd6 *)arg2;
     modelRender_executeGeoCmds(gfx, mtx, (BKGeoCmd*)((u8*)cmd + cmd->unk8));
 }
 
 //Cmd7_LOAD_DL???
-void modelRender_geoCmd_LOADDL2(Gfx **gfx, Mtx **mtx, void *arg2){
+void modelRender_geoCmd_LOADDL2(Gfx **gfx, Mtx **mtx, struct bk_geo_cmd_s *arg2){
     if(D_80370990){
         gSPDisplayList((*gfx)++, (Gfx *)osVirtualToPhysical(modelRenderDisplayList->list + ((GeoCmd7*)arg2)->unkA));
     }
 }
 
 //Cmd8_LOD
-void modelRender_geoCmd_LOD(Gfx **gfx, Mtx **mtx, void *arg2){
+void modelRender_geoCmd_LOD(Gfx **gfx, Mtx **mtx, struct bk_geo_cmd_s *arg2){
     GeoCmd8 *cmd = (GeoCmd8 *)arg2;
     f32 dist;
     
@@ -876,7 +875,7 @@ void modelRender_geoCmd_LOD(Gfx **gfx, Mtx **mtx, void *arg2){
 }
 
 //CmdA_REFERENCE_POINT
-void modelRender_geoCmd_REFPOINT(Gfx **gfx, Mtx **mtx, void *arg2){
+void modelRender_geoCmd_REFPOINT(Gfx **gfx, Mtx **mtx, struct bk_geo_cmd_s *arg2){
     GeoCmdA *cmd = (GeoCmdA *)arg2;
     f32 sp20[3];
 
@@ -897,7 +896,7 @@ void modelRender_geoCmd_REFPOINT(Gfx **gfx, Mtx **mtx, void *arg2){
 }
 
 //CmdC_SELECTOR
-void modelRender_geoCmd_SELECTOR(Gfx **gfx, Mtx **mtx, void *arg2){
+void modelRender_geoCmd_SELECTOR(Gfx **gfx, Mtx **mtx, struct bk_geo_cmd_s *arg2){
     GeoCmdC *cmd = (GeoCmdC *) arg2;
     uintptr_t sub_cmd;
     s32 indx;
@@ -938,7 +937,7 @@ void modelRender_geoCmd_SELECTOR(Gfx **gfx, Mtx **mtx, void *arg2){
 
 //CmdD_DRAW_DISTANCE
 extern f32 GameEngine_GetAspectRatio(void);
-void modelRender_geoCmd_DRAWDIST(Gfx ** gfx, Mtx ** mtx, void *arg2){
+void modelRender_geoCmd_DRAWDIST(Gfx ** gfx, Mtx ** mtx, struct bk_geo_cmd_s *arg2){
     f32 sp2C[3];
     f32 sp20[3];
     GeoCmdD * cmd = (GeoCmdD *)arg2;
@@ -957,7 +956,7 @@ void modelRender_geoCmd_DRAWDIST(Gfx ** gfx, Mtx ** mtx, void *arg2){
 }
 
 //cmdE_???
-void modelRender_geoCmd_UnkE(Gfx ** gfx, Mtx ** mtx, void *arg2){
+void modelRender_geoCmd_UnkE(Gfx ** gfx, Mtx ** mtx, struct bk_geo_cmd_s *arg2){
     f32 sp34[3];
     f32 sp30;
     GeoCmdE * cmd = (GeoCmdE *)arg2;
@@ -998,7 +997,7 @@ void modelRender_geoCmd_UnkE(Gfx ** gfx, Mtx ** mtx, void *arg2){
 }
 
 //cmdF_??? (processes model_setup offset_0x20)
-void modelRender_geoCmd_CAMERA(Gfx ** gfx, Mtx ** mtx, void *arg2){
+void modelRender_geoCmd_CAMERA(Gfx ** gfx, Mtx ** mtx, struct bk_geo_cmd_s *arg2){
     GeoCmdF *cmd = (GeoCmdF *)arg2;
     int tmp_v0 = cameraAreaList_searchForEntryInBounds(modelRenderCameraAreaList, cmd->unkC, cmd->unkA);
     if( (!tmp_v0 && (cmd->unkB & 1))
@@ -1342,7 +1341,7 @@ BoneTransformList *modelRender_getBoneTransformList(void){
     return modelRenderBoneTransformList;
 }
 
-s32 modelbin_getGeoType(BKModelBin *arg0){
+BkGeoType modelbin_getGeoType(BKModelBin *arg0){
     return arg0->geo_type;
 }
 
@@ -1367,7 +1366,7 @@ BKMeshList *modelbin_getMeshList(BKModelBin *arg0){
     return (BKMeshList *)((u8*)arg0 + arg0->mesh_list_offset);
 }
 
-f32 modelbin_getUnk34(UNK_TYPE(void *) arg0){
+f32 modelbin_getUnk34(BKModelBin *arg0){
     return *(f32 *)((u8*)arg0 + 0x34);
 }
 

--- a/src/core2/mumbo_transforms.c
+++ b/src/core2/mumbo_transforms.c
@@ -2,7 +2,6 @@
 #include "functions.h"
 #include "variables.h"
 
-extern void dustEmitter_emit(f32[3], f32[3], s32[4], s32, f32, f32, s32, s32, s32);
 extern void func_803255FC(Actor *);
 extern void func_80325760(Actor *);
 

--- a/src/core2/particle/colordefault.c
+++ b/src/core2/particle/colordefault.c
@@ -19,7 +19,7 @@ s32 dustEmitter_returnGiven(s32 arg0){
     return arg0;
 }
 
-void dustEmitter_empty(void *this){
+void dustEmitter_empty(ParticleEmitter *this){
     return;
 }
 
@@ -43,7 +43,7 @@ void dustEmitter_free(void) {
     }
 }
 
-void dustEmitter_emit(f32 position[3], f32 velocity[3], s32 color[4], s32 arg3, f32 arg4, f32 arg5, s32 arg6, s32 arg7, s32 arg8) {
+void dustEmitter_emit(f32 position[3], f32 velocity[3], s32 color[4], bool arg3, f32 arg4, f32 arg5, s32 arg6, s32 arg7, enum dust_emitter_type_e arg8) {
     s32 pad54;
     s32 pad50;
     s32 pad4C;

--- a/src/core2/quiz/game.c
+++ b/src/core2/quiz/game.c
@@ -9,7 +9,6 @@ extern void func_8025A788(enum comusic_e, f32, f32);
 extern void func_8031CC40(enum map_e, s32);
 extern void fxRipple_802F363C(f32);
 extern void func_802F9D38(s32);
-extern void dustEmitter_emit(f32[3], f32[3], s32[4], s32, f32, f32, s32, s32, s32);
 extern void func_802EE2E8(Actor *arg0, s32 arg1, s32 cnt, s32 arg3, f32 arg4, f32 arg5, f32 arg6);
 extern void gcquiz_func_80319EA4(void);
 

--- a/src/core2/spline_pathfollow.c
+++ b/src/core2/spline_pathfollow.c
@@ -1496,6 +1496,6 @@ void glspline_defrag(void) {
     }
 }
 
-bool func_80344040(Actor *this){
-    return func_80323240(D_80371E70[this->unk44_14], this->unk48, this->position);
+void func_80344040(Actor *this){
+    func_80323240(D_80371E70[this->unk44_14], this->unk48, this->position);
 }

--- a/src/port/ResourceHelpers.cpp
+++ b/src/port/ResourceHelpers.cpp
@@ -14,7 +14,7 @@
 #include <string>
 #include <unordered_map>
 
-#ifdef _DEBUG
+#if defined(_DEBUG) && defined(_MSC_VER)
 #include <crtdbg.h>
 #endif
 

--- a/src/port/ShipUtils.cpp
+++ b/src/port/ShipUtils.cpp
@@ -14,7 +14,7 @@
 #include <windows.h>
 #endif
 
-#ifdef _DEBUG
+#if defined(_DEBUG) && defined(_MSC_VER)
 #include <crtdbg.h>
 #endif
 
@@ -55,7 +55,7 @@ void port_audioStartThread(void) {
 }
 
 int port_checkHeap(const char* label) {
-#ifdef _DEBUG
+#if defined(_DEBUG) && defined(_MSC_VER)
     if (!_CrtCheckMemory()) {
         SPDLOG_ERROR("[port] HEAP CORRUPT at: {}", label);
         return 0;

--- a/src/port/save/SaveManager.cpp
+++ b/src/port/save/SaveManager.cpp
@@ -18,7 +18,7 @@ extern "C" {
 extern SaveData gameFile_saveData[4];
 void savedata_update_crc(void* buffer, s32 size);
 s32 item_getCount(enum item_e item);
-u8 gCompletedBottlesBonusGames[7];
+extern u8 gCompletedBottlesBonusGames[7];
 }
 
 using nlohmann::json;


### PR DESCRIPTION
| Count | Error | Files | Change |
|-------|-------|-------|-----|
| 32 | `sfxSource_triggerCallbackByIndex` undeclared (`-Werror=implicit-function-declaration`) | 20+ core/level `.c` | Added declaration to `functions.h` |
| 12 | `dustEmitter_emit`/`_empty` conflicting types | game.c, effect_debris.c, effect_sparkleemit.c, colordefault.c, mumbo_transforms.c, actor_array.c, ba_marker.c, sarcophagus.c, lockup.c, LAIR/MMM actor_spawninit.c | Removed 10 divergent per-file `extern`s; fixed `colordefault.c` def to `bool`/`enum` (matches upstream) |
| 6 | Marker hit/die callbacks `(ActorMarker*, s32)` → field `(ActorMarker*, ActorMarker*)` | mummum.c, limbo.c, seaman_grublin.c, grublinhood.c | Cast at the 6 assignment sites (upstream keeps signatures; GCC-tolerated) |
| 2 | `crtdbg.h` file not found | ResourceHelpers.cpp, ShipUtils.cpp | Guarded `crtdbg.h`/`_CrtCheckMemory` with `_DEBUG && _MSC_VER` |
| 2 | `s32[]` → `f32*` velocity arg (`-Werror=incompatible-pointer-types`) | sarcophagus.c, lockup.c | Cast the two s32 velocity globals at call sites |
| 1 | `func_80344040` returns `void` from `bool` result type | spline_pathfollow.c, functions.h | Return type `bool`->`void` (return was unused) |
| 1 | `struct ALHeap` referenced with typedef specifier | structs.h / libaudio.h | Gave `ALHeap` a struct tag in `libaudio.h` |
| 2 | `textureList_getDataPtr` decl `void*` vs def `u8*` | model.h, texture_dataaccess.c, texture_capture.c | model.h decl -> `u8 *` (upstream `func_802EA620`) |
| 2 | `actors_appendToSavestate` decl `uintptr_t` vs def/caller `void*` | functions.h, actor_array.c, savestate.c | functions.h decl -> `void *` |
| ~18 | `BKGeoCmdFunc` local `void*` typedef + 31 geo-cmd handlers vs canonical `struct bk_geo_cmd_s*` | model/render.c | Retyped all handlers + dropped local typedef (upstream `modelRender.c`) |
| 2 | `modelbin_getGeoType` (`s32`) / `modelbin_getUnk34` (`void*` param) vs header | model/render.c | Fixed defs to `BkGeoType` / `BKModelBin*` (upstream) |
| 1 | `osPiReadIo` undeclared (N64 PI/boot hardware) | core1/ucode.c | `#if 0`'d the two hardware fns; live stubs `ucode_stub1`/`ucode_stub3` kept |
| 1 (link) | `gCompletedBottlesBonusGames` duplicate symbol (`-fno-common`) | SaveManager.cpp | Port file -> `extern` (decomp `gameSelect.c` owns the def) |
