### PR TITLE
Full note retention done, including note bundles, and sub-area save s…

### DIFF
--- a/include/save.h
+++ b/include/save.h
@@ -15,9 +15,31 @@ typedef struct {
     RandoSaveOption randoSaveOption[RO_MAX];
 } RandoSaveData;
 
+// Note collection retention: per-map bitfield of collected music notes, keyed by
+// (mapId, spawn-order noteIndex). Independent of rando check data so it works for
+// vanilla and romhacks. Level attribution is derived dynamically via map_getLevel.
+#define NOTE_RETENTION_MAP_SLOTS 0x100             // covers all map_e ids with headroom
+#define NOTE_RETENTION_NOTES_PER_MAP 128           // max notes addressable per map
+#define NOTE_RETENTION_BYTES_PER_MAP (NOTE_RETENTION_NOTES_PER_MAP / 8)
+
+typedef struct {
+    u8 collected[NOTE_RETENTION_MAP_SLOTS][NOTE_RETENTION_BYTES_PER_MAP];
+} NoteRetentionSaveData;
+
+// Jinjo collection retention: per-level bitmask of collected jinjo colours, using the
+// same 5-bit layout as ITEM_12_JINJOS. Lets individually collected jinjos persist across
+// level visits instead of resetting on every entry (vanilla requires all 5 in one go).
+#define JINJO_RETENTION_LEVEL_SLOTS 0x20   // covers level_e ids (1..0xD) with headroom
+
+typedef struct {
+    u8 collected[JINJO_RETENTION_LEVEL_SLOTS];
+} JinjoRetentionSaveData;
+
 typedef struct {
     FileType fileType;
     RandoSaveData randoSaveData;
+    NoteRetentionSaveData noteRetention;
+    JinjoRetentionSaveData jinjoRetention;
 } ShipSaveData;
 
 typedef struct{

--- a/src/core2/actor_array.c
+++ b/src/core2/actor_array.c
@@ -5,6 +5,7 @@
 #include "actor.h"
 
 #include "prop.h"
+#include "port/Enhancements/NoteRetention/NoteRetention.h"
 
 extern s32 D_80370990;
 extern f32 GameEngine_GetAspectRatio(void);
@@ -432,6 +433,10 @@ void func_80325FE8(Actor *this) {
 
 void actorArray_free(void) {
     Actor *var_s0;
+
+    // [port] Note retention: every note actor is about to be freed, so drop our
+    // live-actor tracking (markers are being released here).
+    port_noteRetention_onActorsFreed();
 
     if (suBaddieActorArray != NULL) {
         for(var_s0 = suBaddieActorArray->data; var_s0 < &suBaddieActorArray->data[suBaddieActorArray->cnt]; var_s0++){

--- a/src/core2/actor_cubepropsystem.c
+++ b/src/core2/actor_cubepropsystem.c
@@ -1012,7 +1012,14 @@ void code7AF80_initCubeFromFile(File *file_ptr, Cube *cube) {
                 memcpy(&pos[1], raw + 6, 2);
                 memcpy(&pos[2], raw + 8, 2);
                 memcpy(&flags, raw + 10, 2);
-                if (!EventSystem_Should(VB_OVERRIDE_PROP_SPAWN, false, pos)) {
+                // [port] Expose the sprite asset id (or -1 for marker/model props) so
+                // override handlers can identify props by type (e.g. music notes) without
+                // relying on position, which differs in romhacks.
+                s32 propSpriteAsset = -1;
+                if (!(flags & 1) && !((flags >> 1) & 1)) {
+                    propSpriteAsset = ((s32)((word0 >> 20) & 0xFFF)) + 0x572;
+                }
+                if (!EventSystem_Should(VB_OVERRIDE_PROP_SPAWN, false, pos, propSpriteAsset)) {
                 // Extract flag bits using N64 BE bit positions within the u16
                     {
                         bool mf = flags & 1;            // markerFlag (BE bit 0)

--- a/src/core2/ch/jinjo.c
+++ b/src/core2/ch/jinjo.c
@@ -49,7 +49,7 @@ void __chJinjo_802CDBA8(ActorMarker *this, ActorMarker *other){
             fileProgressFlag_set(FILEPROG_E_JINJO_TEXT, 1);
         }
         subaddie_set_state_with_direction(actorPtr, 6, 0.0f , -1);
-        if (!EventSystem_Should(VB_UPDATE_JINJO_HUD, true, actorPtr->position)) {
+        if (!EventSystem_Should(VB_UPDATE_JINJO_HUD, false, actorPtr->position)) {
             if (item_adjustByDiffWithHud(ITEM_12_JINJOS, 1 << ((this->id + 6) & 0x1F)) == 0x1f) // [port] MIPS SLL uses low 5 bits; mask to avoid UB
                 localPtr->unk4 = 1;
         }

--- a/src/core2/context/dialog.c
+++ b/src/core2/context/dialog.c
@@ -875,6 +875,9 @@ int gcdialog_showDialogConditional(s32 text_id, s32 arg1, f32 *pos, ActorMarker 
     if(volatileFlag_get(VOLATILE_FLAG_1) || func_802D686C())
         return 0;
 
+    if(EventSystem_Should(VB_OVERRIDE_DIALOG_SHOW, false, text_id))
+        return 0;
+
     if(!gcdialog_hasCurrentTextId()){
         func_80310B1C(text_id, arg1, marker, (void *)callback, (void *)arg5, arg6);
         if(arg1 & 8){

--- a/src/core2/map/gsworld.c
+++ b/src/core2/map/gsworld.c
@@ -7,6 +7,7 @@
 #include <core2/file.h>
 #include "core2/particle.h"
 #include "port/Interpolation/FrameInterpolation.h"
+#include "port/Enhancements/NoteRetention/NoteRetention.h"
 
 /* .data */
 extern u8 D_80370250 = 0;
@@ -429,6 +430,8 @@ s32 gsworld_getEnableDraw(){
 
 void gsworld_load(enum map_e map_id) {
     File *fp;
+
+    port_noteRetention_beginMapLoad((int32_t)map_id);
 
     core1_15B30_sendMesg3ToRenderThread();
     fp = file_openMap(map_id); //LevelSetupFile_Open

--- a/src/port/Enhancements/Events/Hooks/Events.h
+++ b/src/port/Enhancements/Events/Hooks/Events.h
@@ -33,6 +33,9 @@ typedef enum VBehaviorID {
     VB_BUNDLE_SPAWN_SET_ACTOR_DATA,
     VB_NAPPER_SET_JIGGY_POSITION,
     VB_RESET_DIALOG_LANGUAGE,
+    // Cancellable at the single dialog choke point (gcdialog_showDialogConditional).
+    // Listeners receive the dialog's text_id; returning should=true suppresses the popup.
+    VB_OVERRIDE_DIALOG_SHOW,
     // Mr. Vile minigame (Anchor authority gating): cancelled on clients following a
     // remote authority so local random logic yields to network state.
     VB_VILE_YUMBLIE_EMERGE,

--- a/src/port/Enhancements/Events/Hooks/List/GameEvent.h
+++ b/src/port/Enhancements/Events/Hooks/List/GameEvent.h
@@ -7,7 +7,7 @@ DEFINE_EVENT(OnGameSave, int32_t fileNum;)
 DEFINE_EVENT(OnGameLoad, int32_t fileNum;)
 DEFINE_EVENT(OnPropInit, Prop* propPtr;);
 DEFINE_EVENT(OnSaveFileLoad, int32_t fileNum; void* saveBuffer; int32_t result;)
-DEFINE_EVENT(OnSaveFileSave, void* saveBuffer; int32_t fileNum; int32_t* result;)
+DEFINE_EVENT(OnSaveFileSave, void* saveBuffer; int32_t fileNum; int32_t * result;)
 // Identifies which warp_* dispatcher is firing OnWarpResolveDest. Keep values
 // stable so listener case statements keep matching across refactors.
 typedef enum WarpId {
@@ -15,4 +15,4 @@ typedef enum WarpId {
     WARP_ID_LAIR_ENTER_MM_LOBBY_FROM_SM_LEVEL = 2,
 } WarpId;
 
-DEFINE_EVENT(OnWarpResolveDest, int32_t warpId; int32_t defaultDest; int32_t bkcfOverride; int32_t* dest;);
+DEFINE_EVENT(OnWarpResolveDest, int32_t warpId; int32_t defaultDest; int32_t bkcfOverride; int32_t * dest;);

--- a/src/port/Enhancements/JinjoRetention/JinjoRetention.cpp
+++ b/src/port/Enhancements/JinjoRetention/JinjoRetention.cpp
@@ -1,0 +1,195 @@
+// Jinjo Collection Retention
+//
+// Vanilla resets ITEM_12_JINJOS on every level entry (itemscore_levelReset), so jinjos
+// respawn each visit and must all be collected in one go to earn the jiggy. This persists
+// the per-level set of collected jinjo colors so individually collected jinjos stay
+// collected across visits.
+//
+// How it works:
+//   - Saving is ALWAYS ON: collecting a jinjo records its color bit for the current
+//     level (same 5-bit layout as ITEM_12_JINJOS).
+//   - Application is behind an enhancement toggle (default off): when on, ITEM_12_JINJOS
+//     is seeded on level load from the saved bits, and already collected jinjos are not
+//     respawned. Collecting the remaining jinjos then completes the vanilla 0x1f mask and
+//     spawns the jiggy as usual.
+//
+// Stranded-jiggy guard: if all 5 of a level's jinjos are recorded but that level's jinjo
+// jiggy has not been obtained (player got all 5 but skipped the jiggy), retention is not
+// applied for that level -- the jinjos respawn so the jiggy can still be earned.
+//
+#include <libultraship/bridge.h>
+#include <libultraship/bridge/consolevariablebridge.h>
+
+#include "port/UI/cvar_prefixes.h"
+#include "port/ShipInit.hpp"
+#include "port/Enhancements/Events/PortEnhancements.h"
+#include "port/Enhancements/Events/Hooks/Events.h"
+#include "port/Enhancements/JinjoRetention/JinjoRetention.h"
+#include "port/Rando/Rando.h"
+
+extern "C" {
+#include "enums.h"
+#include "actor.h"
+#include "prop.h"
+#include "functions.h"
+}
+
+#define CVAR_JINJO_RETENTION CVAR_ENHANCEMENT("Gameplay.JinjoRetention")
+#define CVAR_VALUE CVarGetInteger(CVAR_JINJO_RETENTION, 0)
+
+constexpr u8 kAllJinjos = 0x1F; // all five color bits collected
+
+// gameFile_saveData index of the live save slot for the current game, or -1.
+int32_t activeSlot() {
+    if (selectedFileNum == DEFAULT_FILE_NUM || selectedFileNum < 0 || selectedFileNum >= 4) {
+        return -1;
+    }
+    return (int32_t)selectedFileNum;
+}
+
+// Don't run during demos, Bottles bonus games, or rando files.
+bool systemActive() {
+    int32_t slot = activeSlot();
+    if (slot < 0 || gameFile_saveData[slot].shipSaveData.fileType == FILE_TYPE_SAVE_RANDO) {
+        return false;
+    }
+    switch (getGameMode()) {
+        case GAME_MODE_7_ATTRACT_DEMO:
+        case GAME_MODE_8_BOTTLES_BONUS:
+        case GAME_MODE_9_BANJO_AND_KAZOOIE:
+        case GAME_MODE_A_SNS_PICTURE:
+            return false;
+        default:
+            return true;
+    }
+}
+
+bool applyEnabled() {
+    return CVarGetInteger(CVAR_JINJO_RETENTION, 0) != 0;
+}
+
+JinjoRetentionSaveData* store() {
+    int32_t slot = activeSlot();
+    return slot >= 0 ? &gameFile_saveData[slot].shipSaveData.jinjoRetention : nullptr;
+}
+
+bool levelInRange(int32_t level) {
+    return level > 0 && level < JINJO_RETENTION_LEVEL_SLOTS;
+}
+
+u8 collectedBits(int32_t level) {
+    JinjoRetentionSaveData* s = store();
+    return (s != nullptr && levelInRange(level)) ? s->collected[level] : 0;
+}
+
+u8 jinjoBitFromMarker(int32_t markerId) {
+    switch (markerId) {
+        case MARKER_5A_JINJO_BLUE:
+        case MARKER_5B_JINJO_GREEN:
+        case MARKER_5C_JINJO_ORANGE:
+        case MARKER_5D_JINJO_PINK:
+        case MARKER_5E_JINJO_YELLOW:
+            return (u8)(1 << ((markerId + 6) & 0x1F));
+        default:
+            return 0;
+    }
+}
+
+u8 jinjoBitFromActor(int32_t actorId) {
+    switch (actorId) {
+        case ACTOR_60_JINJO_BLUE:
+            return 1 << 0;
+        case ACTOR_62_JINJO_GREEN:
+            return 1 << 1;
+        case ACTOR_5F_JINJO_ORANGE:
+            return 1 << 2;
+        case ACTOR_61_JINJO_PINK:
+            return 1 << 3;
+        case ACTOR_5E_JINJO_YELLOW:
+            return 1 << 4;
+        default:
+            return 0;
+    }
+}
+
+// Whether retention should seed/suppress jinjos for this level. False when retention is
+// off, and false in the stranded-jiggy case so the jinjos respawn and the jiggy is still
+// earnable. Seeding and suppression both gate on this so ITEM_12_JINJOS stays consistent.
+bool retentionActiveForLevel(int32_t level) {
+    if (!applyEnabled() || !levelInRange(level)) {
+        return false;
+    }
+    if (collectedBits(level) == kAllJinjos && !jiggyscore_isCollected((enum jiggy_e)(10 * level - 9))) {
+        return false;
+    }
+    return true;
+}
+
+void RegisterJinjoRetention_Init() {
+    // Record collection. Don't cancel: vanilla still updates ITEM_12_JINJOS / spawns the
+    // jiggy and despawns the jinjo.
+    COND_HOOK(OnActorCollision, EVENT_PRIORITY_NORMAL, CVAR_VALUE, [](IEvent* event) {
+        OnActorCollision* ev = (OnActorCollision*)event;
+        if (!systemActive() || !ev->propId->markerFlag) {
+            return;
+        }
+        ActorMarker* marker = ev->propId->actorProp.marker;
+        if (marker == nullptr) {
+            return;
+        }
+        u8 bit = jinjoBitFromMarker(marker->id);
+        if (bit == 0) {
+            return;
+        }
+        int32_t level = level_get();
+        JinjoRetentionSaveData* s = store();
+        if (s != nullptr && levelInRange(level)) {
+            s->collected[level] |= bit;
+        }
+    });
+
+    // Seed ITEM_12_JINJOS from the saved bits so prior progress carries across visits and
+    // the HUD reflects it. Mirrors note retention's OnSetJiggyList seeding.
+    COND_HOOK(OnSetJiggyList, EVENT_PRIORITY_NORMAL, CVAR_VALUE, [](IEvent* event) {
+        OnSetJiggyList* ev = (OnSetJiggyList*)event;
+        if (!systemActive() || !retentionActiveForLevel(ev->levelId)) {
+            return;
+        }
+        u8 bits = collectedBits(ev->levelId);
+        if (bits != 0) {
+            item_set(ITEM_12_JINJOS, bits);
+        }
+    });
+
+    // Suppress respawning already-collected jinjos. OnActorSpawn is cancellable; returning
+    // a null result with Cancelled means no actor spawns.
+    COND_HOOK(OnActorSpawn, EVENT_PRIORITY_NORMAL, CVAR_VALUE, [](IEvent* event) {
+        OnActorSpawn* ev = (OnActorSpawn*)event;
+        if (!systemActive()) {
+            return;
+        }
+        u8 bit = jinjoBitFromActor(ev->actorId);
+        if (bit == 0) {
+            return;
+        }
+        int32_t level = level_get();
+        if (!retentionActiveForLevel(level) || !(collectedBits(level) & bit)) {
+            return;
+        }
+        ev->result = nullptr;
+        event->Cancelled = true;
+    });
+
+    // The engine's save double-buffers into a scratch slot via bcopy, which doesn't carry
+    // our bits. Sync the live slot's jinjoRetention into the buffer about to be serialized.
+    COND_HOOK(OnSaveFileSave, EVENT_PRIORITY_HIGH, CVAR_VALUE, [](IEvent* event) {
+        OnSaveFileSave* ev = (OnSaveFileSave*)event;
+        SaveData* buf = (SaveData*)ev->saveBuffer;
+        JinjoRetentionSaveData* live = store();
+        if (buf != nullptr && live != nullptr && &buf->shipSaveData.jinjoRetention != live) {
+            buf->shipSaveData.jinjoRetention = *live;
+        }
+    });
+}
+
+static RegisterShipInitFunc initJinjoRetention(RegisterJinjoRetention_Init, { CVAR_JINJO_RETENTION });

--- a/src/port/Enhancements/JinjoRetention/JinjoRetention.h
+++ b/src/port/Enhancements/JinjoRetention/JinjoRetention.h
@@ -1,0 +1,8 @@
+#ifndef PORT_JINJO_RETENTION_H
+#define PORT_JINJO_RETENTION_H
+
+// Jinjo Collection Retention is implemented entirely with port event listeners
+// (collection, level-load seeding, spawn suppression) and needs no engine-side hooks,
+// so this header only marks the module's presence for consistency with NoteRetention.
+
+#endif

--- a/src/port/Enhancements/NoteRetention/NoteRetention.cpp
+++ b/src/port/Enhancements/NoteRetention/NoteRetention.cpp
@@ -1,0 +1,425 @@
+// Note Collection Retention
+//
+// Persists which individual music notes the player has collected so they don't respawn
+// on revisit. Works for vanilla and romhacks because each note is identified
+// by (mapId, spawn-order index) within the map's deterministic cube-prop parse.
+//
+// How it works:
+//   - Static note sprite-props are replaced with ACTOR_51_MUSIC_NOTE actors so a
+//     stable spawn-order index can be attached to each via ObjectExtension.
+//   - Dynamically-spawned note bundles (hut/switch triggers) are also replaced with
+//     our own actors, given indices that continue AFTER the static notes for the map.
+//     Their identity resides in actor->local (not ObjectExtension) because bundle notes
+//     persist across sub-area save/restore, which copies the actor struct but assigns
+//     a fresh marker, so a marker-keyed extension wouldn't survive.
+//   - Saving is ALWAYS ON: collecting a note records (mapId, index) to the save.
+//   - Application is behind an enhancement toggle (default off): when on, already
+//     collected notes are not respawned, and ITEM_C_NOTE is seeded on level load
+//     from the collected count so totals stay reachable. Note-door logic is left
+//     to the vanilla per-level high score, unchanged.
+//
+#include "port/ObjectExtension/ObjectExtension.h"
+#include <libultraship/bridge.h>
+#include <libultraship/bridge/consolevariablebridge.h>
+
+#include "port/UI/cvar_prefixes.h"
+#include "port/ShipInit.hpp"
+#include "port/Enhancements/Events/PortEnhancements.h"
+#include "port/Enhancements/Events/Hooks/Events.h"
+#include "port/Enhancements/NoteRetention/NoteRetention.h"
+#include "port/Rando/Rando.h"
+#include "port/Rando/CustomObject/CustomObject.h"
+
+#include <vector>
+#include <unordered_map>
+
+extern "C" {
+#include "enums.h"
+#include "actor.h"
+#include "prop.h"
+#include "functions.h"
+
+extern f32 gBundle_yaw;
+extern ActorInfo sumusicNote;
+}
+
+namespace {
+
+#define CVAR_NOTE_RETENTION CVAR_ENHANCEMENT("Gameplay.NoteRetention")
+#define CVAR_VALUE CVarGetInteger(CVAR_NOTE_RETENTION, 0)
+
+// The note sprite asset id passed through VB_OVERRIDE_PROP_SPAWN identifies notes.
+constexpr s32 kNoteSpriteAsset = ASSET_6D6_SPRITE_MUSIC_NOTE;
+
+// Per-actor note identity, attached via ObjectExtension. The constructor lets us
+// build instances with parentheses, since brace-init commas break the event macros.
+struct NoteRetentionData {
+    int32_t mapId;
+    int32_t noteIndex;
+    NoteRetentionData(int32_t map = 0, int32_t index = 0) : mapId(map), noteIndex(index) {
+    }
+};
+ObjectExtension::Register<NoteRetentionData> NoteRetentionDataRegister;
+
+// Identity for bundle notes, stored in the actor's local data block. Unlike static
+// notes, bundle notes are restored across sub-area transitions by the engine's actor
+// save-state, which memcpy's the whole Actor struct (so local survives) but assigns
+// a new marker (so an extension wouldn't).
+// magic distinguishes our data from the uninitialized garbage actor_new leaves
+// in local, and from notes we didn't spawn.
+constexpr uint32_t kNoteLocalMagic = 0x4E4F5445u; // 'NOTE'
+struct NoteLocal {
+    uint32_t magic;
+    int32_t mapId;
+    int32_t noteIndex;
+};
+
+NoteLocal* bundleNoteLocal(Actor* actor) {
+    if (actor == nullptr) {
+        return nullptr;
+    }
+    NoteLocal* nl = reinterpret_cast<NoteLocal*>(actor->local);
+    return (nl->magic == kNoteLocalMagic) ? nl : nullptr;
+}
+
+struct QueuedNote {
+    int32_t pos[3];
+    int32_t mapId;
+    int32_t noteIndex;
+    bool spawned;
+};
+
+int32_t noteCounter = 0;
+std::vector<QueuedNote> noteActorQueue;
+std::unordered_map<int64_t, ActorMarker*> activeNoteSet;
+
+int64_t noteKey(int32_t mapId, int32_t noteIndex) {
+    return ((int64_t)mapId << 32) | (uint32_t)noteIndex;
+}
+
+// Active slot is wobbly
+int32_t activeSlot() {
+    if (selectedFileNum == DEFAULT_FILE_NUM || selectedFileNum < 0 || selectedFileNum >= 4) {
+        return -1;
+    }
+    return (int32_t)selectedFileNum;
+}
+
+bool fileValid() {
+    return activeSlot() >= 0;
+}
+
+// Don't run during demos, Bottles bonus games, or rando files
+bool systemActive() {
+    int32_t slot = activeSlot();
+    if (slot < 0 || gameFile_saveData[slot].shipSaveData.fileType == FILE_TYPE_SAVE_RANDO) {
+        return false;
+    }
+    switch (getGameMode()) {
+        case GAME_MODE_7_ATTRACT_DEMO:
+        case GAME_MODE_8_BOTTLES_BONUS:
+        case GAME_MODE_9_BANJO_AND_KAZOOIE:
+        case GAME_MODE_A_SNS_PICTURE:
+            return false;
+        default:
+            return true;
+    }
+}
+
+bool applyEnabled() {
+    return CVarGetInteger(CVAR_NOTE_RETENTION, 0) != 0;
+}
+
+NoteRetentionSaveData* store() {
+    int32_t slot = activeSlot();
+    return slot >= 0 ? &gameFile_saveData[slot].shipSaveData.noteRetention : nullptr;
+}
+
+bool indexInRange(int32_t mapId, int32_t index) {
+    return mapId >= 0 && mapId < NOTE_RETENTION_MAP_SLOTS && index >= 0 && index < NOTE_RETENTION_NOTES_PER_MAP;
+}
+
+bool isCollected(int32_t mapId, int32_t index) {
+    NoteRetentionSaveData* s = store();
+    if (s == nullptr || !indexInRange(mapId, index)) {
+        return false;
+    }
+    return (s->collected[mapId][index >> 3] >> (index & 7)) & 1;
+}
+
+void setCollected(int32_t mapId, int32_t index) {
+    NoteRetentionSaveData* s = store();
+    if (s == nullptr || !indexInRange(mapId, index)) {
+        return;
+    }
+    s->collected[mapId][index >> 3] |= (uint8_t)(1 << (index & 7));
+}
+
+int32_t countCollectedForLevel(int32_t levelId) {
+    NoteRetentionSaveData* s = store();
+    if (s == nullptr) {
+        return 0;
+    }
+    int32_t total = 0;
+    for (int32_t mapId = 0; mapId < NOTE_RETENTION_MAP_SLOTS; mapId++) {
+        // Count this map's collected bits first; only real maps that have been
+        // played ever get bits set. Skipping empties keeps us from calling
+        // map_getLevel on non-existent map ids (e.g. MAP_0_UNKNOWN), which crashes.
+        int32_t mapTotal = 0;
+        for (int32_t b = 0; b < NOTE_RETENTION_BYTES_PER_MAP; b++) {
+            uint8_t byte = s->collected[mapId][b];
+            while (byte) {
+                mapTotal += byte & 1;
+                byte >>= 1;
+            }
+        }
+        if (mapTotal == 0) {
+            continue;
+        }
+        if (map_getLevel((enum map_e)mapId) == (enum level_e)levelId) {
+            total += mapTotal;
+        }
+    }
+    return total;
+}
+
+} // namespace
+
+// Called from gsworld_load (the single entry that parses a map's cubes) before any
+// cube is read. This is the reliable once-per-parse-pass signal -- it fires on every
+// map load AND on intra-level warps/sub-area transitions that re-parse the cubes,
+// even when OnMapLoad doesn't. Resetting the counter here keeps spawn-order indices
+// stable across re-parses. The live-actor set is NOT cleared here: our note actors
+// persist across map changes (they're only torn down by actorArray_free), so the set
+// must persist too, or returning to a map would duplicate its still-live notes.
+extern "C" void port_noteRetention_beginMapLoad(int32_t mapId) {
+    (void)mapId;
+    noteCounter = 0;
+    noteActorQueue.clear();
+}
+
+// Called from actorArray_free. At this point every note actor is gone, so drop the
+// live-actor set and detach the ObjectExtension data.
+extern "C" void port_noteRetention_onActorsFreed(void) {
+    for (auto& [key, marker] : activeNoteSet) {
+        ObjectExtension::GetInstance().Remove<NoteRetentionData>(marker);
+    }
+    activeNoteSet.clear();
+    noteActorQueue.clear();
+}
+
+void RegisterNoteRetention_Init() {
+    COND_VB_SHOULD(VB_OVERRIDE_PROP_SPAWN, EVENT_PRIORITY_NORMAL, true, {
+        s16* spawnPosition = va_arg(args, s16*);
+        s32 spriteAsset = va_arg(args, s32);
+
+        if (!systemActive() || spriteAsset != kNoteSpriteAsset) {
+            return;
+        }
+
+        int32_t mapId = (int32_t)gsworld_getMap();
+        int32_t noteIndex = noteCounter++;
+        if (!indexInRange(mapId, noteIndex)) {
+            return; // out of addressable range: leave as a vanilla sprite prop
+        }
+
+        // From here we own this note: suppress the static sprite prop.
+        *should = true;
+
+        if (activeNoteSet.count(noteKey(mapId, noteIndex))) {
+            return; // a live actor already exists (re-parse): don't duplicate it
+        }
+
+        if (applyEnabled() && isCollected(mapId, noteIndex)) {
+            return; // already collected and retention on: don't respawn it
+        }
+
+        QueuedNote queued;
+        queued.pos[0] = spawnPosition[0];
+        queued.pos[1] = spawnPosition[1];
+        queued.pos[2] = spawnPosition[2];
+        queued.mapId = mapId;
+        queued.noteIndex = noteIndex;
+        queued.spawned = false;
+        noteActorQueue.push_back(queued);
+    });
+
+    // Flush queued notes into actors. actor_new does not re-fire OnActorSpawn, so no recursion.
+    COND_HOOK(OnActorSpawn, EVENT_PRIORITY_NORMAL, CVAR_VALUE, [](IEvent* event) {
+        if (!systemActive() || noteActorQueue.empty()) {
+            return;
+        }
+        for (auto& q : noteActorQueue) {
+            if (q.spawned) {
+                continue;
+            }
+            int32_t pos[3];
+            pos[0] = q.pos[0];
+            pos[1] = q.pos[1];
+            pos[2] = q.pos[2];
+            Actor* note = actor_new(pos, 0, &sumusicNote, ACTOR_FLAG_UNKNOWN_21);
+            ActorMarker* marker = (note != nullptr) ? note->marker : nullptr;
+            if (marker != nullptr) {
+                // Key on the marker (stable across the actor's life and what the collision event hands us).
+                ObjectExtension::GetInstance().Set<NoteRetentionData>(marker, NoteRetentionData(q.mapId, q.noteIndex));
+                activeNoteSet[noteKey(q.mapId, q.noteIndex)] = marker;
+            }
+            q.spawned = true;
+        }
+    });
+
+    // Note bundles get spawn-order indices that continue after the map's static
+    // note count. We override the vanilla bundle spawn to substitute our own actor (carrying
+    // identity in local) and re-apply the vanilla fly-out physics. Detection is by the
+    // bundle's spawned actor type, so it stays romhack-agnostic.
+    COND_VB_SHOULD(VB_OVERRIDE_BUNDLE_SPAWN, EVENT_PRIORITY_NORMAL, true, {
+        bundle_e bundleId = (bundle_e)va_arg(args, int);
+        BundleInfo* bundleInfo = va_arg(args, BundleInfo*);
+        va_arg(args, s32); // index within the bundle (unused: we use our own counter)
+        f32* position = va_arg(args, f32*);
+        Actor** actorOut = va_arg(args, Actor**);
+
+        if (!systemActive() || bundleInfo == nullptr || bundleInfo->actor_id != ACTOR_51_MUSIC_NOTE) {
+            return; // not our note bundle: leave it to vanilla (or rando)
+        }
+
+        int32_t mapId = (int32_t)gsworld_getMap();
+        int32_t noteIndex = noteCounter++;
+        if (!indexInRange(mapId, noteIndex)) {
+            return; // out of addressable range: let vanilla spawn it normally
+        }
+
+        // From here we own this note: suppress the vanilla bundle spawn.
+        *should = true;
+
+        int64_t key = noteKey(mapId, noteIndex);
+        if (activeNoteSet.count(key)) {
+            return; // a live actor already exists (re-trigger this load): don't duplicate
+        }
+        if (applyEnabled() && isCollected(mapId, noteIndex)) {
+            return; // already collected and retention on: don't respawn it
+        }
+
+        int32_t pos[3];
+        pos[0] = (int32_t)position[0];
+        pos[1] = (int32_t)position[1];
+        pos[2] = (int32_t)position[2];
+        Actor* note = actor_new(pos, 0, &sumusicNote, ACTOR_FLAG_UNKNOWN_21);
+        if (note == nullptr) {
+            return;
+        }
+        NoteLocal* nl = reinterpret_cast<NoteLocal*>(note->local);
+        nl->magic = kNoteLocalMagic;
+        nl->mapId = mapId;
+        nl->noteIndex = noteIndex;
+
+        ApplyBundleActorPhysics(note, (int32_t)bundleId, bundleInfo, gBundle_yaw);
+
+        activeNoteSet[key] = note->marker;
+        *actorOut = note;
+    });
+
+    // Prevent restoration from save states, as actors get re-added by the cubeprop parse.
+    COND_HOOK(OnLoadActorSaveState, EVENT_PRIORITY_NORMAL, CVAR_VALUE, [](IEvent* event) {
+        OnLoadActorSaveState* ev = (OnLoadActorSaveState*)event;
+        if (!systemActive() || ev->actor == nullptr) {
+            return;
+        }
+        if ((int32_t)ev->actor->modelCacheIndex != ACTOR_51_MUSIC_NOTE) {
+            return;
+        }
+        if (ev->actor->is_bundle && bundleNoteLocal(ev->actor) != nullptr) {
+            return; // keep restored bundle notes alive
+        }
+        event->Cancelled = true;
+    });
+
+    // Record collection. Don't cancel: vanilla still increments ITEM_C_NOTE and despawns.
+    COND_HOOK(OnActorCollision, EVENT_PRIORITY_NORMAL, CVAR_VALUE, [](IEvent* event) {
+        OnActorCollision* ev = (OnActorCollision*)event;
+        if (!systemActive() || !ev->propId->markerFlag) {
+            return;
+        }
+        ActorMarker* marker = ev->propId->actorProp.marker;
+        if (marker == nullptr || marker->id != MARKER_5F_MUSIC_NOTE) {
+            return;
+        }
+        int32_t mapId;
+        int32_t noteIndex;
+        NoteRetentionData* data = ObjectExtension::GetInstance().Get<NoteRetentionData>(marker);
+        if (data != nullptr) {
+            mapId = data->mapId;
+            noteIndex = data->noteIndex;
+            ObjectExtension::GetInstance().Remove<NoteRetentionData>(marker);
+        } else if (NoteLocal* nl = bundleNoteLocal(marker_getActor(marker))) {
+            mapId = nl->mapId;
+            noteIndex = nl->noteIndex;
+            nl->magic = 0; // consumed
+        } else {
+            return; // not one of ours
+        }
+        setCollected(mapId, noteIndex);
+        activeNoteSet.erase(noteKey(mapId, noteIndex));
+    });
+
+    // Seed the level's note counter from collected notes so totals stay reachable.
+    COND_HOOK(OnSetJiggyList, EVENT_PRIORITY_NORMAL, CVAR_VALUE, [](IEvent* event) {
+        OnSetJiggyList* ev = (OnSetJiggyList*)event;
+        if (!systemActive() || !applyEnabled()) {
+            return;
+        }
+        item_set(ITEM_C_NOTE, countCollectedForLevel(ev->levelId));
+    });
+
+    // With retention applied, the vanilla note-score messages become misleading or fire
+    // spuriously (seeding ITEM_C_NOTE on load re-triggers the high-score milestones), so
+    // suppress them while the CVar is on.
+    COND_VB_SHOULD(VB_OVERRIDE_DIALOG_SHOW, EVENT_PRIORITY_NORMAL, true, {
+        s32 textId = va_arg(args, s32);
+        if (!applyEnabled()) {
+            return;
+        }
+        switch (textId) {
+            case 0xD9C: // Bottles' first-note text: "you can't take notes with you"
+            case 0xF76: // "you just beat your high score"
+            case 0xF74: // milestone: 50 notes (Mumbo's Mountain)
+                *should = true;
+                break;
+            default:
+                break;
+        }
+    });
+
+    // Clean up per-marker data when actors are destroyed (marker pointers get reused).
+    COND_HOOK(OnActorDestroy, EVENT_PRIORITY_NORMAL, CVAR_VALUE, [](IEvent* event) {
+        OnActorDestroy* ev = (OnActorDestroy*)event;
+        if (ev->actor == nullptr) {
+            return;
+        }
+        if (ev->actor->marker != nullptr) {
+            NoteRetentionData* data = ObjectExtension::GetInstance().Get<NoteRetentionData>(ev->actor->marker);
+            if (data != nullptr) {
+                activeNoteSet.erase(noteKey(data->mapId, data->noteIndex));
+            }
+            ObjectExtension::GetInstance().Remove<NoteRetentionData>(ev->actor->marker);
+        }
+        if (NoteLocal* nl = bundleNoteLocal(ev->actor)) {
+            activeNoteSet.erase(noteKey(nl->mapId, nl->noteIndex));
+            nl->magic = 0;
+        }
+    });
+
+    // The engine's save double-buffers into a scratch slot via bcopy, which doesn't
+    // reliably carry our note bits. Sync the live active slot's noteRetention into the
+    // buffer about to be serialized.
+    COND_HOOK(OnSaveFileSave, EVENT_PRIORITY_HIGH, CVAR_VALUE, [](IEvent* event) {
+        OnSaveFileSave* ev = (OnSaveFileSave*)event;
+        SaveData* buf = (SaveData*)ev->saveBuffer;
+        NoteRetentionSaveData* live = store();
+        if (buf != nullptr && live != nullptr && &buf->shipSaveData.noteRetention != live) {
+            buf->shipSaveData.noteRetention = *live;
+        }
+    });
+}
+
+static RegisterShipInitFunc initNoteRetention(RegisterNoteRetention_Init);

--- a/src/port/Enhancements/NoteRetention/NoteRetention.h
+++ b/src/port/Enhancements/NoteRetention/NoteRetention.h
@@ -1,0 +1,17 @@
+#ifndef PORT_NOTE_RETENTION_H
+#define PORT_NOTE_RETENTION_H
+
+#include <stdint.h>
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+void port_noteRetention_beginMapLoad(int32_t mapId);
+void port_noteRetention_onActorsFreed(void);
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif

--- a/src/port/Rando/ObjectBehavior/Molehill.cpp
+++ b/src/port/Rando/ObjectBehavior/Molehill.cpp
@@ -173,7 +173,7 @@ void Rando::ObjectBehavior::InitMolehillBehavior() {
 
     COND_VB_SHOULD(VB_OVERRIDE_BOTTLES_TEXT_CALLBACK, EVENT_PRIORITY_NORMAL, true, {
         Actor* molehillActor = va_arg(args, Actor*);
-        
+
         if (!IS_RANDO && !OPTION_ENABLED) {
             return;
         }
@@ -190,7 +190,7 @@ void Rando::ObjectBehavior::InitMolehillBehavior() {
         if (!IS_RANDO && !OPTION_ENABLED) {
             return;
         }
-        
+
         if (CheckBridgeState()) {
             *should = true;
         }

--- a/src/port/Rando/ObjectBehavior/ObjectBehavior.cpp
+++ b/src/port/Rando/ObjectBehavior/ObjectBehavior.cpp
@@ -413,7 +413,6 @@ void Rando::ObjectBehavior::Init() {
         if (ev->result != NULL) {
             event->Cancelled = true;
         }
-        
     })
 
     REGISTER_LISTENER(OnActorTick, EVENT_PRIORITY_NORMAL, [](IEvent* event) {

--- a/src/port/Rando/ObjectBehavior/Switch.cpp
+++ b/src/port/Rando/ObjectBehavior/Switch.cpp
@@ -18,12 +18,12 @@ void actor_collisionOff(Actor*);
 #define OPTION_ENABLED RANDO_SAVE_OPTIONS[RO_SHUFFLE_JIGGIES].optionValue
 
 void Rando::ObjectBehavior::ModifySwitchBehavior(int32_t switchActorId) {
-	if (!IS_RANDO && !OPTION_ENABLED) {
-		return;
-	}
-    
+    if (!IS_RANDO && !OPTION_ENABLED) {
+        return;
+    }
+
     RandoCheckId randoCheckId = RC_UNKNOWN;
-	
+
     if (item_getCount(ITEM_0_HOURGLASS_TIMER) == 0) {
         switch (switchActorId) {
             case ACTOR_14E_BGS_ELEVATED_WALKWAY_SWITCH:

--- a/src/port/Save/SaveManager.cpp
+++ b/src/port/Save/SaveManager.cpp
@@ -298,6 +298,37 @@ ordered_json Convert_SaveDataToJSON(SaveData* saveData, int32_t fileNum) {
 
     ship["fileType"] = static_cast<int>(saveData->shipSaveData.fileType);
 
+    // Note retention (all files): sparse per-map collected bitfields.
+    ordered_json noteRetention = ordered_json::object();
+    for (int m = 0; m < NOTE_RETENTION_MAP_SLOTS; m++) {
+        bool any = false;
+        for (int b = 0; b < NOTE_RETENTION_BYTES_PER_MAP; b++) {
+            if (saveData->shipSaveData.noteRetention.collected[m][b]) {
+                any = true;
+                break;
+            }
+        }
+        if (!any) {
+            continue;
+        }
+        ordered_json bytes = ordered_json::array();
+        for (int b = 0; b < NOTE_RETENTION_BYTES_PER_MAP; b++) {
+            bytes.push_back(saveData->shipSaveData.noteRetention.collected[m][b]);
+        }
+        noteRetention[std::to_string(m)] = bytes;
+    }
+    ship["noteRetention"] = noteRetention;
+
+    // Jinjo retention (all files): sparse per-level collected colour bitmasks.
+    ordered_json jinjoRetention = ordered_json::object();
+    for (int l = 0; l < JINJO_RETENTION_LEVEL_SLOTS; l++) {
+        if (!saveData->shipSaveData.jinjoRetention.collected[l]) {
+            continue;
+        }
+        jinjoRetention[std::to_string(l)] = saveData->shipSaveData.jinjoRetention.collected[l];
+    }
+    ship["jinjoRetention"] = jinjoRetention;
+
     if (saveData->shipSaveData.fileType == FILE_TYPE_SAVE_RANDO) {
         Rando::Logic::GenerateSaveData(saveData);
         shipRando["seedId"] = saveData->shipSaveData.randoSaveData.seedId;
@@ -519,6 +550,38 @@ SaveData* Convert_JSONToSaveData(int32_t fileNum) {
 
     // Ship Save Data
     saveData->shipSaveData.fileType = j["ship"]["fileType"];
+
+    // Note retention (all files): clear then load sparse per-map bitfields.
+    for (int m = 0; m < NOTE_RETENTION_MAP_SLOTS; m++) {
+        for (int b = 0; b < NOTE_RETENTION_BYTES_PER_MAP; b++) {
+            saveData->shipSaveData.noteRetention.collected[m][b] = 0;
+        }
+    }
+    if (j.contains("ship") && j["ship"].contains("noteRetention")) {
+        for (auto& [key, bytes] : j["ship"]["noteRetention"].items()) {
+            int m = std::stoi(key);
+            if (m < 0 || m >= NOTE_RETENTION_MAP_SLOTS) {
+                continue;
+            }
+            for (int b = 0; b < NOTE_RETENTION_BYTES_PER_MAP && b < (int)bytes.size(); b++) {
+                saveData->shipSaveData.noteRetention.collected[m][b] = bytes[b].get<uint8_t>();
+            }
+        }
+    }
+
+    // Jinjo retention (all files): clear then load sparse per-level bitmasks.
+    for (int l = 0; l < JINJO_RETENTION_LEVEL_SLOTS; l++) {
+        saveData->shipSaveData.jinjoRetention.collected[l] = 0;
+    }
+    if (j.contains("ship") && j["ship"].contains("jinjoRetention")) {
+        for (auto& [key, bits] : j["ship"]["jinjoRetention"].items()) {
+            int l = std::stoi(key);
+            if (l < 0 || l >= JINJO_RETENTION_LEVEL_SLOTS) {
+                continue;
+            }
+            saveData->shipSaveData.jinjoRetention.collected[l] = bits.get<uint8_t>();
+        }
+    }
 
     if (j["ship"]["fileType"].get<int>() == FILE_TYPE_SAVE_RANDO) {
         json rando = j["ship"]["rando"];

--- a/src/port/ShipUtils.cpp
+++ b/src/port/ShipUtils.cpp
@@ -30,11 +30,11 @@ std::vector<std::string> worldNameList = {
     "Rusty Bucket Bay", "Mad Monster Mansion", "Spiral Mountain",
 };
 
-std::vector<std::string> abilityNameList = {
-    "Beak Barge",    "Beak Bomb", "Beak Buster", "Camera Control", "Claw Swipe",  "Climb", "Eggs",
-    "Feathery Flap", "Flap Flip", "Flight",      "Jump Higher",    "Ratatat Rap", "Roll",  "Shock Jump",
-    "Wading Boots",  "Dive",      "Talon Trot",  "Turbo Talon",    "Wonderwing",  "Note Door"
-};
+std::vector<std::string> abilityNameList = { "Beak Barge", "Beak Bomb",   "Beak Buster",  "Camera Control",
+                                             "Claw Swipe", "Climb",       "Eggs",         "Feathery Flap",
+                                             "Flap Flip",  "Flight",      "Jump Higher",  "Ratatat Rap",
+                                             "Roll",       "Shock Jump",  "Wading Boots", "Dive",
+                                             "Talon Trot", "Turbo Talon", "Wonderwing",   "Note Door" };
 
 // Helper for C-style variadic log functions
 static void bk_log_vfmt(spdlog::level::level_enum level, const char* fmt, va_list args) {

--- a/src/port/UI/DeveloperTools/GameplayTools.cpp
+++ b/src/port/UI/DeveloperTools/GameplayTools.cpp
@@ -315,9 +315,9 @@ void GameplayTools_ObjectSpawner() {
         for (auto& [jinjoId, jinjoData] : jinjoDataMap) {
             bool isChecked = std::get<2>(jinjoData);
             if (UIWidgets::Checkbox(std::get<0>(jinjoData), &isChecked,
-                UIWidgets::CheckboxOptions()
-                .Color(std::get<1>(jinjoData))
-                .LabelPosition(UIWidgets::LabelPositions::None))) {
+                                    UIWidgets::CheckboxOptions()
+                                        .Color(std::get<1>(jinjoData))
+                                        .LabelPosition(UIWidgets::LabelPositions::None))) {
                 GameplayTools_UpdateJinjoCheckboxes(jinjoId);
             }
             ImGui::SameLine();
@@ -336,14 +336,14 @@ void GameplayTools_ObjectSpawner() {
         jiggyText += ": " + std::to_string(selectedJiggy);
 
         UIWidgets::SliderInt("##jiggyIndex", &selectedJiggy,
-                                 UIWidgets::IntSliderOptions()
-                                     .Color(THEME_COLOR)
-                                     .Min(JIGGY_01_MM_JINJO)
-                                     .Max(JIGGY_64_MMM_LOGGO)
-                                     .DefaultValue(JIGGY_01_MM_JINJO)
-                                     .Format(jiggyText.c_str())
-                                     .LabelPosition(UIWidgets::LabelPositions::None));
-        
+                             UIWidgets::IntSliderOptions()
+                                 .Color(THEME_COLOR)
+                                 .Min(JIGGY_01_MM_JINJO)
+                                 .Max(JIGGY_64_MMM_LOGGO)
+                                 .DefaultValue(JIGGY_01_MM_JINJO)
+                                 .Format(jiggyText.c_str())
+                                 .LabelPosition(UIWidgets::LabelPositions::None));
+
         ImGui::TableNextColumn();
         if (UIWidgets::Button("Spawn Honeycomb", { .color = THEME_COLOR })) {
             Actor* newActor = actor_new(spawnPosition, 0, &actorInfoMap.at(ACTOR_47_EMPTY_HONEYCOMB).first,
@@ -467,7 +467,7 @@ void DrawMonitoringTools() {
                     ImGui::TableNextColumn();
                     ImGui::PopID();
                 }
-                
+
                 mapIndex++;
             }
             ImGui::EndTable();
@@ -483,7 +483,7 @@ void DrawRandoFlagEditor() {
             ImGui::PushID(f);
             bool flagState = RANDO_SAVE_FLAGS[f].flagState;
             if (UIWidgets::Checkbox(Rando::StaticData::Flags[(RandoInf)f].name, &flagState)) {
-                    CALL_EVENT(SetRandoInfFlag, (RandoInf)f, !RANDO_SAVE_FLAGS[f].flagState);
+                CALL_EVENT(SetRandoInfFlag, (RandoInf)f, !RANDO_SAVE_FLAGS[f].flagState);
             }
             ImGui::PopID();
         }

--- a/src/port/UI/DeveloperTools/Warps.cpp
+++ b/src/port/UI/DeveloperTools/Warps.cpp
@@ -62,7 +62,7 @@ static const std::vector<CuratedWarp> curatedWarps = {
 
 static int32_t curatedWarpId = 0;
 
-void DrawWarpList() {
+static void DrawWarpList() {
     ImGui::SeparatorText("Custom Warp Selector");
     UIWidgets::Combobox("Map Select", &mapId, mapNames, { .color = THEME_COLOR });
     UIWidgets::SliderInt("Exit ID", &exitId,

--- a/src/port/UI/LighthouseGui.cpp
+++ b/src/port/UI/LighthouseGui.cpp
@@ -126,7 +126,8 @@ void SetupGuiElements() {
     mWarpsWindow = std::make_shared<WarpsWindow>("gWindows.Warps", "Warps", ImVec2(480, 600));
     gui->AddGuiWindow(mWarpsWindow);
 
-    mGameplayToolsWindow = std::make_shared<GameplayToolsWindow>("gWindows.GameplayTools", "Gameplay Tools", ImVec2(480, 600));
+    mGameplayToolsWindow =
+        std::make_shared<GameplayToolsWindow>("gWindows.GameplayTools", "Gameplay Tools", ImVec2(480, 600));
     gui->AddGuiWindow(mGameplayToolsWindow);
 
     // mHudEditorWindow = std::make_shared<HudEditorWindow>("gWindows.HudEditor", "HUD Editor", ImVec2(480, 600));

--- a/src/port/UI/LighthouseMenuEnhancements.cpp
+++ b/src/port/UI/LighthouseMenuEnhancements.cpp
@@ -292,6 +292,23 @@ void LighthouseMenu::AddMenuEnhancements() {
         .Options(CheckboxOptions().Tooltip(
             "Hold A+B while underwater to combine Banjo's kick with Kazooie's wing stroke for faster swimming."));
 
+    AddWidget(path, "Note Collection Retention", WIDGET_CVAR_CHECKBOX)
+        .CVar(CVAR_ENHANCEMENT("Gameplay.NoteRetention"))
+        .RaceDisable(false)
+        .Options(CheckboxOptions().Tooltip(
+            "Notes you've already collected stay collected and don't respawn when you revisit a level. "
+            "Collection is always tracked; this toggle controls whether collected notes are skipped on "
+            "load. Note-door totals still use the vanilla per-level high score."));
+
+    AddWidget(path, "Jinjo Collection Retention", WIDGET_CVAR_CHECKBOX)
+        .CVar(CVAR_ENHANCEMENT("Gameplay.JinjoRetention"))
+        .RaceDisable(false)
+        .Options(CheckboxOptions().Tooltip(
+            "Jinjos you've already collected stay collected across visits instead of resetting each time "
+            "you enter a level, so you no longer need all five in one go. Collection is always tracked; "
+            "this toggle controls whether collected jinjos are skipped on load and your progress is "
+            "restored."));
+
     // Enhancements -> Saving
     path = { "Enhancements", "Saving", SECTION_COLUMN_1 };
     AddSidebarEntry("Enhancements", path.sidebarName, 1);

--- a/src/port/enhancements/events/hooks/list/GameEvent.h
+++ b/src/port/enhancements/events/hooks/list/GameEvent.h
@@ -7,7 +7,7 @@ DEFINE_EVENT(OnGameSave, int32_t fileNum;)
 DEFINE_EVENT(OnGameLoad, int32_t fileNum;)
 DEFINE_EVENT(OnPropInit, Prop* propPtr;);
 DEFINE_EVENT(OnSaveFileLoad, int32_t fileNum; void* saveBuffer; int32_t result;)
-DEFINE_EVENT(OnSaveFileSave, void* saveBuffer; int32_t fileNum; int32_t* result;)
+DEFINE_EVENT(OnSaveFileSave, void* saveBuffer; int32_t fileNum; int32_t * result;)
 // Identifies which warp_* dispatcher is firing OnWarpResolveDest. Keep values
 // stable so listener case statements keep matching across refactors.
 typedef enum WarpId {
@@ -15,4 +15,4 @@ typedef enum WarpId {
     WARP_ID_LAIR_ENTER_MM_LOBBY_FROM_SM_LEVEL = 2,
 } WarpId;
 
-DEFINE_EVENT(OnWarpResolveDest, int32_t warpId; int32_t defaultDest; int32_t bkcfOverride; int32_t* dest;);
+DEFINE_EVENT(OnWarpResolveDest, int32_t warpId; int32_t defaultDest; int32_t bkcfOverride; int32_t * dest;);


### PR DESCRIPTION
Adds full note and jinjo retention. Recording is always active, enhancement gates loading functionality.

Also fixes a bug with the `VB_UPDATE_JINJO_HUD` event where the handling changed but the default didn't. Don't know the ramifications on rando for it, but HUD and final colleciton/jiggy spawn weren't working in vanilla.

There was also a multiple definition error for a function having to do with warps between the two implementations.