### PR TITLE
Occlusion Debugger, Show Stonehenge

### DIFF
--- a/include/functions.h
+++ b/include/functions.h
@@ -99,15 +99,6 @@ void nodeprop_getPosition(NodeProp *, f32[3]);
 void spawnableActorList_add(ActorInfo *arg0, Actor *(*arg1)(s32[3], s32, ActorInfo *, u32), u32 arg2);
 void spawnableActorList_addIfMapVisited(ActorInfo *arg0, Actor *(*arg1)(s32[3], s32, ActorInfo *, u32), u32 arg2, enum map_e arg3);
 
-// --- core2/map/model.c ---
-BKCollisionTriangle *func_80309B48(f32 startPoint[3], f32 endPoint[3], f32 arg2[3], u32 flagFilter);
-// NOTE: func_802E76B0, collisionList_func_802E805C, func_802E8E88, func_802E9118,
-// func_802E92AC, func_802E9DD8 return BKCollisionTriangle* but have conflicting
-// local externs (bool/s32/void) in decomp source files. Files that need
-// the pointer type already have correct local externs.
-BKCollisionTriangle *func_802E76B0(BKCollisionList *collisionList, BKVertexList *vertexList, f32 startPoint[3], f32 endPoint[3], f32 arg4[3], u32 flagFilter);
-f32  mapModel_getFloorY(f32[3]);
-
 // --- core2/actor_cubepropsystem.c ---
 BKCollisionTriangle *func_803311D4(Cube *cube, f32 arg1[3], f32 arg2[3], f32 arg3[3], u32 arg4);
 
@@ -204,9 +195,6 @@ Struct83s *func_803406D4(Struct83s *self);
 // --- core2/vtx/list.c ---
 
 // --- core2/spline_bezier.c ---
-
-// --- core2/map/model.c ---
-Vec3fArray *func_803097A0(void);
 
 // --- core2/model/render.c ---
 
@@ -2520,11 +2508,22 @@ void func_8034B9E4(void);
 void func_8034BA7C(enum map_e map_id, s32 exit_id);
 
 // --- core2/map/model.c ---
+// NOTE: func_802E76B0, collisionList_func_802E805C, func_802E8E88, func_802E9118,
+// func_802E92AC, func_802E9DD8 return BKCollisionTriangle* but have conflicting
+// local externs (bool/s32/void) in decomp source files. Files that need
+// the pointer type already have correct local externs.
+BKCollisionTriangle *func_802E76B0(BKCollisionList *collisionList, BKVertexList *vertexList, f32 startPoint[3], f32 endPoint[3], f32 arg4[3], u32 flagFilter);
+Vec3fArray *func_803097A0(void);
+BKCollisionTriangle *func_80309B48(f32 startPoint[3], f32 endPoint[3], f32 arg2[3], u32 flagFilter);
 bool func_80309D58(f32 arg0[3], s32 arg1);
 bool mapModel_has_xlu_bin(void);
 void func_8030A078(void);
 void mapModel_defrag(void);
 void mapModel_free(void);
+void mapModel_getBounds(s32 min[3], s32 max[3]);
+f32  mapModel_getFloorY(f32[3]);
+BKModel *mapModel_getModel(s32 arg0);
+BKModelBin *mapModel_getModelBin(s32 arg0);
 void mapModel_opa_draw(Gfx **gfx, Mtx **mtx, Vtx **vtx);
 void mapModel_setEnvColor(s32 r, s32 g, s32 b);
 void mapModel_xlu_draw(Gfx **gfx, Mtx **mtx, Vtx **vtx);
@@ -3130,10 +3129,6 @@ void func_8034CF90(void *arg0, BKModel *arg1, s32 arg2);
 
 // --- core2/vtx/renderstart.c ---
 void setStruct6DsOpacity(Struct6Ds *arg0, s32 arg1);
-
-// --- core2/map/model.c ---
-BKModel *mapModel_getModel(s32 arg0);
-void mapModel_getBounds(s32 min[3], s32 max[3]);
 
 // --- core2/anim/anim_cache.c ---
 int animCache_getBoneTransformList(s16 index, BoneTransformList **arg1);

--- a/src/core2/map/model.c
+++ b/src/core2/map/model.c
@@ -2,7 +2,6 @@
 #include "functions.h"
 #include "variables.h"
 #include "port/Romhack/RomhackConfig.h"
-#include "port/DevTools/OcclusionDebug.h"
 
 #include "core2/modelRender.h"
 #include "core2/coords.h"
@@ -365,7 +364,6 @@ void mapModel_opa_draw(Gfx **gfx, Mtx **mtx, Vtx **vtx) {
             modelRender_setAnimatedTexturesCacheId(temp_a0);
         }
         modelRender_setEnvColor(mapModel.env_red, mapModel.env_green, mapModel.env_blue, 0xFF);
-        OcclusionDebug_BeginPart(0);
         modelRender_draw(gfx, mtx, NULL, NULL, mapModel.description->scale, NULL, mapModel.model_bin_opa);
         if (!mapModel_has_xlu_bin()) {
             func_802F7BC0(gfx, mtx, vtx);
@@ -386,7 +384,6 @@ void mapModel_xlu_draw(Gfx **gfx, Mtx **mtx, Vtx **vtx) {
             modelRender_setAnimatedTexturesCacheId(temp_a0);
         }
         modelRender_setEnvColor(mapModel.env_red, mapModel.env_green, mapModel.env_blue, 0xFF);
-        OcclusionDebug_BeginPart(1);
         modelRender_draw(gfx, mtx, NULL, NULL, mapModel.description->scale, NULL, mapModel.model_bin_xlu);
         func_802F7BC0(gfx, mtx, vtx);
     }

--- a/src/core2/map/model.c
+++ b/src/core2/map/model.c
@@ -2,6 +2,7 @@
 #include "functions.h"
 #include "variables.h"
 #include "port/Romhack/RomhackConfig.h"
+#include "port/DevTools/OcclusionDebug.h"
 
 #include "core2/modelRender.h"
 #include "core2/coords.h"
@@ -364,6 +365,7 @@ void mapModel_opa_draw(Gfx **gfx, Mtx **mtx, Vtx **vtx) {
             modelRender_setAnimatedTexturesCacheId(temp_a0);
         }
         modelRender_setEnvColor(mapModel.env_red, mapModel.env_green, mapModel.env_blue, 0xFF);
+        OcclusionDebug_BeginPart(0);
         modelRender_draw(gfx, mtx, NULL, NULL, mapModel.description->scale, NULL, mapModel.model_bin_opa);
         if (!mapModel_has_xlu_bin()) {
             func_802F7BC0(gfx, mtx, vtx);
@@ -384,6 +386,7 @@ void mapModel_xlu_draw(Gfx **gfx, Mtx **mtx, Vtx **vtx) {
             modelRender_setAnimatedTexturesCacheId(temp_a0);
         }
         modelRender_setEnvColor(mapModel.env_red, mapModel.env_green, mapModel.env_blue, 0xFF);
+        OcclusionDebug_BeginPart(1);
         modelRender_draw(gfx, mtx, NULL, NULL, mapModel.description->scale, NULL, mapModel.model_bin_xlu);
         func_802F7BC0(gfx, mtx, vtx);
     }

