### PR TITLE
Free-run the audio worker; native-rate demo pacing

### DIFF
--- a/src/core1/audio_instruments.c
+++ b/src/core1/audio_instruments.c
@@ -10,6 +10,7 @@
 #include "version.h"
 
 #include <libultra/exception.h>
+#include "port/Patches/Patches.h"
 
 extern void func_8025F570(ALCSPlayer *, u8);
 extern void func_8025F510(ALCSPlayer *, u8, u8);
@@ -310,6 +311,10 @@ void func_8024F83C(void){
 
 void func_8024F890(u8 arg0, s32 arg1){
     s32 i;
+    // [port] This function directly mutates the sequence player's target (n_alCSeqNew) and
+    // chanMask while the free-running audio worker reads them in n_alAudioFrame. Unlike
+    // the rest of the audio code, it has no osSetIntMask bracket. Guard it with the audio lock.
+    port_lockAudio();
     if(arg1 == -1){
         if(arg1 != D_80281720[arg0].index) {
             alCSPStop(&D_80281720[arg0].cseqp);
@@ -342,6 +347,7 @@ void func_8024F890(u8 arg0, s32 arg1){
             func_8025F3F0(&D_80281720[arg0].cseqp, D_80281720[arg0].unk17C, D_80281720[arg0].unk180);
         }
     }
+    port_unlockAudio();
 }
 
 s32 func_8024FA6C(u8 arg0){

--- a/src/core1/audio_instruments.c
+++ b/src/core1/audio_instruments.c
@@ -291,15 +291,19 @@ void func_8024F764(s32 arg0){//music track load
 
 void func_8024F7C4(s32 arg0){
     s32 i;
+    port_lockAudio();
     if(D_802820E0[arg0] != NULL){
         i = 0;
         for(i = 0; i != 6; i++){
-            if(D_80281720[i].index == arg0)
+            if(D_80281720[i].index == arg0){
+                port_unlockAudio();
                 return;
+            }
         }
         assetcache_release(D_802820E0[arg0]);
         D_802820E0[arg0] = 0;
     }
+    port_unlockAudio();
 }
 
 void func_8024F83C(void){

--- a/src/core2/gameloop.c
+++ b/src/core2/gameloop.c
@@ -549,6 +549,9 @@ bool func_802E4424(void) {
                 return false;
 
             case 6:                                     /* switch 1 */
+                // [port] Hold audio across the attract-demo load so its jingle starts fresh once
+                // the demo is on screen instead of playing (and drifting) through the cold freeze.
+                port_beginDemoAudioHold();
                 func_8034B8C0(D_8037E8E0.map, D_8037E8E0.exit);
                 func_802E3E7C(GAME_MODE_7_ATTRACT_DEMO);
                 return false;

--- a/src/port/Audio/AudioSync.cpp
+++ b/src/port/Audio/AudioSync.cpp
@@ -1,0 +1,50 @@
+// [port] Audio engine synchronization: a single recursive lock serializing the free-running
+// audio worker (GameEngine::HandleAudioThread, advancing the synth in n_alAudioFrame) against the
+// game thread's SFX/music writes.
+//
+// osSetIntMask lives here, not with the libultra OS stubs, because in this port it's no longer an
+// interrupt primitive — its only callers are the N64 audio files, which bracket every
+// thread-shared section with osSetIntMask(OS_IM_NONE)/restore. Routing those brackets to this
+// lock protects all of them with no edits to the audio code.
+
+#include <mutex>
+
+extern "C" {
+#include <libultra/exception.h> // OSIntMask, OS_IM_NONE
+}
+
+namespace {
+std::recursive_mutex gAudioLock;
+thread_local int gAudioMaskDepth = 0;
+} // namespace
+
+extern "C" void port_lockAudio(void) {
+    gAudioLock.lock();
+}
+
+extern "C" void port_unlockAudio(void) {
+    gAudioLock.unlock();
+}
+
+extern "C" void port_audioIntMaskEnter(void) {
+    gAudioLock.lock();
+    gAudioMaskDepth++;
+}
+
+extern "C" void port_audioIntMaskExit(void) {
+    if (gAudioMaskDepth > 0) {
+        gAudioMaskDepth--;
+        gAudioLock.unlock();
+    }
+}
+
+// OS_IM_NONE enters a critical section, a restored mask exits it. Returns 0 so the saved value
+// the caller passes to the paired restore is non-OS_IM_NONE.
+extern "C" OSIntMask osSetIntMask(OSIntMask mask) {
+    if (mask == OS_IM_NONE) {
+        port_audioIntMaskEnter();
+    } else {
+        port_audioIntMaskExit();
+    }
+    return 0;
+}

--- a/src/port/Audio/GameAudio.h
+++ b/src/port/Audio/GameAudio.h
@@ -1,22 +1,18 @@
 #pragma once
 #include <thread>
-#include <condition_variable>
+#include <atomic>
+
 static struct AudioState {
     std::thread thread;
-    std::condition_variable cv_to_thread, cv_from_thread;
-    std::mutex mutex;
-    bool running = false;
-    bool processing = false;
+    std::atomic<bool> running{ false };
+    std::atomic<bool> ready{ false };
 
     void shutdown() {
         if (thread.joinable()) {
-            {
-                std::lock_guard<std::mutex> lock(mutex);
-                running = false;
-            }
-            cv_to_thread.notify_all();
+            running = false;
             thread.join();
         }
+        ready = false;
     }
 
     ~AudioState() {

--- a/src/port/Engine.cpp
+++ b/src/port/Engine.cpp
@@ -78,7 +78,7 @@ Acmd* n_alAudioFrame(Acmd* cmdList, s32* cmdLen, s16* outBuf, s32 outLen);
 void func_802403F0(void);
 void func_80250650(void);
 
-// [port] Soundfont ROM symbols — loaded from OTR in LoadSoundfonts()
+// Soundfont ROM symbols — loaded from OTR in LoadSoundfonts()
 u8* soundfont1ctl_ROM_START = NULL;
 u8* soundfont1ctl_ROM_END = NULL;
 u8* soundfont1tbl_ROM_START = NULL;
@@ -330,7 +330,7 @@ void GameEngine::FinishInit() {
     context->InitCrashHandler();
     context->InitEventSystem();
 
-    this->context->InitAudio({ .SampleRate = 22000, .SampleLength = 736, .DesiredBuffered = 3800 });
+    this->context->InitAudio({ .SampleRate = 22000, .SampleLength = 736, .DesiredBuffered = 2208 });
 
     lhFast3dWindow->SetTargetFps(60);
     lhFast3dWindow->SetMaximumFrameLatency(1);
@@ -952,7 +952,7 @@ void GameEngine::Create(int argc, char* argv[]) {
     const auto instance = Instance = new GameEngine();
     // instance->AudioInit();
     // DisplayListPatch::Run();
-    // [port] BK renders at 292x216, not the standard 320x240.
+    // BK renders at 292x216, not the standard 320x240.
     GfxSetNativeDimensions(292, 216);
     instance->RunExtract(argc, argv);
     instance->FinishInit();
@@ -1091,71 +1091,72 @@ extern "C" uint32_t GameEngine_GetSamplesPerFrame() {
     return SAMPLES_PER_FRAME;
 }
 
-// [port] 2 VIs per game frame (30fps)
+// 2 VIs per game frame (30fps)
 #define gVIsPerFrame 2
 
-// [port] 736 samples per audio update (44000/60, aligned to 184-sample boundary)
+// 736 samples per audio update (44000/60, aligned to 184-sample boundary)
 #define AlFrameSize 736
+
+// Attract-demo audio hold
+static std::atomic<bool> sHoldAudio{ false };
+static constexpr int kDemoAudioHoldFrames = 2; // frames to stay held after the load
+static int sHoldFramesRemaining = 0;           // game-thread countdown
+
+extern "C" void port_beginDemoAudioHold(void) {
+    if (kDemoAudioHoldFrames <= 0) {
+        return;
+    }
+    sHoldFramesRemaining = kDemoAudioHoldFrames;
+    sHoldAudio.store(true);
+}
 
 void GameEngine::HandleAudioThread() {
     int16_t audioBuffer[AlFrameSize * 2];
     Acmd cmdList[0x800];
 
+    // Free-run: continuously keep the backend queue topped up, real-time paced and
+    // decoupled from the game frame, so a long game frame can't starve the device.
     while (audio.running) {
-        {
-            std::unique_lock<std::mutex> lock(audio.mutex);
-            while (!audio.processing && audio.running) {
-                audio.cv_to_thread.wait(lock);
-            }
-            if (!audio.running) {
-                break;
+        if (audio.ready) {
+            while (audio.running && AudioPlayerBuffered() < AudioPlayerGetDesiredBuffered()) {
+                int samplesToGen = AlFrameSize * 2 * sizeof(int16_t);
+
+                memset(audioBuffer, 0, samplesToGen);
+
+                // While held, leave the buffer as silence and do NOT advance the engine.
+                if (!sHoldAudio) {
+                    int32_t cmdLen = 0;
+                    // Lock only the engine work; the volume scale and backend submit touch
+                    // worker-local / backend state, not the synth.
+                    port_lockAudio();
+                    func_802403F0();
+                    n_alAudioFrame(cmdList, &cmdLen, audioBuffer, AlFrameSize);
+                    func_80250650();
+                    port_unlockAudio();
+
+                    float master_vol = CVarGetInteger(CVAR_SETTING("Volume.Master"), 100) / 100.0f;
+                    for (u32 i = 0; i < AlFrameSize * 2; i++) {
+                        audioBuffer[i] = static_cast<s16>(audioBuffer[i] * master_vol);
+                    }
+                }
+                AudioPlayerPlayFrame((uint8_t*)audioBuffer, samplesToGen);
             }
         }
-
-        // [port] generate audio chunks until backend buffer is full
-        while (AudioPlayerBuffered() < AudioPlayerGetDesiredBuffered()) {
-            int32_t cmdLen = 0;
-            int samplesToGen = AlFrameSize * 2 * sizeof(int16_t);
-
-            memset(audioBuffer, 0, samplesToGen);
-
-            func_802403F0(); // [port] recycle stale DMA cache entries
-            n_alAudioFrame(cmdList, &cmdLen, audioBuffer, AlFrameSize);
-            func_80250650(); // [port] process channel volume/tempo fades (originally in audioManager_handleFrameMsg)
-            float master_vol = CVarGetInteger(CVAR_SETTING("Volume.Master"), 100) / 100.0f;
-
-            for (u32 i = 0; i < AlFrameSize * 2; i++) {
-                audioBuffer[i] = static_cast<s16>(audioBuffer[i] * master_vol);
-            }
-            AudioPlayerPlayFrame((uint8_t*)audioBuffer, samplesToGen);
-        }
-
-        {
-            std::unique_lock<std::mutex> lock(audio.mutex);
-            audio.processing = false;
-        }
-        audio.cv_from_thread.notify_one();
+        std::this_thread::sleep_for(std::chrono::milliseconds(2));
     }
 }
 
 void GameEngine::StartAudioFrame() {
-    {
-        std::unique_lock<std::mutex> Lock(audio.mutex);
-        audio.processing = true;
-    }
-    audio.cv_to_thread.notify_one();
+    // Worker free-runs now; this only marks the engine initialized (first call is after
+    // audio init, once the game loop is running).
+    audio.ready = true;
 }
 
 void GameEngine::EndAudioFrame() {
-    {
-        std::unique_lock<std::mutex> Lock(audio.mutex);
-        while (audio.processing) {
-            audio.cv_from_thread.wait(Lock);
-        }
-    }
+    // No-op: audio generation is decoupled from the game frame.
 }
 
-// [port] Load soundfont BLOBs from OTR and set ROM symbol pointers
+// Load soundfont BLOBs from OTR and set ROM symbol pointers
 static void LoadSoundfonts() {
     auto rm = Ship::Context::GetRawInstance()->GetResourceManager();
 
@@ -1196,16 +1197,15 @@ void GameEngine::AudioStartThread() {
     if (!audio.running) {
         audio.running = true;
         audio.thread = std::thread(HandleAudioThread);
+#ifdef _WIN32
+        SetThreadPriority(audio.thread.native_handle(), THREAD_PRIORITY_TIME_CRITICAL);
+#endif
     }
 }
 
 void GameEngine::AudioExit() {
-    {
-        std::unique_lock lock(audio.mutex);
-        audio.running = false;
-    }
-    audio.cv_to_thread.notify_all();
-    // Wait until the audio thread quit
+    // Free-run worker checks `running` each loop (~every 2 ms), so just clear it and join.
+    audio.running = false;
     if (audio.thread.joinable()) {
         audio.thread.join();
     }
@@ -1300,7 +1300,7 @@ void GameEngine::ProcessGfxCommands(Gfx* commands) {
         target_fps = (int)AdaptiveFps_Cap((uint32_t)target_fps);
     }
 
-    // [port] Some music-synced cutscenes cap interpolation at native 30
+    // Some music-synced cutscenes cap interpolation at native 30
     int fpsCap = port_getInterpolationFpsCap();
     if (fpsCap > 0 && target_fps > fpsCap) {
         target_fps = fpsCap;
@@ -1367,6 +1367,11 @@ void GameEngine::ProcessGfxCommands(Gfx* commands) {
     }
 
     RunCommands(commands, mtx_replacements, activeFrames);
+
+    // [port] Release the demo audio hold after kDemoAudioHoldFrames rendered frames.
+    if (sHoldAudio.load() && --sHoldFramesRemaining <= 0) {
+        sHoldAudio.store(false);
+    }
 }
 
 uint32_t GameEngine::GetInterpolationFPS() {

--- a/src/port/Engine.cpp
+++ b/src/port/Engine.cpp
@@ -77,6 +77,8 @@ Acmd* n_alAudioFrame(Acmd* cmdList, s32* cmdLen, s16* outBuf, s32 outLen);
 // DMA cache cleanup (decomp audio_manager.c)
 void func_802403F0(void);
 void func_80250650(void);
+// Game mode helper
+bool func_802E4A08(void);
 
 // Soundfont ROM symbols — loaded from OTR in LoadSoundfonts()
 u8* soundfont1ctl_ROM_START = NULL;
@@ -1296,14 +1298,19 @@ void GameEngine::ProcessGfxCommands(Gfx* commands) {
     // of node allocations per tick at high refresh rates.
     static std::vector<std::unordered_map<Mtx*, MtxF>> mtx_replacements;
     int target_fps = (int)GameEngine::Instance->GetInterpolationFPS();
-    if (CVarGetInteger(CVAR_SETTING("AdaptiveFPS"), 1)) {
-        target_fps = (int)AdaptiveFps_Cap((uint32_t)target_fps);
-    }
 
-    // Some music-synced cutscenes cap interpolation at native 30
-    int fpsCap = port_getInterpolationFpsCap();
-    if (fpsCap > 0 && target_fps > fpsCap) {
-        target_fps = fpsCap;
+    // Demo/replay modes render at the native rate
+    const bool replayMode = func_802E4A08();
+    if (!replayMode) {
+        if (CVarGetInteger(CVAR_SETTING("AdaptiveFPS"), 1)) {
+            target_fps = (int)AdaptiveFps_Cap((uint32_t)target_fps);
+        }
+
+        // Some music-synced cutscenes cap interpolation at native 30
+        int fpsCap = port_getInterpolationFpsCap();
+        if (fpsCap > 0 && target_fps > fpsCap) {
+            target_fps = fpsCap;
+        }
     }
 
     // Game-logic VI per tick: gVIsPerFrame (=2 -> 30 Hz) normally; demo
@@ -1326,6 +1333,11 @@ void GameEngine::ProcessGfxCommands(Gfx* commands) {
     // eff (the fractional-ratio jitter at target=30 / VI=3).
     int subframesPerTick = target_fps / effective_logic_fps;
     if (subframesPerTick < 1) {
+        subframesPerTick = 1;
+    }
+
+    // Replay modes never interpolate: one render per tick, held to viPerTick/60 by the floor.
+    if (replayMode) {
         subframesPerTick = 1;
     }
 

--- a/src/port/Game.cpp
+++ b/src/port/Game.cpp
@@ -26,6 +26,8 @@ extern "C" {
 #include "enums.h"
 #include "core1/core1.h"
 #include "core1/main.h"
+// Non-interactive demo/playback modes (attract demo, file playback, etc.) -- decomp gameloop.c
+bool func_802E4A08(void);
 }
 
 // Tracks whether mainLoop actually fed the renderer this iteration.
@@ -63,7 +65,8 @@ void push_frame() {
 
     sTickStart = std::chrono::steady_clock::now();
     GameEngine::Instance->StartFrame();
-    const bool recordInterpolation = GameEngine::IsInterpolationEnabled();
+    // Demo/playback modes render at native rate with no interpolation, so skip recording it.
+    const bool recordInterpolation = GameEngine::IsInterpolationEnabled() && !func_802E4A08();
     if (recordInterpolation) {
         FrameInterpolation_StartRecord();
     }

--- a/src/port/Patches/Patches.h
+++ b/src/port/Patches/Patches.h
@@ -87,6 +87,17 @@ void port_mirror_patchTextActors(void);
 
 int port_isInCharacterParade(void);
 
+// Audio engine lock
+
+void port_lockAudio(void);
+void port_unlockAudio(void);
+void port_audioIntMaskEnter(void);
+void port_audioIntMaskExit(void);
+
+// Attract-demo audio hold
+
+void port_beginDemoAudioHold(void);
+
 #ifdef __cplusplus
 }
 #endif

--- a/src/port/stub.c
+++ b/src/port/stub.c
@@ -170,9 +170,6 @@ int osStopTimer(void* t) {
 
 void osDpSetStatus(u32 data) {
 }
-OSIntMask osSetIntMask(OSIntMask a) {
-    return 0;
-}
 
 void __osError(s16 error_code, s16 num_args, ...) {
 }


### PR DESCRIPTION
Decouples audio generation from the game tick with a free-running audio worker, fixing the file-select/character-parade crackle and the cold-load audio hitching. Thread safety is handled without touching libultraship: `osSetIntMask` is remapped to a single recursive lock, which covers every N64 audio critical section, plus an explicit lock on the one un-bracketed writer. Also adds a short attract-demo audio hold so the first demo's jingle starts fresh instead of drifting through the cold-load freeze, and renders demo/playback modes at native 30 (no interpolation or adaptive FPS) for the authentic cadence.