### PR TITLE
Use casts for va_arg

### DIFF
--- a/src/port/Rando/ObjectBehavior/Bundle.cpp
+++ b/src/port/Rando/ObjectBehavior/Bundle.cpp
@@ -25,7 +25,7 @@ void Rando::ObjectBehavior::InitBundleBehavior() {
     })
 
     COND_VB_SHOULD(VB_OVERRIDE_BUNDLE_SPAWN, EVENT_PRIORITY_NORMAL, true, {
-        bundle_e bundleId = va_arg(args, bundle_e);
+        bundle_e bundleId = (bundle_e)va_arg(args, int);
         BundleInfo* bundleInfo = va_arg(args, BundleInfo*);
         s32 bundleCount = va_arg(args, s32);
         f32* position = va_arg(args, f32*);

--- a/src/port/Rando/ObjectBehavior/Jiggy.cpp
+++ b/src/port/Rando/ObjectBehavior/Jiggy.cpp
@@ -19,7 +19,7 @@ void Rando::ObjectBehavior::InitJiggyBehavior() {
     })
 
     COND_VB_SHOULD(VB_OVERRIDE_JIGGY_SPAWN, EVENT_PRIORITY_NORMAL, true, {
-        jiggy_e jiggyId = va_arg(args, jiggy_e);
+        jiggy_e jiggyId = (jiggy_e)va_arg(args, int);
         f32* position = va_arg(args, f32*);
 
         if (!IS_RANDO && !OPTION_ENABLED) {


### PR DESCRIPTION
Pulling a value out of `va_arg` as an enum is a nono. Linux compilation will outright tell you this will crash. Seen this way too many times in 2ship. Your options are to either pull it out as an `int` and cast it, which I did here, or use pointers.