### PR TITLE
Fix some bottles bonus and pause menu framebuffer bugs

### DIFF
--- a/src/core2/ch/bottlesbonuscursor.c
+++ b/src/core2/ch/bottlesbonuscursor.c
@@ -4,6 +4,7 @@
 #include "variables.h"
 
 #include "bk_time.h"
+#include "port/Interpolation/FrameInterpolation.h"
 
 #ifndef ABS
 #define	ABS(d)		((d) >= 0) ? (d) : -(d)
@@ -156,7 +157,9 @@ void chBottlesBonusCursor_draw(Gfx **gfx, Mtx **mtx, Vtx **vtx) {
         (s32)sp3C, (s32)sp3C,
         gFramebuffers[getActiveFramebuffer()]
     );
+    FrameInterpolation_RecordOpenChild("bbonus_cursor", 0);
     modelRender_draw(gfx, mtx, this->position, rotation, this->scale, NULL, marker_loadModelBin(chBottlesBonusCursorMarker));
+    FrameInterpolation_RecordCloseChild();
     viewport_func_8024E030(this->position, D_8037E5C0.unk10);
     if (this->state == 1) {
         D_8037E5C0.unk10[0] -= 24.0f;

--- a/src/core2/context/bound.c
+++ b/src/core2/context/bound.c
@@ -12,8 +12,8 @@ extern Gfx D_803688E8[] = {
     gsDPSetCycleType(G_CYC_1CYCLE),
     gsDPPipelineMode(G_PM_NPRIMITIVE),
     gsDPSetAlphaCompare(G_AC_NONE),
-    gsDPSetCombineLERP(0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0),
-    gsDPSetRenderMode(IM_RD | CVG_DST_SAVE | ZMODE_OPA | FORCE_BL | GBL_c1(G_BL_CLR_FOG, G_BL_A_FOG, G_BL_CLR_MEM, G_BL_1MA), IM_RD | CVG_DST_SAVE | ZMODE_OPA | FORCE_BL | G_RM_NOOP2),
+    gsDPSetCombineMode(G_CC_PRIMITIVE, G_CC_PRIMITIVE),
+    gsDPSetRenderMode(IM_RD | CVG_DST_SAVE | ZMODE_OPA | FORCE_BL | GBL_c1(G_BL_CLR_IN, G_BL_A_IN, G_BL_CLR_MEM, G_BL_1MA), IM_RD | CVG_DST_SAVE | ZMODE_OPA | FORCE_BL | G_RM_NOOP2),
     gsSPEndDisplayList(),
 }; //_gcBoundDisplayList
 
@@ -25,8 +25,9 @@ u8 _gcbound_blue; //D_80380902
 /* .code */
 void  _gcbound_draw(Gfx** dl, s32 a, s32 r, s32 g, s32 b){
     gSPDisplayList((*dl)++, D_803688E8);
-    gDPSetFogColor((*dl)++, r, g, b, a);
-    gSPTextureRectangle((*dl)++, 0,  0, (gFramebufferWidth-1)<<2, (gFramebufferHeight-1)<<2, 0, 0, 0, 0x100, 0x100);
+    gDPSetPrimColor((*dl)++, 0, 0, r, g, b, a);
+    // [port] Overscan past the 4:3 native bounds so the fade still fills the screen
+    gSPWideTextureRectangle((*dl)++, -1024, -1024, 2048, 2048, 0, 0, 0, 0x100, 0x100);
 }
 
 void gcbound_draw(Gfx** dl){

--- a/src/port/Engine.cpp
+++ b/src/port/Engine.cpp
@@ -1485,32 +1485,35 @@ extern "C" float OTRGetHUDAspectRatio() {
     return ((float)CVarGetInteger("gHUDAspectRatio.X", 1) / (float)CVarGetInteger("gHUDAspectRatio.Y", 1));
 }
 
+static float OTRWidescreenHalfHeight() {
+    auto interpreter = GameEngine_GetInterpreter();
+    return interpreter->mNativeDimensions.width * 3.0f / 4.0f / 2.0f;
+}
+
 extern "C" float OTRGetDimensionFromLeftEdge(float v) {
     auto interpreter = GameEngine_GetInterpreter();
     return (interpreter->mNativeDimensions.width / 2 -
-            interpreter->mNativeDimensions.height / 2 * interpreter->mCurDimensions.aspect_ratio + (v));
+            OTRWidescreenHalfHeight() * interpreter->mCurDimensions.aspect_ratio + (v));
 }
 
 extern "C" float OTRGetDimensionFromRightEdge(float v) {
     auto interpreter = GameEngine_GetInterpreter();
     return (interpreter->mNativeDimensions.width / 2 +
-            interpreter->mNativeDimensions.height / 2 * interpreter->mCurDimensions.aspect_ratio -
+            OTRWidescreenHalfHeight() * interpreter->mCurDimensions.aspect_ratio -
             (interpreter->mNativeDimensions.width - v));
 }
 
 extern "C" float OTRGetDimensionFromLeftEdgeForcedAspect(float v, float aspectRatio) {
     auto interpreter = GameEngine_GetInterpreter();
     return (interpreter->mNativeDimensions.width / 2 -
-            interpreter->mNativeDimensions.height / 2 *
-                (aspectRatio > 0 ? aspectRatio : interpreter->mCurDimensions.aspect_ratio) +
+            OTRWidescreenHalfHeight() * (aspectRatio > 0 ? aspectRatio : interpreter->mCurDimensions.aspect_ratio) +
             (v));
 }
 
 extern "C" float OTRGetDimensionFromRightEdgeForcedAspect(float v, float aspectRatio) {
     auto interpreter = GameEngine_GetInterpreter();
     return (interpreter->mNativeDimensions.width / 2 +
-            interpreter->mNativeDimensions.height / 2 *
-                (aspectRatio > 0 ? aspectRatio : interpreter->mCurDimensions.aspect_ratio) -
+            OTRWidescreenHalfHeight() * (aspectRatio > 0 ? aspectRatio : interpreter->mCurDimensions.aspect_ratio) -
             (interpreter->mNativeDimensions.width - v));
 }
 


### PR DESCRIPTION
Missed interpolation on the cursor, and a decomp artifact causing the white fade to not work. Pause menu captured framebuffer was slightly off from main render view.