### PR TITLE
Clean up falling jiggy transition patches into dedicated cpp file and use CALL_EVENT

### DIFF
--- a/include/gc/gctransition.h
+++ b/include/gc/gctransition.h
@@ -14,9 +14,4 @@ void gctransition_8030BEA4(s32 arg0);
 void gctransition_update(void);
 void gctransition_reset(void);
 
-// [port] Accessors for FramebufferPatches.cpp
-int gctransition_isFallingPieces(void);
-int gctransition_isFallingPiecesIn(void);
-int gctransition_getSubstate(void);
-
 #endif

--- a/src/core1/display_list.c
+++ b/src/core1/display_list.c
@@ -97,14 +97,6 @@ void scissorBox_SetForGameMode(Gfx **gdl, s32 framebuffer_idx) {
     else{
         scissorBox_setDefault();
         func_80253640(gdl, gFramebuffers[framebuffer_idx]);
-        // [port] During transition capture, also redirect rendering to the
-        // transition GPU FB so the scene is captured for jiggy piece textures.
-        if (port_shouldCaptureTransition()) {
-            s32 trFb = port_getTransitionGpuFbId();
-            if (trFb >= 0) {
-                gsSPSetFB((*gdl)++, trFb);
-            }
-        }
     }
 }
 

--- a/src/core2/context/transition.c
+++ b/src/core2/context/transition.c
@@ -202,7 +202,6 @@ void _gctranstion_changeState(s32 state, TransitionInfo *desc){
         }
         else{
             osViBlack(1);
-            port_setViBlack(1); // [port] hide screen (Engine.cpp skips present when set)
             port_requestReadback(); // [port] need readback active for transition capture
             anctrl_setAnimTimer(s_current_transition.anctrl, 0.25f); //set animation timer
         }
@@ -284,25 +283,11 @@ void gctransition_draw(Gfx **gdl, Mtx **mptr, Vtx **vptr){
         modelRender_setDepthMode(MODEL_RENDER_DEPTH_FULL);
     }
 