--- a/src/core2/model/render.c
+++ b/src/core2/model/render.c
@@ -9,6 +9,7 @@
 
 #include "port/Patches/Patches.h"
 #include "port/Interpolation/FrameInterpolation.h"
+#include "port/DevTools/OcclusionDebug.h"
 
 #define ARRAYLEN(x) (sizeof(x) / sizeof((x)[0]))
 
@@ -866,13 +867,22 @@ void modelRender_geoCmd_LOD(Gfx **gfx, Mtx **mtx, struct bk_geo_cmd_s *arg2){
     f32 dist;
 
     if(cmd->subgeo_offset_1C){
+        s32 draw;
         if(port_shouldDisableLOD()){
             dist = 1.0f;
         } else {
             mlMtx_apply_vec3f(transformed_pos, cmd->unk10);
             dist = gu_sqrtf(transformed_pos[0]*transformed_pos[0] + transformed_pos[1]*transformed_pos[1] + transformed_pos[2]*transformed_pos[2]);
         }
-        if(cmd->min_C < dist && dist <= cmd->max_8){
+        draw = (cmd->min_C < dist && dist <= cmd->max_8);
+        // [port] Occlusion debugger: record + allow force-draw of this LOD band.
+        if (OcclusionDebug_IsActive()) {
+            s32 offset = (s32)((u8*)cmd - (u8*)modelRenderModelBin);
+            if (OcclusionDebug_OnCullCmd(OCCLUSION_CMD_LOD, offset, draw, NULL, 0, (s32)cmd->min_C, (s32)cmd->max_8)) {
+                draw = 1;
+            }
+        }
+        if(draw){
             modelRender_executeGeoCmds(gfx, mtx, (BKGeoCmd*)((u8*)cmd + cmd->subgeo_offset_1C));
         }
     }
@@ -966,15 +976,24 @@ void modelRender_geoCmd_UnkE(Gfx ** gfx, Mtx ** mtx, struct bk_geo_cmd_s *arg2){
     GeoCmdE * cmd = (GeoCmdE *)arg2;
 
     if(cmd->unk12 == -1){
+        s32 draw;
         sp34[0] = (f32)cmd->unk8[0] * modelRenderScale;
         sp34[1] = (f32)cmd->unk8[1] * modelRenderScale;
         sp34[2] = (f32)cmd->unk8[2] * modelRenderScale;
         sp30 = (f32)cmd->unkE*modelRenderScale;
-        if(viewport_func_8024DB50(sp34, sp30) && cmd->unk10){
+        draw = viewport_func_8024DB50(sp34, sp30) && cmd->unk10;
+        if (OcclusionDebug_IsActive()) {
+            s32 offset = (s32)((u8*)cmd - (u8*)modelRenderModelBin);
+            if (OcclusionDebug_OnCullCmd(OCCLUSION_CMD_UNKE, offset, draw, NULL, 0, 0, 0) && cmd->unk10) {
+                draw = 1;
+            }
+        }
+        if(draw){
             modelRender_executeGeoCmds(gfx, mtx, (BKGeoCmd*)((u8*)cmd + cmd->unk10));
         }
     }
     else{
+        s32 draw;
         sp34[0] = (f32)cmd->unk8[0];
         sp34[1] = (f32)cmd->unk8[1];
         sp34[2] = (f32)cmd->unk8[2];
@@ -992,7 +1011,14 @@ void modelRender_geoCmd_UnkE(Gfx ** gfx, Mtx ** mtx, struct bk_geo_cmd_s *arg2){
         sp34[0] += modelRenderCameraPosition[0];
         sp34[1] += modelRenderCameraPosition[1];
         sp34[2] += modelRenderCameraPosition[2];
-        if(viewport_func_8024DB50(sp34, sp30) && cmd->unk10){
+        draw = viewport_func_8024DB50(sp34, sp30) && cmd->unk10;
+        if (OcclusionDebug_IsActive()) {
+            s32 offset = (s32)((u8*)cmd - (u8*)modelRenderModelBin);
+            if (OcclusionDebug_OnCullCmd(OCCLUSION_CMD_UNKE, offset, draw, NULL, 0, 0, 0) && cmd->unk10) {
+                draw = 1;
+            }
+        }
+        if(draw){
             modelRender_executeGeoCmds(gfx, mtx, (BKGeoCmd*)((u8*)cmd + cmd->unk10));
         }
 
@@ -1004,9 +1030,16 @@ void modelRender_geoCmd_UnkE(Gfx ** gfx, Mtx ** mtx, struct bk_geo_cmd_s *arg2){
 void modelRender_geoCmd_CAMERA(Gfx ** gfx, Mtx ** mtx, struct bk_geo_cmd_s *arg2){
     GeoCmdF *cmd = (GeoCmdF *)arg2;
     int tmp_v0 = cameraAreaList_searchForEntryInBounds(modelRenderCameraAreaList, cmd->unkC, cmd->unkA);
-    if( (!tmp_v0 && (cmd->unkB & 1))
-        || (tmp_v0 && (cmd->unkB & 2))
-    ){
+    int draw = (!tmp_v0 && (cmd->unkB & 1)) || (tmp_v0 && (cmd->unkB & 2));
+    // [port] Occlusion debugger: record this command (keyed by its byte offset within the
+    // model bin, which is stable per asset) and allow it to be force-drawn.
+    if (OcclusionDebug_IsActive()) {
+        s32 offset = (s32)((u8*)cmd - (u8*)modelRenderModelBin);
+        if (OcclusionDebug_OnCullCmd(OCCLUSION_CMD_CAMERA, offset, draw, cmd->unkC, cmd->unkA, cmd->unkB, 0)) {
+            draw = 1;
+        }
+    }
+    if (draw) {
         if(cmd->unk8 != 0)
             modelRender_executeGeoCmds(gfx, mtx, (BKGeoCmd*)((u8*)cmd + cmd->unk8));
     }

--- a/src/core2/model/render.c
+++ b/src/core2/model/render.c
@@ -9,7 +9,7 @@
 
 #include "port/Patches/Patches.h"
 #include "port/Interpolation/FrameInterpolation.h"
-#include "port/DevTools/OcclusionDebug.h"
+#include "port/Patches/GeoCull.h"
 
 #define ARRAYLEN(x) (sizeof(x) / sizeof((x)[0]))
 
@@ -875,13 +875,7 @@ void modelRender_geoCmd_LOD(Gfx **gfx, Mtx **mtx, struct bk_geo_cmd_s *arg2){
             dist = gu_sqrtf(transformed_pos[0]*transformed_pos[0] + transformed_pos[1]*transformed_pos[1] + transformed_pos[2]*transformed_pos[2]);
         }
         draw = (cmd->min_C < dist && dist <= cmd->max_8);
-        // [port] Occlusion debugger: record + allow force-draw of this LOD band.
-        if (OcclusionDebug_IsActive()) {
-            s32 offset = (s32)((u8*)cmd - (u8*)modelRenderModelBin);
-            if (OcclusionDebug_OnCullCmd(OCCLUSION_CMD_LOD, offset, draw, NULL, 0, (s32)cmd->min_C, (s32)cmd->max_8)) {
-                draw = 1;
-            }
-        }
+        draw = port_geoCullDraw(OCCLUSION_CMD_LOD, cmd, modelRenderModelBin, draw, NULL, 0, (s32)cmd->min_C, (s32)cmd->max_8);
         if(draw){
             modelRender_executeGeoCmds(gfx, mtx, (BKGeoCmd*)((u8*)cmd + cmd->subgeo_offset_1C));
         }
@@ -981,13 +975,8 @@ void modelRender_geoCmd_UnkE(Gfx ** gfx, Mtx ** mtx, struct bk_geo_cmd_s *arg2){
         sp34[1] = (f32)cmd->unk8[1] * modelRenderScale;
         sp34[2] = (f32)cmd->unk8[2] * modelRenderScale;
         sp30 = (f32)cmd->unkE*modelRenderScale;
-        draw = viewport_func_8024DB50(sp34, sp30) && cmd->unk10;
-        if (OcclusionDebug_IsActive()) {
-            s32 offset = (s32)((u8*)cmd - (u8*)modelRenderModelBin);
-            if (OcclusionDebug_OnCullCmd(OCCLUSION_CMD_UNKE, offset, draw, NULL, 0, 0, 0) && cmd->unk10) {
-                draw = 1;
-            }
-        }
+        draw = (viewport_func_8024DB50(sp34, sp30) && cmd->unk10) ? 1 : 0;
+        draw = port_geoCullDraw(OCCLUSION_CMD_UNKE, cmd, modelRenderModelBin, draw, NULL, 0, 0, 0) && cmd->unk10;
         if(draw){
             modelRender_executeGeoCmds(gfx, mtx, (BKGeoCmd*)((u8*)cmd + cmd->unk10));
         }
@@ -1011,13 +1000,8 @@ void modelRender_geoCmd_UnkE(Gfx ** gfx, Mtx ** mtx, struct bk_geo_cmd_s *arg2){
         sp34[0] += modelRenderCameraPosition[0];
         sp34[1] += modelRenderCameraPosition[1];
         sp34[2] += modelRenderCameraPosition[2];
-        draw = viewport_func_8024DB50(sp34, sp30) && cmd->unk10;
-        if (OcclusionDebug_IsActive()) {
-            s32 offset = (s32)((u8*)cmd - (u8*)modelRenderModelBin);
-            if (OcclusionDebug_OnCullCmd(OCCLUSION_CMD_UNKE, offset, draw, NULL, 0, 0, 0) && cmd->unk10) {
-                draw = 1;
-            }
-        }
+        draw = (viewport_func_8024DB50(sp34, sp30) && cmd->unk10) ? 1 : 0;
+        draw = port_geoCullDraw(OCCLUSION_CMD_UNKE, cmd, modelRenderModelBin, draw, NULL, 0, 0, 0) && cmd->unk10;
         if(draw){
             modelRender_executeGeoCmds(gfx, mtx, (BKGeoCmd*)((u8*)cmd + cmd->unk10));
         }
@@ -1031,14 +1015,7 @@ void modelRender_geoCmd_CAMERA(Gfx ** gfx, Mtx ** mtx, struct bk_geo_cmd_s *arg2
     GeoCmdF *cmd = (GeoCmdF *)arg2;
     int tmp_v0 = cameraAreaList_searchForEntryInBounds(modelRenderCameraAreaList, cmd->unkC, cmd->unkA);
     int draw = (!tmp_v0 && (cmd->unkB & 1)) || (tmp_v0 && (cmd->unkB & 2));
-    // [port] Occlusion debugger: record this command (keyed by its byte offset within the
-    // model bin, which is stable per asset) and allow it to be force-drawn.
-    if (OcclusionDebug_IsActive()) {
-        s32 offset = (s32)((u8*)cmd - (u8*)modelRenderModelBin);
-        if (OcclusionDebug_OnCullCmd(OCCLUSION_CMD_CAMERA, offset, draw, cmd->unkC, cmd->unkA, cmd->unkB, 0)) {
-            draw = 1;
-        }
-    }
+    draw = port_geoCullDraw(OCCLUSION_CMD_CAMERA, cmd, modelRenderModelBin, draw, cmd->unkC, cmd->unkA, cmd->unkB, 0);
     if (draw) {
         if(cmd->unk8 != 0)
             modelRender_executeGeoCmds(gfx, mtx, (BKGeoCmd*)((u8*)cmd + cmd->unk8));

--- a/src/port/DevTools/OcclusionDebug.cpp
+++ b/src/port/DevTools/OcclusionDebug.cpp
@@ -12,17 +12,23 @@
 #include <spdlog/spdlog.h>
 
 #include "port/UI/cvar_prefixes.h"
+#include "port/Patches/GeoCull.h"
+#include "port/ShipInit.hpp"
+#include "port/Enhancements/Events/Hooks/Events.h"
 
 extern "C" {
-#include "functions.h" // gsworld_getMap
+#include "functions.h" // gsworld_getMap, mapModel_getModelBin
 }
+
+// mapModel_getModelBin returns BKModelBin*; the debugger only compares it as an opaque
+// pointer, so reinterpret to const void* at the call sites.
 
 #define CVAR_OCCLUSION_ACTIVE CVAR_DEVELOPER_TOOLS("OcclusionDebug.Active")
 
 namespace {
 
-constexpr int kParts = 2; // 0 = opaque, 1 = translucent
-const char* kPartNames[kParts] = { "OPA", "XLU" };
+constexpr int kParts = 3; // 0 = opaque map model, 1 = translucent map model, 2 = other
+const char* kPartNames[kParts] = { "OPA", "XLU", "?" };
 
 const char* CmdTypeName(int type) {
     switch (type) {
@@ -34,8 +40,7 @@ const char* CmdTypeName(int type) {
 }
 
 // Each command is keyed by (model part, byte offset within the model bin). The offset is
-// fixed per asset, so it never shifts when force-drawing reveals more geometry — unlike a
-// traversal-order index.
+// fixed per asset, so it never shifts when force-drawing reveals more geometry.
 struct Key {
     int part;
     int offset;
@@ -50,18 +55,26 @@ struct CullCmdRecord {
     unsigned char areaIds[12]; // CAMERA only
     int detail0;               // CAMERA: flags (unkB); LOD: min distance
     int detail1;               // LOD: max distance
-    int drawnVanilla;          // would the unmodified gate draw this command on its last visit?
+    int drawnVanilla;
     bool seenThisFrame;
 };
 
 std::mutex sMutex;
 std::map<Key, CullCmdRecord> sRecorded; // accumulated across frames, cleared on map change
-std::set<Key> sForceDraw;                 // commands the dev pinned to always draw
-bool sForceAll = false;                   // momentary: draw every command (enumerate the whole tree)
-int sCurrentPart = 0;
+std::set<Key> sForceDraw;
+bool sForceAll = false;
 int sRecordedMap = -1;
 
-// Kind-specific one-line description for the Detail column.
+int PartForBin(const void* bin) {
+    if (bin == (const void*)mapModel_getModelBin(0)) {
+        return 0;
+    }
+    if (bin == (const void*)mapModel_getModelBin(1)) {
+        return 1;
+    }
+    return 2;
+}
+
 std::string DetailString(const CullCmdRecord& rec) {
     if (rec.type == OCCLUSION_CMD_CAMERA) {
         std::string ids;
@@ -84,51 +97,53 @@ std::string DetailString(const CullCmdRecord& rec) {
     return "";
 }
 
-} // namespace
+// OnGeoCull listener: record the command and apply the developer's force-draw choices.
+void OnGeoCull_Record(IEvent* event) {
+    auto* ev = reinterpret_cast<OnGeoCull*>(event);
 
-extern "C" int OcclusionDebug_IsActive(void) {
-    return CVarGetInteger(CVAR_OCCLUSION_ACTIVE, 0);
-}
-
-extern "C" void OcclusionDebug_BeginPart(int part) {
-    if (!OcclusionDebug_IsActive() || part < 0 || part >= kParts) {
-        return;
-    }
-    if (part == 0) {
-        // Opaque is drawn first each frame.
-        std::lock_guard<std::mutex> lock(sMutex);
-        int map = (int)gsworld_getMap();
-        if (map != sRecordedMap) {
-            // New map: the offsets belong to a different model, so start over.
-            sRecorded.clear();
-            sForceDraw.clear();
-            sRecordedMap = map;
-        }
-        for (auto& [key, rec] : sRecorded) {
-            rec.seenThisFrame = false;
-        }
-    }
-    sCurrentPart = part;
-}
-
-extern "C" int OcclusionDebug_OnCullCmd(int type, int offset, int drawnVanilla, const unsigned char* areaIds,
-                                        int areaCount, int detail0, int detail1) {
-    Key key{ sCurrentPart, offset };
+    Key key{ PartForBin(ev->modelBin), ev->offset };
 
     std::lock_guard<std::mutex> lock(sMutex);
     CullCmdRecord& rec = sRecorded[key];
-    rec.type = type;
-    rec.areaCount = (areaCount > 12) ? 12 : (areaCount < 0 ? 0 : areaCount);
+    rec.type = ev->type;
+    rec.areaCount = (ev->areaCount > 12) ? 12 : (ev->areaCount < 0 ? 0 : ev->areaCount);
     for (int i = 0; i < 12; i++) {
-        rec.areaIds[i] = (i < rec.areaCount && areaIds != nullptr) ? areaIds[i] : 0;
+        rec.areaIds[i] = (i < rec.areaCount && ev->areaIds != nullptr) ? ev->areaIds[i] : 0;
     }
-    rec.detail0 = detail0;
-    rec.detail1 = detail1;
-    rec.drawnVanilla = drawnVanilla;
+    rec.detail0 = ev->detail0;
+    rec.detail1 = ev->detail1;
+    rec.drawnVanilla = ev->drawnVanilla;
     rec.seenThisFrame = true;
 
-    return (sForceAll || sForceDraw.count(key)) ? 1 : 0;
+    if (sForceAll || sForceDraw.count(key)) {
+        *ev->forceDraw = true;
+    }
 }
+
+// Per game tick: clear "seen this frame" flags and reset on map change.
+void OnFrame_Reset(IEvent*) {
+    std::lock_guard<std::mutex> lock(sMutex);
+    int map = (int)gsworld_getMap();
+    if (map != sRecordedMap) {
+        sRecorded.clear();
+        sForceDraw.clear();
+        sRecordedMap = map;
+    }
+    for (auto& [key, rec] : sRecorded) {
+        rec.seenThisFrame = false;
+    }
+}
+
+} // namespace
+
+void RegisterOcclusionDebug_Init() {
+    bool active = CVarGetInteger(CVAR_OCCLUSION_ACTIVE, 0);
+    GeoCull_SetConsumer(GEOCULL_CONSUMER_DEBUG, active);
+    COND_HOOK(OnGeoCull, EVENT_PRIORITY_NORMAL, active, OnGeoCull_Record);
+    COND_HOOK(GameFrameUpdate, EVENT_PRIORITY_NORMAL, active, OnFrame_Reset);
+}
+
+static RegisterShipInitFunc sInitOcclusionDebug(RegisterOcclusionDebug_Init, { CVAR_OCCLUSION_ACTIVE });
 
 void OcclusionDebugWindow::DrawElement() {
     bool active = CVarGetInteger(CVAR_OCCLUSION_ACTIVE, 0);
@@ -136,12 +151,11 @@ void OcclusionDebugWindow::DrawElement() {
         CVarSetInteger(CVAR_OCCLUSION_ACTIVE, active);
         Ship::Context::GetRawInstance()->GetWindow()->GetGui()->SaveConsoleVariablesNextFrame();
     }
-    ImGui::TextWrapped("Flip 'Force draw all' on for a moment to walk the whole camera-area tree and populate the list "
-                       "(the screen will look broken — that is expected), then turn it off and tick 'Force Draw' on "
+    ImGui::TextWrapped("Flip 'Force draw all' on for a moment to walk every cull command and populate the list (the "
+                       "screen will look broken — that is expected), then turn it off and tick 'Force Draw' on "
                        "individual rows to find the chunk(s) that reveal the target scenery. Offsets are stable, so the "
                        "list never shifts. Dump the chosen set to the log when done.");
 
-    // Snapshot under the lock; render outside it.
     struct Row {
         Key key;
         CullCmdRecord rec;
@@ -187,14 +201,12 @@ void OcclusionDebugWindow::DrawElement() {
                 if (k.part < 0 || k.part >= kParts) {
                     continue;
                 }
+                char buf[16];
+                snprintf(buf, sizeof(buf), "0x%X", k.offset);
                 if (!parts[k.part].empty()) {
                     parts[k.part] += ", ";
                 }
-                parts[k.part] += "0x" + [](int v) {
-                    char buf[16];
-                    snprintf(buf, sizeof(buf), "%X", v);
-                    return std::string(buf);
-                }(k.offset);
+                parts[k.part] += buf;
             }
         }
         SPDLOG_INFO("[OcclusionDebug] map 0x{:X}: OPA {{{}}} XLU {{{}}}", mapId, parts[0], parts[1]);
@@ -227,7 +239,6 @@ void OcclusionDebugWindow::DrawElement() {
             ImGui::TextWrapped("%s", DetailString(row.rec).c_str());
 
             ImGui::TableNextColumn();
-            // Grey out commands not visited this frame (their parent branch wasn't walked).
             if (!row.rec.seenThisFrame) {
                 ImGui::TextDisabled("--");
             } else {

--- a/src/port/DevTools/OcclusionDebug.cpp
+++ b/src/port/DevTools/OcclusionDebug.cpp
@@ -1,0 +1,251 @@
+#include "OcclusionDebug.h"
+
+#include <map>
+#include <set>
+#include <mutex>
+#include <vector>
+#include <string>
+
+#include <imgui.h>
+#include <libultraship/bridge.h>
+#include <ship/Context.h>
+#include <spdlog/spdlog.h>
+
+#include "port/UI/cvar_prefixes.h"
+
+extern "C" {
+#include "functions.h" // gsworld_getMap
+}
+
+#define CVAR_OCCLUSION_ACTIVE CVAR_DEVELOPER_TOOLS("OcclusionDebug.Active")
+
+namespace {
+
+constexpr int kParts = 2; // 0 = opaque, 1 = translucent
+const char* kPartNames[kParts] = { "OPA", "XLU" };
+
+const char* CmdTypeName(int type) {
+    switch (type) {
+        case OCCLUSION_CMD_CAMERA: return "CAMERA";
+        case OCCLUSION_CMD_LOD: return "LOD";
+        case OCCLUSION_CMD_UNKE: return "UnkE";
+        default: return "?";
+    }
+}
+
+// Each command is keyed by (model part, byte offset within the model bin). The offset is
+// fixed per asset, so it never shifts when force-drawing reveals more geometry — unlike a
+// traversal-order index.
+struct Key {
+    int part;
+    int offset;
+    bool operator<(const Key& o) const {
+        return (part != o.part) ? (part < o.part) : (offset < o.offset);
+    }
+};
+
+struct CullCmdRecord {
+    int type;
+    int areaCount;
+    unsigned char areaIds[12]; // CAMERA only
+    int detail0;               // CAMERA: flags (unkB); LOD: min distance
+    int detail1;               // LOD: max distance
+    int drawnVanilla;          // would the unmodified gate draw this command on its last visit?
+    bool seenThisFrame;
+};
+
+std::mutex sMutex;
+std::map<Key, CullCmdRecord> sRecorded; // accumulated across frames, cleared on map change
+std::set<Key> sForceDraw;                 // commands the dev pinned to always draw
+bool sForceAll = false;                   // momentary: draw every command (enumerate the whole tree)
+int sCurrentPart = 0;
+int sRecordedMap = -1;
+
+// Kind-specific one-line description for the Detail column.
+std::string DetailString(const CullCmdRecord& rec) {
+    if (rec.type == OCCLUSION_CMD_CAMERA) {
+        std::string ids;
+        for (int i = 0; i < rec.areaCount; i++) {
+            if (i) {
+                ids += ",";
+            }
+            ids += std::to_string((int)rec.areaIds[i]);
+        }
+        const char* branch = (rec.detail0 & 1) ? ((rec.detail0 & 2) ? "in+out" : "outside")
+                                               : ((rec.detail0 & 2) ? "inside" : "-");
+        return "areas {" + ids + "} " + branch;
+    }
+    if (rec.type == OCCLUSION_CMD_LOD) {
+        return "dist " + std::to_string(rec.detail0) + ".." + std::to_string(rec.detail1);
+    }
+    if (rec.type == OCCLUSION_CMD_UNKE) {
+        return "frustum sphere";
+    }
+    return "";
+}
+
+} // namespace
+
+extern "C" int OcclusionDebug_IsActive(void) {
+    return CVarGetInteger(CVAR_OCCLUSION_ACTIVE, 0);
+}
+
+extern "C" void OcclusionDebug_BeginPart(int part) {
+    if (!OcclusionDebug_IsActive() || part < 0 || part >= kParts) {
+        return;
+    }
+    if (part == 0) {
+        // Opaque is drawn first each frame.
+        std::lock_guard<std::mutex> lock(sMutex);
+        int map = (int)gsworld_getMap();
+        if (map != sRecordedMap) {
+            // New map: the offsets belong to a different model, so start over.
+            sRecorded.clear();
+            sForceDraw.clear();
+            sRecordedMap = map;
+        }
+        for (auto& [key, rec] : sRecorded) {
+            rec.seenThisFrame = false;
+        }
+    }
+    sCurrentPart = part;
+}
+
+extern "C" int OcclusionDebug_OnCullCmd(int type, int offset, int drawnVanilla, const unsigned char* areaIds,
+                                        int areaCount, int detail0, int detail1) {
+    Key key{ sCurrentPart, offset };
+
+    std::lock_guard<std::mutex> lock(sMutex);
+    CullCmdRecord& rec = sRecorded[key];
+    rec.type = type;
+    rec.areaCount = (areaCount > 12) ? 12 : (areaCount < 0 ? 0 : areaCount);
+    for (int i = 0; i < 12; i++) {
+        rec.areaIds[i] = (i < rec.areaCount && areaIds != nullptr) ? areaIds[i] : 0;
+    }
+    rec.detail0 = detail0;
+    rec.detail1 = detail1;
+    rec.drawnVanilla = drawnVanilla;
+    rec.seenThisFrame = true;
+
+    return (sForceAll || sForceDraw.count(key)) ? 1 : 0;
+}
+
+void OcclusionDebugWindow::DrawElement() {
+    bool active = CVarGetInteger(CVAR_OCCLUSION_ACTIVE, 0);
+    if (ImGui::Checkbox("Enable recording / force-draw", &active)) {
+        CVarSetInteger(CVAR_OCCLUSION_ACTIVE, active);
+        Ship::Context::GetRawInstance()->GetWindow()->GetGui()->SaveConsoleVariablesNextFrame();
+    }
+    ImGui::TextWrapped("Flip 'Force draw all' on for a moment to walk the whole camera-area tree and populate the list "
+                       "(the screen will look broken — that is expected), then turn it off and tick 'Force Draw' on "
+                       "individual rows to find the chunk(s) that reveal the target scenery. Offsets are stable, so the "
+                       "list never shifts. Dump the chosen set to the log when done.");
+
+    // Snapshot under the lock; render outside it.
+    struct Row {
+        Key key;
+        CullCmdRecord rec;
+        bool forced;
+    };
+    std::vector<Row> rows;
+    bool forceAll;
+    int mapId;
+    {
+        std::lock_guard<std::mutex> lock(sMutex);
+        forceAll = sForceAll;
+        mapId = sRecordedMap;
+        rows.reserve(sRecorded.size());
+        for (auto& [key, rec] : sRecorded) {
+            rows.push_back({ key, rec, sForceDraw.count(key) > 0 });
+        }
+    }
+
+    ImGui::Separator();
+    ImGui::Text("Map: 0x%X    Cull commands seen: %zu", mapId, rows.size());
+
+    if (ImGui::Checkbox("Force draw all (enumerate)", &forceAll)) {
+        std::lock_guard<std::mutex> lock(sMutex);
+        sForceAll = forceAll;
+    }
+    ImGui::SameLine();
+    if (ImGui::Button("Clear list")) {
+        std::lock_guard<std::mutex> lock(sMutex);
+        sRecorded.clear();
+        sRecordedMap = -1;
+    }
+    ImGui::SameLine();
+    if (ImGui::Button("Clear force-draw")) {
+        std::lock_guard<std::mutex> lock(sMutex);
+        sForceDraw.clear();
+    }
+    ImGui::SameLine();
+    if (ImGui::Button("Dump force-draw set to log")) {
+        std::string parts[kParts];
+        {
+            std::lock_guard<std::mutex> lock(sMutex);
+            for (const Key& k : sForceDraw) {
+                if (k.part < 0 || k.part >= kParts) {
+                    continue;
+                }
+                if (!parts[k.part].empty()) {
+                    parts[k.part] += ", ";
+                }
+                parts[k.part] += "0x" + [](int v) {
+                    char buf[16];
+                    snprintf(buf, sizeof(buf), "%X", v);
+                    return std::string(buf);
+                }(k.offset);
+            }
+        }
+        SPDLOG_INFO("[OcclusionDebug] map 0x{:X}: OPA {{{}}} XLU {{{}}}", mapId, parts[0], parts[1]);
+    }
+
+    if (ImGui::BeginTable("OcclusionCmds", 6,
+                          ImGuiTableFlags_Borders | ImGuiTableFlags_RowBg | ImGuiTableFlags_SizingFixedFit |
+                              ImGuiTableFlags_ScrollY)) {
+        ImGui::TableSetupColumn("Part", ImGuiTableColumnFlags_WidthFixed);
+        ImGui::TableSetupColumn("Offset", ImGuiTableColumnFlags_WidthFixed);
+        ImGui::TableSetupColumn("Type", ImGuiTableColumnFlags_WidthFixed);
+        ImGui::TableSetupColumn("Detail", ImGuiTableColumnFlags_WidthStretch);
+        ImGui::TableSetupColumn("Drawn", ImGuiTableColumnFlags_WidthFixed);
+        ImGui::TableSetupColumn("Force Draw", ImGuiTableColumnFlags_WidthFixed);
+        ImGui::TableHeadersRow();
+
+        for (Row& row : rows) {
+            ImGui::TableNextRow();
+
+            ImGui::TableNextColumn();
+            ImGui::Text("%s", kPartNames[row.key.part]);
+
+            ImGui::TableNextColumn();
+            ImGui::Text("0x%X", row.key.offset);
+
+            ImGui::TableNextColumn();
+            ImGui::Text("%s", CmdTypeName(row.rec.type));
+
+            ImGui::TableNextColumn();
+            ImGui::TextWrapped("%s", DetailString(row.rec).c_str());
+
+            ImGui::TableNextColumn();
+            // Grey out commands not visited this frame (their parent branch wasn't walked).
+            if (!row.rec.seenThisFrame) {
+                ImGui::TextDisabled("--");
+            } else {
+                ImGui::Text("%s", row.rec.drawnVanilla ? "yes" : "no");
+            }
+
+            ImGui::TableNextColumn();
+            bool fd = row.forced;
+            std::string id = "##fd" + std::to_string(row.key.part) + "_" + std::to_string(row.key.offset);
+            if (ImGui::Checkbox(id.c_str(), &fd)) {
+                std::lock_guard<std::mutex> lock(sMutex);
+                if (fd) {
+                    sForceDraw.insert(row.key);
+                } else {
+                    sForceDraw.erase(row.key);
+                }
+            }
+        }
+        ImGui::EndTable();
+    }
+}

--- a/src/port/DevTools/OcclusionDebug.h
+++ b/src/port/DevTools/OcclusionDebug.h
@@ -1,0 +1,51 @@
+#pragma once
+
+// Camera-area occlusion debugger.
+//
+// BK gates chunks of level geometry on which "camera area" box the camera occupies
+// (see modelRender_geoCmd_CAMERA). That portal culling is what hides distant landmark
+// scenery like the MM stonehenge. This tool enumerates every camera-area command in the
+// current map model, lets you force-draw individual ones live, and dumps the chosen set
+// so it can be baked into a per-map allowlist.
+
+#ifdef __cplusplus
+#include <libultraship/libultraship.h>
+
+class OcclusionDebugWindow final : public Ship::GuiWindow {
+  public:
+    using GuiWindow::GuiWindow;
+
+    void InitElement() override {}
+    void DrawElement() override;
+    void UpdateElement() override {}
+};
+
+extern "C" {
+#endif
+
+// Nonzero while the developer has recording/force-draw enabled (cvar-gated). Used as a
+// cheap early-out so the per-command hooks cost nothing when the tool is off.
+int OcclusionDebug_IsActive(void);
+
+// Called once before each map-model part is drawn so per-part command indices are stable.
+// part: 0 = opaque, 1 = translucent. Part 0 (drawn first each frame) also publishes the
+// previous frame's recorded list to the UI and starts a fresh capture.
+void OcclusionDebug_BeginPart(int part);
+
+// Geo-command kinds that conditionally cull level geometry. Distant scenery can be hidden
+// by any of these, so the debugger instruments them all.
+#define OCCLUSION_CMD_CAMERA 0 // geoCmd_CAMERA: gated on which camera-area box the camera is in
+#define OCCLUSION_CMD_LOD 1    // geoCmd_LOD: gated on distance band [min, max]
+#define OCCLUSION_CMD_UNKE 2   // geoCmd_UnkE: gated on a bounding sphere passing the view frustum
+
+// Called from each conditional cull command. `offset` is the command's byte offset within
+// the model bin (a stable per-asset key). `drawnVanilla` is the unmodified recurse decision.
+// areaIds/areaCount apply to CAMERA only (NULL/0 otherwise); detail0/detail1 are kind-specific
+// extras for display (CAMERA: flags; LOD: min,max). Records the command and returns nonzero if
+// the developer has toggled it — or "force draw all" — to draw.
+int OcclusionDebug_OnCullCmd(int type, int offset, int drawnVanilla, const unsigned char* areaIds, int areaCount,
+                             int detail0, int detail1);
+
+#ifdef __cplusplus
+}
+#endif

--- a/src/port/DevTools/OcclusionDebug.h
+++ b/src/port/DevTools/OcclusionDebug.h
@@ -2,13 +2,11 @@
 
 // Camera-area occlusion debugger.
 //
-// BK gates chunks of level geometry on which "camera area" box the camera occupies
-// (see modelRender_geoCmd_CAMERA). That portal culling is what hides distant landmark
-// scenery like the MM stonehenge. This tool enumerates every camera-area command in the
-// current map model, lets you force-draw individual ones live, and dumps the chosen set
-// so it can be baked into a per-map allowlist.
+// Listens on OnGeoCull (fired per conditional cull command in the map model) to enumerate
+// every culled geometry chunk in the current map, lets you force-draw individual ones live,
+// and dumps the chosen set so it can be baked into the draw-distance enhancement. All wiring
+// is internal — render.c only fires OnGeoCull via port_geoCullDraw (see GeoCull.h).
 
-#ifdef __cplusplus
 #include <libultraship/libultraship.h>
 
 class OcclusionDebugWindow final : public Ship::GuiWindow {
@@ -19,33 +17,3 @@ class OcclusionDebugWindow final : public Ship::GuiWindow {
     void DrawElement() override;
     void UpdateElement() override {}
 };
-
-extern "C" {
-#endif
-
-// Nonzero while the developer has recording/force-draw enabled (cvar-gated). Used as a
-// cheap early-out so the per-command hooks cost nothing when the tool is off.
-int OcclusionDebug_IsActive(void);
-
-// Called once before each map-model part is drawn so per-part command indices are stable.
-// part: 0 = opaque, 1 = translucent. Part 0 (drawn first each frame) also publishes the
-// previous frame's recorded list to the UI and starts a fresh capture.
-void OcclusionDebug_BeginPart(int part);
-
-// Geo-command kinds that conditionally cull level geometry. Distant scenery can be hidden
-// by any of these, so the debugger instruments them all.
-#define OCCLUSION_CMD_CAMERA 0 // geoCmd_CAMERA: gated on which camera-area box the camera is in
-#define OCCLUSION_CMD_LOD 1    // geoCmd_LOD: gated on distance band [min, max]
-#define OCCLUSION_CMD_UNKE 2   // geoCmd_UnkE: gated on a bounding sphere passing the view frustum
-
-// Called from each conditional cull command. `offset` is the command's byte offset within
-// the model bin (a stable per-asset key). `drawnVanilla` is the unmodified recurse decision.
-// areaIds/areaCount apply to CAMERA only (NULL/0 otherwise); detail0/detail1 are kind-specific
-// extras for display (CAMERA: flags; LOD: min,max). Records the command and returns nonzero if
-// the developer has toggled it — or "force draw all" — to draw.
-int OcclusionDebug_OnCullCmd(int type, int offset, int drawnVanilla, const unsigned char* areaIds, int areaCount,
-                             int detail0, int detail1);
-
-#ifdef __cplusplus
-}
-#endif

--- a/src/port/Enhancements/Events/Hooks/List/BehaviorEvent.h
+++ b/src/port/Enhancements/Events/Hooks/List/BehaviorEvent.h
@@ -26,6 +26,12 @@ DEFINE_EVENT(OnPlayerAnimReset)
 DEFINE_EVENT(OnPlayerTransformChange, Transformation tf_id;)
 DEFINE_EVENT(OnPlayerAnimSubRangeChange, f32 duration; f32 end_position;)
 DEFINE_EVENT(OnWaterPyramidTimer, s32* timer;)
+// Fired per conditional geometry-cull command in the map model (camera-area portal, LOD
+// band, frustum sphere). Listeners may set *forceDraw to draw a chunk the vanilla gate
+// would skip. `type` is OCCLUSION_CMD_* (see GeoCull.h); `offset` is the command's byte
+// offset within `modelBin` (a stable per-asset key). areaIds/areaCount apply to CAMERA.
+DEFINE_EVENT(OnGeoCull, s32 type; s32 offset; const void* modelBin; const u8* areaIds; s32 areaCount; s32 detail0;
+             s32 detail1; s32 drawnVanilla; bool* forceDraw;)
 // Mr. Vile minigame (Anchor sync). Fired only on the client actually running the local
 // logic; followers have the originating code paths suppressed via VB_VILE_* behaviors.
 DEFINE_EVENT(OnVileHoleStateChange, ActorMarker* marker; f32 * position; s32 state; s32 pieceType;)

--- a/src/port/Enhancements/Events/PortEnhancements.cpp
+++ b/src/port/Enhancements/Events/PortEnhancements.cpp
@@ -40,6 +40,7 @@ void PortEnhancements_Register() {
     REGISTER_EVENT(OnBoggyRaceSetSpeed);
     REGISTER_EVENT(OnBootLogosCheck);
     REGISTER_EVENT(OnFurnaceFunDialog);
+    REGISTER_EVENT(OnGeoCull);
     REGISTER_EVENT(OnGruntyJinjonatorComplete);
     REGISTER_EVENT(OnIntroCutsceneCheck);
     REGISTER_EVENT(OnMumboTokenUpdate);

--- a/src/port/Patches/GeoCull.cpp
+++ b/src/port/Patches/GeoCull.cpp
@@ -1,0 +1,28 @@
+#include "GeoCull.h"
+
+#include "port/Enhancements/Events/Hooks/Events.h"
+
+static int sConsumerMask = 0;
+
+extern "C" void GeoCull_SetConsumer(int consumerBit, int active) {
+    if (active) {
+        sConsumerMask |= consumerBit;
+    } else {
+        sConsumerMask &= ~consumerBit;
+    }
+}
+
+extern "C" int port_geoCullDraw(int type, const void* cmd, const void* modelBin, int drawnVanilla,
+                                const unsigned char* areaIds, int areaCount, int detail0, int detail1) {
+    // Nothing listening: leave the vanilla decision untouched and skip the event entirely
+    // (CallEvent does a string-keyed map lookup per call, which we don't want per geo command
+    // in normal play).
+    if (sConsumerMask == 0) {
+        return drawnVanilla;
+    }
+
+    int offset = (int)((const unsigned char*)cmd - (const unsigned char*)modelBin);
+    bool forceDraw = false;
+    CALL_EVENT(OnGeoCull, type, offset, modelBin, areaIds, areaCount, detail0, detail1, drawnVanilla, &forceDraw);
+    return (drawnVanilla || forceDraw) ? 1 : 0;
+}

--- a/src/port/Patches/GeoCull.h
+++ b/src/port/Patches/GeoCull.h
@@ -1,0 +1,38 @@
+#pragma once
+
+// Geometry-cull dispatch.
+//
+// BK's map model conditionally culls chunks of level geometry via a few geo commands
+// (camera-area portal, LOD distance band, frustum sphere). render.c routes each of those
+// decisions through port_geoCullDraw, which fires the OnGeoCull event so port-side
+// listeners — the occlusion debugger and the draw-distance enhancement — can force a chunk
+// to draw. When no listener is active the call is a cheap no-op, so normal play pays
+// nothing.
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+// Conditional cull command kinds.
+#define OCCLUSION_CMD_CAMERA 0 // geoCmd_CAMERA: gated on which camera-area box the camera is in
+#define OCCLUSION_CMD_LOD 1    // geoCmd_LOD: gated on distance band [min, max]
+#define OCCLUSION_CMD_UNKE 2   // geoCmd_UnkE: gated on a bounding sphere passing the view frustum
+
+// Consumer bits for GeoCull_SetConsumer; the event only fires while at least one is set.
+#define GEOCULL_CONSUMER_DEBUG 1
+#define GEOCULL_CONSUMER_ENHANCEMENT 2
+
+// Called from each conditional cull command in render.c. `cmd`/`modelBin` give the command's
+// stable byte offset; `drawnVanilla` is the unmodified recurse decision. areaIds/areaCount
+// apply to CAMERA only (NULL/0 otherwise); detail0/detail1 are kind-specific extras (CAMERA:
+// flags; LOD: min,max). Returns the final draw decision (1 = draw).
+int port_geoCullDraw(int type, const void* cmd, const void* modelBin, int drawnVanilla, const unsigned char* areaIds,
+                     int areaCount, int detail0, int detail1);
+
+// Listeners enable/disable themselves as consumers so the per-command event firing can be
+// skipped entirely when nothing is listening.
+void GeoCull_SetConsumer(int consumerBit, int active);
+
+#ifdef __cplusplus
+}
+#endif

--- a/src/port/Patches/GraphicsPatches.cpp
+++ b/src/port/Patches/GraphicsPatches.cpp
@@ -1,10 +1,12 @@
 #include <libultraship/bridge.h>
 #include "port/UI/cvar_prefixes.h"
+#include "port/Enhancements/Events/Hooks/Events.h"
+#include "port/ShipInit.hpp"
+#include "port/Patches/GeoCull.h"
 
 extern "C" {
 #include "enums.h"
-
-int getGameMode(void);
+#include "functions.h"
 
 int port_getDrawDistanceLevel(void) {
     int level = CVarGetInteger(CVAR_ENHANCEMENT("Graphics.DrawDistance"), 0);
@@ -19,3 +21,33 @@ int port_shouldDisableLOD(void) {
     return CVarGetInteger(CVAR_ENHANCEMENT("Graphics.DisableLOD"), 0);
 }
 }
+
+// ============================================================================
+// LEVEL OCCLUSION — extend draw distance to camera-area portal geometry
+// ============================================================================
+//
+// Some distant level geometry is hidden by BK's camera-area portal culling rather than the
+// distance/LOD culls the prop draw-distance enhancement covers. Disabling that culling
+// wholesale floods the render buffer, so at the maxed draw-distance level we force just the
+// specific chunks known to suffer from it. Currently the only one is the Mumbo's Mountain
+// stonehenge: a single "outside areas {1,2}" CAMERA command in the opaque map model.
+
+static void OnGeoCull_LevelOcclusion(IEvent* event) {
+    auto* ev = reinterpret_cast<OnGeoCull*>(event);
+    if (ev->type != OCCLUSION_CMD_CAMERA) {
+        return;
+    }
+    if (gsworld_getMap() == MAP_2_MM_MUMBOS_MOUNTAIN && ev->offset == 0x2CD0 &&
+        ev->modelBin == (const void*)mapModel_getModelBin(0)) {
+        *ev->forceDraw = true;
+    }
+}
+
+void RegisterLevelOcclusion_Init() {
+    bool maxed = CVarGetInteger(CVAR_ENHANCEMENT("Graphics.DrawDistance"), 0) >= 4;
+    GeoCull_SetConsumer(GEOCULL_CONSUMER_ENHANCEMENT, maxed);
+    COND_HOOK(OnGeoCull, EVENT_PRIORITY_NORMAL, maxed, OnGeoCull_LevelOcclusion);
+}
+
+static RegisterShipInitFunc sInitLevelOcclusion(RegisterLevelOcclusion_Init,
+                                                { CVAR_ENHANCEMENT("Graphics.DrawDistance") });

--- a/src/port/UI/LighthouseGui.cpp
+++ b/src/port/UI/LighthouseGui.cpp
@@ -5,6 +5,7 @@
 #include <imgui_internal.h>
 #include "UIWidgets.hpp"
 #include "src/port/devtools/EventDebugger.h"
+#include "src/port/DevTools/OcclusionDebug.h"
 
 #ifdef __APPLE__
 #include <fast/backends/gfx_metal.h>
@@ -66,6 +67,7 @@ std::shared_ptr<InputViewer> mInputViewer;
 std::shared_ptr<InputViewerSettingsWindow> mInputViewerSettings;
 std::shared_ptr<LighthouseModalWindow> mModalWindow;
 std::shared_ptr<EventDebuggerWindow> mEventDebuggerWindow;
+std::shared_ptr<OcclusionDebugWindow> mOcclusionDebugWindow;
 
 UIWidgets::Colors GetMenuThemeColor() {
     return mLighthouseMenu->GetMenuThemeColor();
@@ -186,6 +188,9 @@ void SetupGuiElements() {
 
     mEventDebuggerWindow = std::make_shared<EventDebuggerWindow>(CVAR_WINDOW("EventDebugger"), "Event Debugger");
     gui->AddGuiWindow(mEventDebuggerWindow);
+
+    mOcclusionDebugWindow = std::make_shared<OcclusionDebugWindow>(CVAR_WINDOW("OcclusionDebug"), "Occlusion Debugger");
+    gui->AddGuiWindow(mOcclusionDebugWindow);
 }
 
 void Destroy() {
@@ -218,6 +223,7 @@ void Destroy() {
     mInputViewer = nullptr;
     mInputViewerSettings = nullptr;
     mEventDebuggerWindow = nullptr;
+    mOcclusionDebugWindow = nullptr;
 }
 
 void RegisterPopup(std::string title, std::string message, std::string button1, std::string button2,

--- a/src/port/UI/LighthouseMenuDevTools.cpp
+++ b/src/port/UI/LighthouseMenuDevTools.cpp
@@ -149,6 +149,16 @@ void LighthouseMenu::AddMenuDevTools() {
         .HideInSearch(true)
         .Options(WindowButtonOptions().Tooltip("Enables the separate Event Debugger Window."));
 
+    path.sidebarName = "Occlusion Debugger";
+    AddSidebarEntry("Dev Tools", path.sidebarName, 1);
+    AddWidget(path, "Popout Occlusion Debugger", WIDGET_WINDOW_BUTTON)
+        .CVar(CVAR_WINDOW("OcclusionDebug"))
+        .WindowName("Occlusion Debugger")
+        .HideInSearch(true)
+        .Options(WindowButtonOptions().Tooltip(
+            "Enumerates the current map's camera-area (portal occlusion) geometry and lets you force-draw individual "
+            "chunks to find what to add to a per-map draw allowlist."));
+
     // path.sidebarName = "Object Viewer";
     // AddSidebarEntry("Dev Tools", path.sidebarName, 1);
     // AddWidget(path, "Popout Object Viewer", WIDGET_WINDOW_BUTTON)


### PR DESCRIPTION
This adds a new dev tool, the occlusion debugger, which allows debugging of geoCmd evaluations to determine geoCmd_CAMERA level geometry changes based on which camera region box the camera is in.

Then adds Stonehenge display to 100% draw distance. Should be evaluated later for somehow modifying it based on distance for things like 25-75%.

Also consolidates all 4 or 5 `core2/map/model.c` sections in `functions.h`.