### PR TITLE
Romhack saves hotfix

### DIFF
--- a/src/port/Save/SaveConverter.cpp
+++ b/src/port/Save/SaveConverter.cpp
@@ -228,10 +228,9 @@ Result ExportToRecompBin(const std::string& dstPath, int slot) {
 }
 
 Result PickAndImport(int slot) {
-    auto selection = pfd::open_file("Select a save to import", ".",
-                                    { "Save files (*.srm *.bin *.eep *.sav)", "*.srm *.bin *.eep *.sav",
-                                      "All Files", "*" })
-                         .result();
+    // We can't predict the file extension a save will come in, and we already validate later in the chain
+    // Trust the user to pick the correct file
+    auto selection = pfd::open_file("Select a save to import", ".", { "All Files", "*" }).result();
     if (selection.empty()) {
         return {};
     }

--- a/src/port/Save/SaveManager.cpp
+++ b/src/port/Save/SaveManager.cpp
@@ -4,7 +4,7 @@
 #include <libultraship/bridge/consolevariablebridge.h>
 #include "port/Enhancements/Events/Hooks/Events.h"
 #include "port/ShipUtils.h"
-#include "port/Romhack/RomhackConfig.h"
+#include "port/UI/LighthouseModMenuWindow.h"
 #include <fstream>
 #include <filesystem>
 #include <regex>
@@ -29,10 +29,10 @@ namespace fs = std::filesystem;
 static bool mLoaded = false;
 
 std::string SaveManager_GetSavePath(const std::string& filename) {
-    const char* romName = port_getRomhackName();
-    std::string dir = Ship_IsCStringEmpty(romName)
+    std::string romName = GetActiveRomhackBasename();
+    std::string dir = romName.empty()
                           ? Ship::Context::GetPathRelativeToAppDirectory("saves")
-                          : Ship::Context::GetPathRelativeToAppDirectory("saves/~romhacks/" + std::string(romName));
+                          : Ship::Context::GetPathRelativeToAppDirectory("saves/~romhacks/" + romName);
     std::error_code ec;
     fs::create_directories(dir, ec);
     if (ec) {

--- a/src/port/UI/LighthouseModMenuWindow.cpp
+++ b/src/port/UI/LighthouseModMenuWindow.cpp
@@ -231,6 +231,10 @@ static std::string GetActiveHack() {
     return "";
 }
 
+std::string GetActiveRomhackBasename() {
+    return GetActiveHack();
+}
+
 static bool ShownInModMenu(const std::string& name, const std::string& activeHack) {
     auto it = modCategory.find(name);
     if (it == modCategory.end()) {

--- a/src/port/UI/LighthouseModMenuWindow.h
+++ b/src/port/UI/LighthouseModMenuWindow.h
@@ -36,6 +36,10 @@ void UpdateModFiles(bool init = false, bool reset = false);
 // handled by the mod scan instead. Valid only after UpdateModFiles() has run.
 bool IsScopedModFolderName(const std::string& topLevelName);
 
+// Filename stem of the currently active romhack overlay (the enabled .o2r
+// carrying an aGameConfig), or "" if none is active.
+std::string GetActiveRomhackBasename();
+
 void EnableMod(std::string file);
 void DisableMod(std::string file);
 


### PR DESCRIPTION
Romhack save folders would use a subfolder based on the name baked into the o2r at extraction time, unlike mods subfolders. This would only diverge if a user renamed their romhack o2r. Be consistent between mods and saves, and also drop the file type filter from save imports.