-    // [port] Widescreen transition scaling.
-    f32 transitionScale;
-    {
-        f32 aspectRatio = GameEngine_GetAspectRatio() / (320.0f / 240.0f);
-        s32 isJigsaw = (s_current_transition.transistion_info != NULL &&
-            (s_current_transition.transistion_info->uid == 0x10 ||
-             s_current_transition.transistion_info->uid == 0x11));
-
-        if (isJigsaw && aspectRatio > 1.01f) {
-            // Jigsaw: X-scale projection fills widescreen. UV mapping in
-            // port_patchTransitionModel uses vpW to match.
-            transitionScale = 1.0f;
-            Mtx *xScaleMtx = (*mptr)++;
-            guScale(xScaleMtx, aspectRatio, 1.0f, 1.0f);
-            gSPMatrix((*gdl)++, xScaleMtx, G_MTX_PROJECTION | G_MTX_MUL | G_MTX_NOPUSH);
-        } else {
-            transitionScale = (aspectRatio > 1.01f) ? aspectRatio + 0.1f : 1.0f;
-        }
-    }
+    // [port] Widescreen transition scaling is applied by the port listener
+    f32 transitionScale = 1.0f;
+    CALL_EVENT(OnTransitionModelScale, gdl, mptr,
+               s_current_transition.transistion_info != NULL ? s_current_transition.transistion_info->uid : 0,
+               &transitionScale);
 
     //complex animation (from animation bin file)
     if(s_current_transition.state == 1 || s_current_transition.state == 6){
@@ -414,21 +399,6 @@ int gctransition_active(void){
     return s_current_transition.state != TRANSITION_STATE_0_NONE;
 }
 
-// [port] Accessors for port code in FramebufferPatches.cpp.
-int gctransition_isFallingPieces(void) {
-    if (s_current_transition.transistion_info == NULL) return 0;
-    return s_current_transition.transistion_info->model_index == ASSET_467_MODEL_TRANSITION_FALLING_JIGGIES;
-}
-
-int gctransition_isFallingPiecesIn(void) {
-    if (s_current_transition.transistion_info == NULL) return 0;
-    return s_current_transition.transistion_info->uid == TRANSITION_ID_10_FALLING_PIECES_IN;
-}
-
-int gctransition_getSubstate(void) {
-    return s_current_transition.substate;
-}
-
 int gctransition_8030BDC0(void){
     return ( s_current_transition.state == TRANSITION_STATE_3_BLACK_OUT)
     || (( s_current_transition.state == TRANSITION_STATE_1_LOADING) && (s_current_transition.unk0 < 2))
@@ -467,7 +437,7 @@ void gctransition_update(void){
     dt = time_getDelta();
     if(s_current_transition.transistion_info == NULL)
         return;
-    
+
     if(s_current_transition.anctrl != NULL){
         anctrl_update(s_current_transition.anctrl);
         if(s_current_transition.state == TRANSITION_STATE_4_FADE_IN){
@@ -489,7 +459,6 @@ void gctransition_update(void){
                     break;
                 case 4:
                     osViBlack(0);
-                    port_setViBlack(0);     // [port] show screen again
                     port_freezeReadback(0); // [port] resume readback
                     break;
                 default:
@@ -540,4 +509,9 @@ void gctransition_update(void){
             gsworld_update();
     }
     s_current_transition.substate++;
+    if (s_current_transition.transistion_info != NULL &&
+        s_current_transition.transistion_info->model_index == ASSET_467_MODEL_TRANSITION_FALLING_JIGGIES) {
+        CALL_EVENT(OnTransitionStateUpdate, s_current_transition.transistion_info->model_index,
+                   s_current_transition.transistion_info->uid, s_current_transition.substate);
+    }
 }

--- a/src/core2/frame/auxbuffer.c
+++ b/src/core2/frame/auxbuffer.c
@@ -4,7 +4,7 @@
 #include "variables.h"
 
 int gfx_create_framebuffer(unsigned int width, unsigned int height, unsigned int native_width,
-                           unsigned int native_height, unsigned char resize);
+                           unsigned int native_height, unsigned char resize, unsigned char force_fixed_aspect);
 
 s32 sAuxGpuFbId = -1;
 
@@ -61,7 +61,7 @@ void func_8030C1A0(void){
         }
     }
     if (sAuxGpuFbId < 0) {
-        sAuxGpuFbId = gfx_create_framebuffer(IMAGE_WIDTH, IMAGE_HEIGHT, IMAGE_WIDTH, IMAGE_HEIGHT, 0);
+        sAuxGpuFbId = gfx_create_framebuffer(IMAGE_WIDTH, IMAGE_HEIGHT, IMAGE_WIDTH, IMAGE_HEIGHT, 0, 0);
     }
 }
 

--- a/src/core2/gameloop.c
+++ b/src/core2/gameloop.c
@@ -128,10 +128,8 @@ void func_802E39D0(Gfx **gdl, Mtx **mptr, Vtx **vptr, s32 framebuffer_idx, s32 a
     CALL_EVENT(OnWorldDraw, gdl, mptr, vptr);
     port_mirror_endScene();
     port_mirror_undoProjection(gdl, mptr);
-    // [port] After scene draw, capture the transition GPU FB if active.
-    // Resets FB and copies backbuffer → transition FB (GPU-side, no readback).
     if (port_shouldCaptureTransition()) {
-        port_readTransitionFbToCpu(gdl);
+        port_captureTransitionFb(gdl);
     }
     if(!arg4){
         func_802E67AC();

--- a/src/port/Enhancements/Events/Hooks/List/EngineEvent.h
+++ b/src/port/Enhancements/Events/Hooks/List/EngineEvent.h
@@ -21,6 +21,8 @@ DEFINE_EVENT(OnDialogLoaded, s32 textId; char* text;);
 
 DEFINE_EVENT(OnModelLoad, s32 modelId; void* modelInfo; s32 * reload;);
 DEFINE_EVENT(ViewportFrustumUpdate, float* frustumX; float* frustumY;);
+DEFINE_EVENT(OnTransitionModelScale, Gfx** gfx; Mtx * *mtx; s32 uid; f32* scale;);
+DEFINE_EVENT(OnTransitionStateUpdate, s32 modelId; s32 uid; s32 substate;);
 DEFINE_EVENT(DrawDistanceCubeWidth, int32_t mapWidth; int32_t * width;);
 
 DEFINE_EVENT(OnActorTick, Actor* actor;);

--- a/src/port/Enhancements/Events/PortEnhancements.cpp
+++ b/src/port/Enhancements/Events/PortEnhancements.cpp
@@ -23,6 +23,8 @@ void PortEnhancements_Register() {
     REGISTER_EVENT(OnDialogLoaded);
     REGISTER_EVENT(OnModelLoad);
     REGISTER_EVENT(ViewportFrustumUpdate);
+    REGISTER_EVENT(OnTransitionModelScale);
+    REGISTER_EVENT(OnTransitionStateUpdate);
     REGISTER_EVENT(DrawDistanceCubeWidth);
     REGISTER_EVENT(OnActorTick);
     REGISTER_EVENT(OnPropTick);

--- a/src/port/Patches/FramebufferPatches.cpp
+++ b/src/port/Patches/FramebufferPatches.cpp
@@ -8,19 +8,12 @@
 extern "C" {
 
 #include "core1/core1.h"
-#include "gc/gctransition.h"
 #include "model.h"
 
 int gfx_create_framebuffer(unsigned int width, unsigned int height, unsigned int native_width,
-                           unsigned int native_height, unsigned char resize);
+                           unsigned int native_height, unsigned char resize, unsigned char force_fixed_aspect);
 void gfx_register_fb_texture(const void* cpuAddr, int fbId);
 BKGfxList* modelbin_getGfxList(BKModelBin* arg0);
-
-// Emulate N64's osViBlack on PC. On N64, osViBlack(1) blanked the TV
-// output but the RDP still rendered to framebuffers. On PC, we let the GPU
-// render normally (so readback captures the world), then clear the backbuffer
-// to black before presenting.
-static bool s_viBlack = false;
 
 // During FADE_IN, the game disables scene drawing one frame before
 // capturing gFramebuffers. Without freezing, the readback would overwrite
@@ -30,14 +23,6 @@ static bool s_freezeReadback = false;
 
 // On-demand readback
 static int s_readbackRequestFrames = 0;
-
-void port_setViBlack(int active) {
-    s_viBlack = (active != 0);
-}
-
-int port_isViBlack(void) {
-    return s_viBlack ? 1 : 0;
-}
 
 void port_freezeReadback(int freeze) {
     s_freezeReadback = (freeze != 0);
@@ -67,20 +52,10 @@ static int s_pauseFbId = -1;
 
 int port_getPauseFramebufferId(void) {
     if (s_pauseFbId < 0) {
-        s_pauseFbId =
-            gfx_create_framebuffer(gFramebufferWidth, gFramebufferHeight, gFramebufferWidth, gFramebufferHeight, 1);
+        s_pauseFbId = gfx_create_framebuffer(gFramebufferWidth, gFramebufferHeight, gFramebufferWidth,
+                                             gFramebufferHeight, 1, 0);
     }
     return s_pauseFbId;
-}
-
-// Transition capture query
-
-int port_shouldCaptureTransition(void) {
-    if (!gctransition_isFallingPieces())
-        return 0;
-    if (gctransition_isFallingPiecesIn())
-        return gctransition_getSubstate() <= 2;
-    return gctransition_getSubstate() == 2;
 }
 
 // DL walking helper
@@ -203,15 +178,19 @@ static s32 sTransitionGpuFbId = -1;
 s32 port_getTransitionGpuFbId(void) {
     if (sTransitionGpuFbId < 0) {
         sTransitionGpuFbId = gfx_create_framebuffer(DEFAULT_FRAMEBUFFER_WIDTH, DEFAULT_FRAMEBUFFER_HEIGHT,
-                                                    DEFAULT_FRAMEBUFFER_WIDTH, DEFAULT_FRAMEBUFFER_HEIGHT, 1);
+                                                    DEFAULT_FRAMEBUFFER_WIDTH, DEFAULT_FRAMEBUFFER_HEIGHT, 1, 0);
         gfx_register_fb_texture(sTransitionFbDummy, sTransitionGpuFbId);
     }
     return sTransitionGpuFbId;
 }
 
-void port_readTransitionFbToCpu(Gfx** gfx) {
-    if (sTransitionGpuFbId >= 0) {
-        gsSPResetFB((*gfx)++);
+// Capture the finished scene for the falling-jiggy piece textures by blitting the
+// main framebuffer into the transition FB (same technique as the pause snapshot).
+// Called after the scene draw.
+void port_captureTransitionFb(Gfx** gfx) {
+    s32 trFb = port_getTransitionGpuFbId(); // create + register on first use
+    if (trFb >= 0) {
+        gDPCopyFB((*gfx)++, trFb, 0, 0, NULL); // copy main FB -> transition FB
     }
 }
 

--- a/src/port/Patches/Patches.h
+++ b/src/port/Patches/Patches.h
@@ -36,7 +36,7 @@ void port_readAuxFbToCpu(void* gfx_ptr);
 void port_patchPictureModel(void* model_bin, int32_t min_xy, int32_t max_xy, int32_t min_z, int32_t max_z,
                             uint32_t from);
 int32_t port_getTransitionGpuFbId(void);
-void port_readTransitionFbToCpu(void* gfx_ptr);
+void port_captureTransitionFb(void* gfx_ptr);
 void port_patchTransitionModel(void* model_bin);
 
 // Sprite Display Cache (SpritePatches.cpp)

--- a/src/port/Patches/TransitionPatches.cpp
+++ b/src/port/Patches/TransitionPatches.cpp
@@ -1,0 +1,80 @@
+#include <libultraship/libultraship.h>
+
+#include <libultra/gbi.h>
+#include <libultra/gu.h>
+
+#include "port/Engine.h"
+#include "port/Enhancements/Events/Hooks/Events.h"
+#include "port/ShipInit.hpp"
+#include "port/Patches/Patches.h"
+
+extern "C" {
+#include "enums.h"
+}
+
+// Falling-pieces transition uids.
+#define TRANSITION_FALLING_PIECES_IN 0x10
+#define TRANSITION_FALLING_PIECES_OUT 0x11
+
+// Cached transition state.
+static int32_t sTransitionModelId = 0;
+static int32_t sTransitionUid = 0;
+static int32_t sTransitionSubstate = 0;
+
+// Emulate N64's osViBlack on PC. On N64, osViBlack(1) blanked the TV output but
+// the RDP still rendered to framebuffers. On PC we render normally (so the capture
+// sees the world), then Engine.cpp clears the backbuffer to black before present
+// while this flag is set.
+static bool s_viBlack = false;
+
+extern "C" void port_setViBlack(int active) {
+    s_viBlack = (active != 0);
+}
+
+extern "C" int port_isViBlack(void) {
+    return s_viBlack ? 1 : 0;
+}
+
+extern "C" int port_shouldCaptureTransition(void) {
+    if (sTransitionModelId != ASSET_467_MODEL_TRANSITION_FALLING_JIGGIES) {
+        return 0;
+    }
+    // IN captures through substates 0-2.
+    // OUT snapshots only at substate 2.
+    if (sTransitionUid == TRANSITION_FALLING_PIECES_IN) {
+        return sTransitionSubstate <= 2;
+    }
+    return sTransitionSubstate == 2;
+}
+
+void RegisterTransitionPatches_Init() {
+    // Cache the pushed transition state for the capture decision.
+    REGISTER_LISTENER(OnTransitionStateUpdate, EVENT_PRIORITY_NORMAL, [](IEvent* event) {
+        auto* ev = (OnTransitionStateUpdate*)event;
+        sTransitionModelId = ev->modelId;
+        sTransitionUid = ev->uid;
+        sTransitionSubstate = ev->substate;
+        port_setViBlack(ev->uid == TRANSITION_FALLING_PIECES_IN && ev->substate <= 4 ? 1 : 0);
+    });
+
+    // Widescreen transition scaling. For the falling jiggy pieces, X-scale the
+    // projection so the pieces fill a non-4:3 viewport; the captured-FB UVs
+    // (port_patchTransitionModel) map 1:1 to match. Other transitions get a small
+    // overscan. Structural widescreen fix, always on.
+    REGISTER_LISTENER(OnTransitionModelScale, EVENT_PRIORITY_NORMAL, [](IEvent* event) {
+        auto* ev = (OnTransitionModelScale*)event;
+        float aspectRatio = GameEngine_GetAspectRatio() / (320.0f / 240.0f);
+        bool isJigsaw = (ev->uid == TRANSITION_FALLING_PIECES_IN || ev->uid == TRANSITION_FALLING_PIECES_OUT);
+
+        if (isJigsaw && aspectRatio > 1.01f) {
+            *ev->scale = 1.0f;
+            Mtx* xScaleMtx = (*ev->mtx)++;
+            guScale(xScaleMtx, aspectRatio, 1.0f, 1.0f);
+            gSPMatrix((*ev->gfx)++, xScaleMtx, G_MTX_PROJECTION | G_MTX_MUL | G_MTX_NOPUSH);
+        } else {
+            *ev->scale = (aspectRatio > 1.01f) ? aspectRatio + 0.1f : 1.0f;
+        }
+    });
+}
+
+static RegisterShipInitFunc transitionPatchesInitFunc(RegisterTransitionPatches_Init);


### PR DESCRIPTION
Falling jiggy transition no longer stretches a 4:3 framebuffer to widescreen, and is cleaned up to use the event system like everything else. This was one of the first things touched in the project, predating the event system standardization. Now it's buttery smooth.