### PR TITLE
Polish

### DIFF
--- a/src/core1/viewport.c
+++ b/src/core1/viewport.c
@@ -366,14 +366,11 @@ bool viewport_cube_isInFrustum2(Cube *cube) {
     rel_pos[2] = (f32) ((cube->z * 1000) + 500) - sViewportPosition[2];
 
     {
-        // [port] Extended draw distance: scale distance threshold by CVar level.
-        // 0 = vanilla (1.6e7), 1-3 = graduated, 4 = no distance cull.
-        int drawDistLevel = port_getDrawDistanceLevel();
-        static const f32 distSqThresholds[] = { 1.6e7f, 2.5e7f, 4.0e7f, 8.0e7f };
-        if (drawDistLevel < 4) {
-            if (LENGTH_SQ_VEC3F(rel_pos) > distSqThresholds[drawDistLevel]) {
-                return false;
-            }
+        // [port] Extended draw distance: scale the cube cull threshold by the distance multiplier.
+        // Vanilla threshold is 1.6e7 (4000 units squared); the multiplier is linear, so square it.
+        f32 mul = port_drawDistanceMul();
+        if (LENGTH_SQ_VEC3F(rel_pos) > 1.6e7f * mul * mul) {
+            return false;
         }
     }
 
@@ -393,16 +390,8 @@ bool viewport_func_8024DB50(f32 pos[3], f32 distance) {
     f32 delta[3];
     s32 i;
 
-    // [port] Extended draw distance: scale bounding radius by CVar level.
-    // 0 = vanilla, 1-3 = graduated, 4 = bypass all plane checks.
-    {
-        int drawDistLevel = port_getDrawDistanceLevel();
-        // 4 = no distance limit, keep frustum plane checks active
-        if (drawDistLevel > 0 && drawDistLevel < 4) {
-            static const f32 distanceScale[] = { 1.0f, 1.5f, 2.0f, 3.0f };
-            distance *= distanceScale[drawDistLevel];
-        }
-    }
+    // [port] Extended draw distance: scale bounding radius by the distance multiplier.
+    distance *= port_drawDistanceMul();
 
     delta[0] = pos[0] - sViewportPosition[0];
     delta[1] = pos[1] - sViewportPosition[1];

--- a/src/core2/ba/ba_camera.c
+++ b/src/core2/ba/ba_camera.c
@@ -172,13 +172,14 @@ int func_8029105C(s32 arg0){
         return true;
     }
 
-    if(bainput_should_rotate_camera_left() && ncDynamicCamA_func_802C1DB0(-45.0f)){
+    // [port] Invert Camera X flips the C-button swivel direction (Retro/Pocket horizontal camera).
+    if(bainput_should_rotate_camera_left() && ncDynamicCamA_func_802C1DB0(-45.0f * port_cameraInvertXSign())){
         func_80291488(arg0);
         func_8029103C();
         return true;
     }
-    
-    if(bainput_should_rotate_camera_right() && ncDynamicCamA_func_802C1DB0(45.0f)){
+
+    if(bainput_should_rotate_camera_right() && ncDynamicCamA_func_802C1DB0(45.0f * port_cameraInvertXSign())){
         func_80291488(arg0);
         func_8029103C();
         return true;

--- a/src/core2/bs/scripted_look.c
+++ b/src/core2/bs/scripted_look.c
@@ -2,6 +2,7 @@
 #include "functions.h"
 #include "variables.h"
 #include "core2/ba/physics.h"
+#include "port/Controller/ModernCamera.h"
 
 extern f32 bastick_getX(void);
 
@@ -45,8 +46,8 @@ void bsDroneLook_update(void) {
     if (ncFirstPersonCamera_getState() == FIRSTPERSON_STATE_2_IDLE) {
         //camera is in "idle" state
         ncFirstPersonCamera_getZoomedInRotation(eye_rotation);
-        eye_rotation[0] -= bastick_getY() * 90.0f * dt;
-        eye_rotation[1] -= bastick_getX() * 90.0f * dt;
+        eye_rotation[0] -= bastick_getY() * 90.0f * dt * port_cameraInvertYSign();
+        eye_rotation[1] -= bastick_getX() * 90.0f * dt * port_cameraInvertXSign();
         eye_rotation[2] = 0.0f;
         eye_rotation[0] = (eye_rotation[0] > 180.0f) ? ml_max_f(305.0f, eye_rotation[0]) : ml_min_f(70.0f, eye_rotation[0]);
         ncFirstPersonCamera_setZoomedOutRotation(eye_rotation);

--- a/src/core2/ch/bottlesbonus.c
+++ b/src/core2/ch/bottlesbonus.c
@@ -426,6 +426,7 @@ void chBottlesBonus_completedPuzzle(void) {
 
     actor = marker_getActor(chBottlesBonusMarker);
     gCompletedBottlesBonusGames[chBottlesBonusPuzzleIndex] = true;
+    CALL_EVENT(OnBottlesBonusComplete, chBottlesBonusPuzzleIndex);
     func_80311714(0);
     gcdialog_showDialog(D_803681A0[chBottlesBonusPuzzleIndex + 1].text_id, 0x86, actor->position, chBottlesBonusMarker, chBottlesBonus_IncrementPuzzle, NULL);
     func_80311714(1);

--- a/src/core2/fx/enemy_shadow.c
+++ b/src/core2/fx/enemy_shadow.c
@@ -3,6 +3,7 @@
 #include "functions.h"
 #include "variables.h"
 #include "port/Patches/Patches.h"
+#include "port/Interpolation/FrameInterpolation.h"
 
 
 
@@ -54,7 +55,9 @@ Actor *chBadShad_draw(ActorMarker *marker, Gfx **gfx, Mtx **mtx, Vtx **vtx){
         modelRender_setAlpha(other->alpha_124_19);
     sp40 = ml_map_f(this->actor_specific_1_f, 0.0f , 800.0f, 0.53f, 0.18f)*this->unk1C[1];
     modelRender_setDepthMode(MODEL_RENDER_DEPTH_COMPARE);
+    FrameInterpolation_NoInterpolatePush();
     modelRender_draw(gfx, mtx, this->position, sp44, sp40, NULL, marker_loadModelBin(marker));
+    FrameInterpolation_NoInterpolatePop();
     return this;
 }
 

--- a/src/core2/fx/enemy_shadow.c
+++ b/src/core2/fx/enemy_shadow.c
@@ -2,6 +2,7 @@
 #include "core1/core1.h"
 #include "functions.h"
 #include "variables.h"
+#include "port/Patches/Patches.h"
 
 
 
@@ -88,9 +89,10 @@ f32 func_802D7038(Actor *this) {
 
 void func_802D7124(Actor *actor, f32 arg1) {
     f32 vp[3];
+    f32 mul = port_drawDistanceMul();
 
     viewport_getPosition_vec3f(vp);
-    if ((actor->position[0] - vp[0]) * (actor->position[0] - vp[0]) + (actor->position[2] - vp[2]) * (actor->position[2] - vp[2]) < 12250000.0f) {
+    if ((actor->position[0] - vp[0]) * (actor->position[0] - vp[0]) + (actor->position[2] - vp[2]) * (actor->position[2] - vp[2]) < 12250000.0f * mul * mul) {
         func_802D729C(actor, arg1);
     }
 }

--- a/src/port/Controller/ControlSchemes.cpp
+++ b/src/port/Controller/ControlSchemes.cpp
@@ -216,6 +216,7 @@ extern "C" void port_shapeControllerInput(void* contPad) {
 
     const bool modern = CVarGetInteger(CVAR_SETTING("Controls.Scheme"), CONTROL_SCHEME_RETRO) == CONTROL_SCHEME_MODERN;
     const bool crouched = (bs_getState() == BS_CROUCH);
+    const bool eggPooping = (bs_getState() == BS_A_EGG_ASS);
 
     int32_t rx = pad->right_stick_x;
     int32_t ry = pad->right_stick_y;
@@ -223,7 +224,7 @@ extern "C" void port_shapeControllerInput(void* contPad) {
     int32_t ary = (ry < 0) ? -ry : ry;
 
     if (modern) {
-        if (!crouched) {
+        if (!crouched && !eggPooping) {
             pad->button &= ~BTN_CDOWN;
         }
 
@@ -418,7 +419,8 @@ extern "C" void port_shapeControllerInput(void* contPad) {
     static bool sBWasHeld = false;
     const int32_t kBHoldFrames = 12; // ~0.2s before a standing press counts as a hold
     bool bHeld = (pad->button & BTN_CDOWN) != 0;
-    if (CVarGetInteger(CVAR_SETTING("Controls.Scheme"), CONTROL_SCHEME_RETRO) == CONTROL_SCHEME_POCKET && !crouched) {
+    if (CVarGetInteger(CVAR_SETTING("Controls.Scheme"), CONTROL_SCHEME_RETRO) == CONTROL_SCHEME_POCKET && !crouched &&
+        !eggPooping) {
         pad->button &= ~BTN_CDOWN;
         if (bHeld) {
             if (sBHeldFrames < kBHoldFrames) {

--- a/src/port/Controller/ModernCamera.cpp
+++ b/src/port/Controller/ModernCamera.cpp
@@ -128,7 +128,7 @@ extern "C" void port_modernCamera_update(void) {
         float x;
         float y;
         ReadStickNorm(x, y);
-        yawDelta = -YawInput(x) * kYawSpeed * dt;
+        yawDelta = YawInput(x) * kYawSpeed * dt * port_cameraInvertXSign();
     }
 
     OrbitCamera_Update(&sModern, yawDelta, 0.0f);
@@ -196,4 +196,12 @@ extern "C" void port_modernCamera_handleZoom(void) {
     if (adown < kZoomOff) {
         sArmed = true;
     }
+}
+
+extern "C" float port_cameraInvertXSign(void) {
+    return CVarGetInteger(CVAR_ENHANCEMENT("Camera.InvertX"), 0) ? -1.0f : 1.0f;
+}
+
+extern "C" float port_cameraInvertYSign(void) {
+    return CVarGetInteger(CVAR_ENHANCEMENT("Camera.InvertY"), 0) ? -1.0f : 1.0f;
 }

--- a/src/port/Controller/ModernCamera.h
+++ b/src/port/Controller/ModernCamera.h
@@ -11,6 +11,8 @@ int port_modernCamera_handleYaw(void);
 void port_modernCamera_update(void);
 void port_modernCamera_handleZoom(void);
 int port_camera_suppressVanillaZoom(void);
+float port_cameraInvertXSign(void);
+float port_cameraInvertYSign(void);
 
 #ifdef __cplusplus
 }

--- a/src/port/Enhancements/Events/Hooks/List/GameEvent.h
+++ b/src/port/Enhancements/Events/Hooks/List/GameEvent.h
@@ -6,6 +6,7 @@ DEFINE_EVENT(OnActorDestroy, Actor* actor;)
 DEFINE_EVENT(OnGameSave, int32_t fileNum;)
 DEFINE_EVENT(OnGameLoad, int32_t fileNum;)
 DEFINE_EVENT(OnPropInit, Prop* propPtr;)
+DEFINE_EVENT(OnBottlesBonusComplete, int32_t index;)
 DEFINE_EVENT(OnSaveFileLoad, int32_t fileNum; void* saveBuffer; int32_t result;)
 DEFINE_EVENT(OnSaveFileSave, void* saveBuffer; int32_t fileNum; int32_t * result;)
 // Identifies which warp_* dispatcher is firing OnWarpResolveDest. Keep values

--- a/src/port/Enhancements/Events/PortEnhancements.cpp
+++ b/src/port/Enhancements/Events/PortEnhancements.cpp
@@ -74,6 +74,7 @@ void PortEnhancements_Register() {
     // Register game events
     REGISTER_EVENT(OnGameLoad);
     REGISTER_EVENT(OnGameSave);
+    REGISTER_EVENT(OnBottlesBonusComplete);
     REGISTER_EVENT(OnSaveFileLoad);
     REGISTER_EVENT(OnSaveFileSave);
     REGISTER_EVENT(OnSaveClear);

--- a/src/port/Enhancements/Restorations/ReturnToLair.cpp
+++ b/src/port/Enhancements/Restorations/ReturnToLair.cpp
@@ -10,6 +10,7 @@
 
 extern "C" struct1Bs D_8036C560[];
 extern "C" enum level_e level_get(void);
+extern "C" bool fileProgressFlag_get(enum file_progress_e index);
 
 typedef struct struct_1A_s {
     f32 delay;
@@ -31,8 +32,16 @@ void RegisterReturnToLair_Init() {
 
         if (CVAR && !port_isRomhack()) {
             s32 level = level_get();
-            *should = !(level > 0 && level < LEVEL_C_BOSS && level != LEVEL_6_LAIR &&
-                        level != LEVEL_B_SPIRAL_MOUNTAIN && D_8036C560[level - 1].map != -1);
+            bool isSpiralMountain = (level == LEVEL_B_SPIRAL_MOUNTAIN);
+            // The enter-lair cutscene flag is what flips the save's start map to the Lair, so it
+            // doubles as "the player has reached the Lair at least once".
+            bool beenToLair = fileProgressFlag_get(FILEPROG_BD_ENTER_LAIR_CUTSCENE);
+            bool validWorld = level > 0 && level < LEVEL_C_BOSS && level != LEVEL_6_LAIR &&
+                              D_8036C560[level - 1].map != -1;
+            // Spiral Mountain has a valid Lair warp entry, but only offer the option there once the
+            // Lair has actually been visited.
+            bool showOption = validWorld && (!isSpiralMountain || beenToLair);
+            *should = !showOption;
             if (!*should) {
                 menuData[0].y = 45;
                 menuData[1].y = 75;
@@ -42,8 +51,11 @@ void RegisterReturnToLair_Init() {
                 menuData[2].delay = 0.2f;
                 menuData[3].delay = 0.3f;
                 menuData[1].portrait = ZOOMBOX_SPRITE_5_GRUNTILDA_2;
+                // From Spiral Mountain you head forward to the Lair rather than exiting back to it.
+                menuData[1].str =
+                    isSpiralMountain ? (u8*)"GO TO GRUNTY'S LAIR" : (u8*)"EXIT TO WITCH'S LAIR";
             } else {
-                // Not in a world level — reset to vanilla layout
+                // Option hidden — reset to vanilla layout
                 menuData[0].y = 55;
                 menuData[1].y = -100;
                 menuData[2].y = 90;
@@ -52,6 +64,7 @@ void RegisterReturnToLair_Init() {
                 menuData[2].delay = 0.1f;
                 menuData[3].delay = 0.2f;
                 menuData[1].portrait = ZOOMBOX_SPRITE_4_BANJO_1;
+                menuData[1].str = (u8*)"EXIT TO WITCH'S LAIR";
             }
         } else {
             *should = true;
@@ -63,6 +76,7 @@ void RegisterReturnToLair_Init() {
             menuData[2].delay = 0.1f;
             menuData[3].delay = 0.2f;
             menuData[1].portrait = ZOOMBOX_SPRITE_4_BANJO_1;
+            menuData[1].str = (u8*)"EXIT TO WITCH'S LAIR";
         }
     });
 

--- a/src/port/Enhancements/Restorations/ReturnToLair.cpp
+++ b/src/port/Enhancements/Restorations/ReturnToLair.cpp
@@ -36,8 +36,8 @@ void RegisterReturnToLair_Init() {
             // The enter-lair cutscene flag is what flips the save's start map to the Lair, so it
             // doubles as "the player has reached the Lair at least once".
             bool beenToLair = fileProgressFlag_get(FILEPROG_BD_ENTER_LAIR_CUTSCENE);
-            bool validWorld = level > 0 && level < LEVEL_C_BOSS && level != LEVEL_6_LAIR &&
-                              D_8036C560[level - 1].map != -1;
+            bool validWorld =
+                level > 0 && level < LEVEL_C_BOSS && level != LEVEL_6_LAIR && D_8036C560[level - 1].map != -1;
             // Spiral Mountain has a valid Lair warp entry, but only offer the option there once the
             // Lair has actually been visited.
             bool showOption = validWorld && (!isSpiralMountain || beenToLair);
@@ -52,8 +52,7 @@ void RegisterReturnToLair_Init() {
                 menuData[3].delay = 0.3f;
                 menuData[1].portrait = ZOOMBOX_SPRITE_5_GRUNTILDA_2;
                 // From Spiral Mountain you head forward to the Lair rather than exiting back to it.
-                menuData[1].str =
-                    isSpiralMountain ? (u8*)"GO TO GRUNTY'S LAIR" : (u8*)"EXIT TO WITCH'S LAIR";
+                menuData[1].str = isSpiralMountain ? (u8*)"GO TO GRUNTY'S LAIR" : (u8*)"EXIT TO WITCH'S LAIR";
             } else {
                 // Option hidden — reset to vanilla layout
                 menuData[0].y = 55;

--- a/src/port/Localization/Localization.cpp
+++ b/src/port/Localization/Localization.cpp
@@ -267,6 +267,9 @@ static const LocalizedUiString sUiStrings[] = {
       (const u8*)"ZUR]CK ZUM SPIEL" },
     { "EXIT TO WITCH'S LAIR", (const u8*)"\xfd\x6a\x6e\x82\x4d\xd2\xcd\xe1\xf3\xd6\xcf\xdc\xf4\xe2",
       (const u8*)"ANTRE DE LA SORCI\x63RE", (const u8*)"ZUR HEXENH\\HLE" },
+    // Spiral Mountain variant of the Return-to-Lair option; reuses the lair translations.
+    { "GO TO GRUNTY'S LAIR", (const u8*)"\xfd\x6a\x6e\x82\x4d\xd2\xcd\xe1\xf3\xd6\xcf\xdc\xf4\xe2",
+      (const u8*)"ANTRE DE LA SORCI\x63RE", (const u8*)"ZUR HEXENH\\HLE" },
     { "VIEW TOTALS", (const u8*)"\xfd\x6a\x63\x3b\x5f\x78\xb8\xd9\xe2", (const u8*)"STATISTIQUES",
       (const u8*)"STATISTIK" },
     { "SAVE AND QUIT", (const u8*)"\xfd\x6a\x5d\x3b\x8d\xc5\xcc\xbe\xe5\xe2", (const u8*)"SAUVER ET QUITTER",

--- a/src/port/Patches/GraphicsPatches.cpp
+++ b/src/port/Patches/GraphicsPatches.cpp
@@ -8,6 +8,11 @@
 #define CVAR_DRAW_DISTANCE CVAR_ENHANCEMENT("Graphics.DrawDistance")
 #define CVAR_DISABLE_LOD CVAR_ENHANCEMENT("Graphics.DisableLOD")
 
+static const int kMaxDrawDistanceMul = 6;
+static int sDrawDistanceCubeWidth(int mul) {
+    return 4 * mul;
+}
+
 static int sDrawDistanceLevel = 0;
 static int sDisableLOD = 0;
 
@@ -164,51 +169,38 @@ void port_drawLivesCount(Gfx** gfx, Mtx** mtx, Vtx** vtx, char* str, f32 baseX, 
 }
 
 int port_getDrawDistanceLevel(void) {
-    int level = CVarGetInteger(CVAR_ENHANCEMENT("Graphics.DrawDistance"), 0);
-    if (IsDemoMode() && getGameMode() != GAME_MODE_4_PAUSED) {
-        level = 0;
+    int mul = CVarGetInteger(CVAR_ENHANCEMENT("Graphics.DrawDistance"), 1);
+    if (mul < 1) {
+        mul = 1;
     }
-    return level;
+    if (mul > kMaxDrawDistanceMul) {
+        mul = kMaxDrawDistanceMul;
+    }
+    if (IsDemoMode() && getGameMode() != GAME_MODE_4_PAUSED) {
+        mul = 1;
+    }
+    return mul;
 }
 
 float port_drawDistanceMul(void) {
-    int lvl = port_getDrawDistanceLevel();
-    if (lvl >= 4) {
-        return 1e9f;
+    int level = port_getDrawDistanceLevel();
+    if (level <= 1) {
+        return 1.0f;
     }
-    if (lvl > 0) {
-        static const float scale[] = { 1.0f, 1.25f, 1.5811f, 2.2361f };
-        return scale[lvl];
-    }
-    return 1.0f;
+    return (float)level + 0.1f; // Nudge
 }
 
 void port_applyModelDrawDistanceCull(int* fadeFlag, float* cullMult, float* cullDist) {
-    int lvl = port_getDrawDistanceLevel();
-    if (lvl >= 4) {
-        *fadeFlag = 0;
-        *cullMult = 1e30f;
-        *cullDist = 1e30f;
-    } else if (lvl > 0) {
-        static const float cullDistScale[] = { 1.0f, 1.25f, 1.5811f, 2.2361f };
-        *cullMult *= cullDistScale[lvl];
-        *cullDist *= cullDistScale[lvl];
-    }
+    float mul = port_drawDistanceMul();
+    *cullMult *= mul;
+    *cullDist *= mul;
 }
 
 int port_spriteSizeCulled(float depth, float size, float baseThreshold, int disableFlag) {
     if (disableFlag) {
         return 0;
     }
-    int lvl = port_getDrawDistanceLevel();
-    if (lvl >= 4) {
-        return 0;
-    }
-    float scale = 1.0f;
-    if (lvl > 0) {
-        static const float spriteCullScale[] = { 1.0f, 1.6667f, 2.1082f, 2.9814f };
-        scale = spriteCullScale[lvl];
-    }
+    float scale = port_drawDistanceMul();
     return (3000.0f * scale < depth) && (((size / depth) * scale) < baseThreshold);
 }
 
@@ -239,24 +231,22 @@ static void OnGeoCull_LevelOcclusion(IEvent* event) {
 }
 
 void RegisterLevelOcclusion_Init() {
-    bool maxed = CVarGetInteger(CVAR_DRAW_DISTANCE, 0) >= 4;
+    bool maxed = CVarGetInteger(CVAR_DRAW_DISTANCE, 1) >= kMaxDrawDistanceMul;
     GeoCull_SetConsumer(GEOCULL_CONSUMER_ENHANCEMENT, maxed);
     COND_HOOK(OnGeoCull, EVENT_PRIORITY_NORMAL, maxed, OnGeoCull_LevelOcclusion);
 }
 
 static RegisterShipInitFunc sInitLevelOcclusion(RegisterLevelOcclusion_Init, { CVAR_DRAW_DISTANCE });
 
-static const int kCubeWidthByLevel[] = { 4, 6, 8, 10, 18 };
-
 static void RegisterDrawDistanceGraphics_Init() {
-    COND_HOOK(DrawDistanceCubeWidth, EVENT_PRIORITY_NORMAL, CVarGetInteger(CVAR_DRAW_DISTANCE, 0) > 0,
+    COND_HOOK(DrawDistanceCubeWidth, EVENT_PRIORITY_NORMAL, CVarGetInteger(CVAR_DRAW_DISTANCE, 1) > 1,
               [](IEvent* event) {
-                  int lvl = port_getDrawDistanceLevel();
-                  if (lvl <= 0) {
+                  int mul = port_getDrawDistanceLevel();
+                  if (mul <= 1) {
                       return;
                   }
                   auto* ev = (DrawDistanceCubeWidth*)event;
-                  int width = (lvl <= 4) ? kCubeWidthByLevel[lvl] : 4;
+                  int width = sDrawDistanceCubeWidth(mul);
                   if (width > ev->mapWidth) {
                       width = ev->mapWidth;
                   }
@@ -267,7 +257,7 @@ static void RegisterDrawDistanceGraphics_Init() {
 static RegisterShipInitFunc drawDistanceGraphicsInit(RegisterDrawDistanceGraphics_Init, { CVAR_DRAW_DISTANCE });
 
 static void RefreshDrawDistanceCVars() {
-    sDrawDistanceLevel = CVarGetInteger(CVAR_DRAW_DISTANCE, 0);
+    sDrawDistanceLevel = CVarGetInteger(CVAR_DRAW_DISTANCE, 1);
     sDisableLOD = CVarGetInteger(CVAR_DISABLE_LOD, 0);
 }
 

--- a/src/port/Patches/GraphicsPatches.cpp
+++ b/src/port/Patches/GraphicsPatches.cpp
@@ -69,7 +69,7 @@ void port_drawLivesCount(Gfx** gfx, Mtx** mtx, Vtx** vtx, char* str, f32 baseX, 
     gDPSetPrimColor((*gfx)++, 0, 0, 0xFF, 0xFF, 0xFF, 0xFF);
 
     for (i = 0; str[i] != '\0'; i++) {
-        s32 glyphId = D_80380F20[(u8) str[i]];
+        s32 glyphId = D_80380F20[(u8)str[i]];
         s32 fontType;
         BKSpriteTextureBlock* glyph;
         uintptr_t texData;
@@ -87,10 +87,10 @@ void port_drawLivesCount(Gfx** gfx, Mtx** mtx, Vtx** vtx, char* str, f32 baseX, 
         }
 
         if (leftMargin == 0.0f) {
-            leftMargin = -(f32) glyph->x * 0.5f;
+            leftMargin = -(f32)glyph->x * 0.5f;
         }
         drawX = cursorX + leftMargin;
-        drawY = screenY - (f32) glyph->h * 0.5f;
+        drawY = screenY - (f32)glyph->h * 0.5f;
 
         texData = (uintptr_t)(glyph + 1);
         while (texData % 8) {
@@ -100,18 +100,18 @@ void port_drawLivesCount(Gfx** gfx, Mtx** mtx, Vtx** vtx, char* str, f32 baseX, 
         const char* hdPath = NULL;
         CALL_EVENT(ResolveSpriteHdPath, glyph, &hdPath);
         if (hdPath != NULL) {
-            texData = (uintptr_t) hdPath;
+            texData = (uintptr_t)hdPath;
         }
         const char* boldHdPath = NULL;
         CALL_EVENT(ResolveBoldFontHd, glyph, &boldHdPath);
         if (boldHdPath != NULL) {
-            texData = (uintptr_t) boldHdPath;
+            texData = (uintptr_t)boldHdPath;
         }
 
         if (fontType == SPRITE_TYPE_RGBA32) {
-            gDPLoadTextureTile((*gfx)++, texData, G_IM_FMT_RGBA, G_IM_SIZ_32b, glyph->w, glyph->h, 0, 0,
-                               glyph->x - 1, glyph->y - 1, 0, G_TX_CLAMP, G_TX_CLAMP, G_TX_NOMASK, G_TX_NOMASK,
-                               G_TX_NOLOD, G_TX_NOLOD);
+            gDPLoadTextureTile((*gfx)++, texData, G_IM_FMT_RGBA, G_IM_SIZ_32b, glyph->w, glyph->h, 0, 0, glyph->x - 1,
+                               glyph->y - 1, 0, G_TX_CLAMP, G_TX_CLAMP, G_TX_NOMASK, G_TX_NOMASK, G_TX_NOLOD,
+                               G_TX_NOLOD);
         } else if (fontType == SPRITE_TYPE_IA8) {
             gDPLoadTextureTile((*gfx)++, texData, G_IM_FMT_IA, G_IM_SIZ_8b, glyph->w, glyph->h, 0, 0, glyph->x - 1,
                                glyph->y - 1, 0, G_TX_CLAMP, G_TX_CLAMP, G_TX_NOMASK, G_TX_NOMASK, G_TX_NOLOD,
@@ -121,11 +121,10 @@ void port_drawLivesCount(Gfx** gfx, Mtx** mtx, Vtx** vtx, char* str, f32 baseX, 
                                glyph->y - 1, 0, G_TX_CLAMP, G_TX_CLAMP, G_TX_NOMASK, G_TX_NOMASK, G_TX_NOLOD,
                                G_TX_NOLOD);
         } else if (fontType == SPRITE_TYPE_I4) {
-            gDPLoadTextureTile_4b((*gfx)++, texData, G_IM_FMT_I, glyph->w, glyph->h, 0, 0, glyph->x - 1,
-                                  glyph->y - 1, 0, G_TX_CLAMP, G_TX_CLAMP, G_TX_NOMASK, G_TX_NOMASK, G_TX_NOLOD,
-                                  G_TX_NOLOD);
+            gDPLoadTextureTile_4b((*gfx)++, texData, G_IM_FMT_I, glyph->w, glyph->h, 0, 0, glyph->x - 1, glyph->y - 1,
+                                  0, G_TX_CLAMP, G_TX_CLAMP, G_TX_NOMASK, G_TX_NOMASK, G_TX_NOLOD, G_TX_NOLOD);
         } else if (fontType == SPRITE_TYPE_CI8) {
-            void* pal = print_getCurrentFontPalette((u8) glyphId);
+            void* pal = print_getCurrentFontPalette((u8)glyphId);
             gDPLoadTLUT_pal256((*gfx)++, pal);
             gDPLoadTextureTile((*gfx)++, texData, G_IM_FMT_CI, G_IM_SIZ_8b, glyph->w, glyph->h, 0, 0, glyph->x - 1,
                                glyph->y - 1, 0, G_TX_CLAMP, G_TX_CLAMP, G_TX_NOMASK, G_TX_NOMASK, G_TX_NOLOD,
@@ -135,19 +134,19 @@ void port_drawLivesCount(Gfx** gfx, Mtx** mtx, Vtx** vtx, char* str, f32 baseX, 
             continue;
         }
 
-        glyphW = (f32) glyph->x - 1.0f;
-        glyphH = (f32) glyph->y - 1.0f;
-        centerX = drawX - (f32) gFramebufferWidth * 0.5f;
-        centerY = drawY - (f32) gFramebufferHeight * 0.5f - 0.5f;
+        glyphW = (f32)glyph->x - 1.0f;
+        glyphH = (f32)glyph->y - 1.0f;
+        centerX = drawX - (f32)gFramebufferWidth * 0.5f;
+        centerY = drawY - (f32)gFramebufferHeight * 0.5f - 0.5f;
 
         gSPVertex((*gfx)++, (uintptr_t)*vtx, 4, 0);
         for (vy = 0; vy < 2; vy++) {
             for (vx = 0; vx < 2; vx++) {
-                (*vtx)->v.ob[0] = (s16)(s32)((centerX + glyphW * (f32) vx) * 4.0f);
-                (*vtx)->v.ob[1] = (s16)(s32)((centerY + glyphH * (f32) vy) * -4.0f);
+                (*vtx)->v.ob[0] = (s16)(s32)((centerX + glyphW * (f32)vx) * 4.0f);
+                (*vtx)->v.ob[1] = (s16)(s32)((centerY + glyphH * (f32)vy) * -4.0f);
                 (*vtx)->v.ob[2] = -0xA;
-                (*vtx)->v.tc[0] = (s16)(s32)(glyphW * (f32) vx * 64.0f);
-                (*vtx)->v.tc[1] = (s16)(s32)(glyphH * (f32) vy * 64.0f);
+                (*vtx)->v.tc[0] = (s16)(s32)(glyphW * (f32)vx * 64.0f);
+                (*vtx)->v.tc[1] = (s16)(s32)(glyphH * (f32)vy * 64.0f);
                 (*vtx)->v.cn[0] = 0xFF;
                 (*vtx)->v.cn[1] = 0xFF;
                 (*vtx)->v.cn[2] = 0xFF;
@@ -157,7 +156,7 @@ void port_drawLivesCount(Gfx** gfx, Mtx** mtx, Vtx** vtx, char* str, f32 baseX, 
         }
         gSP1Quadrangle((*gfx)++, 0, 1, 3, 2, 0);
 
-        cursorX += (f32) glyph->x;
+        cursorX += (f32)glyph->x;
     }
 
     gDPPipeSync((*gfx)++);

--- a/src/port/Rando/LighthouseMenuRando.cpp
+++ b/src/port/Rando/LighthouseMenuRando.cpp
@@ -96,7 +96,9 @@ void LighthouseMenu::AddMenuRando() {
 
     AddWidget(path, "Seed Metrics", WIDGET_SEPARATOR_TEXT);
 
-    AddWidget(path, "Metrics", WIDGET_CUSTOM).CustomFunction([](WidgetInfo& info) { DrawSeedMetrics(); }).HideInSearch(true);
+    AddWidget(path, "Metrics", WIDGET_CUSTOM)
+        .CustomFunction([](WidgetInfo& info) { DrawSeedMetrics(); })
+        .HideInSearch(true);
 
     // Rando - Shuffle Options
     AddSidebarEntry("Rando", "Shuffle Options", 1);

--- a/src/port/Resource/AssetTrace.cpp
+++ b/src/port/Resource/AssetTrace.cpp
@@ -80,8 +80,7 @@ void port_traceBadAssetId(uint32_t assetId) {
 
         if (SymFromAddr(proc, addr, &symDisp, sym)) {
             if (SymGetLineFromAddr64(proc, addr, &lineDisp, &line)) {
-                SPDLOG_WARN("    #{:02} {}+0x{:x}  ({}:{})", i, sym->Name, symDisp, line.FileName,
-                            line.LineNumber);
+                SPDLOG_WARN("    #{:02} {}+0x{:x}  ({}:{})", i, sym->Name, symDisp, line.FileName, line.LineNumber);
             } else {
                 SPDLOG_WARN("    #{:02} {}+0x{:x}", i, sym->Name, symDisp);
             }
@@ -109,7 +108,6 @@ void port_traceBadAssetId(uint32_t assetId) {
         raise(SIGTRAP);
     }
 #else
-    SPDLOG_WARN("[AssetTrace] invalid asset id {} (backtrace unavailable on this platform)",
-                assetId);
+    SPDLOG_WARN("[AssetTrace] invalid asset id {} (backtrace unavailable on this platform)", assetId);
 #endif
 }

--- a/src/port/Save/SaveManager.cpp
+++ b/src/port/Save/SaveManager.cpp
@@ -3,7 +3,9 @@
 #include <spdlog/spdlog.h>
 #include <libultraship/bridge/consolevariablebridge.h>
 #include "port/Enhancements/Events/Hooks/Events.h"
+#include "port/ShipInit.hpp"
 #include "port/ShipUtils.h"
+#include "port/UI/cvar_prefixes.h"
 #include "port/UI/LighthouseModMenuWindow.h"
 #include <fstream>
 #include <filesystem>
@@ -27,6 +29,8 @@ using nlohmann::json;
 using nlohmann::ordered_json;
 namespace fs = std::filesystem;
 static bool mLoaded = false;
+
+#define CVAR_NAME_BOTTLES_BONUS CVAR_ENHANCEMENT("Saving.PersistBottlesBonus")
 
 std::string SaveManager_GetSavePath(const std::string& filename) {
     std::string romName = GetActiveRomhackBasename();
@@ -645,8 +649,9 @@ static void LoadGlobalData() {
         }
     }
 
-    // Bottles Bonus
-    if (j.contains("bottlesBonusCompleted")) {
+    // Bottles Bonus: only restore from the global save when persistence is enabled.
+    // With it off, completion stays session-only (vanilla), reset at file select.
+    if (CVarGetInteger(CVAR_NAME_BOTTLES_BONUS, 0) && j.contains("bottlesBonusCompleted")) {
         const auto& bb = j["bottlesBonusCompleted"];
         for (int k = 0; k < 7 && k < (int)bb.size(); k++) {
             gCompletedBottlesBonusGames[k] = bb[k].get<int>() ? 1 : 0;
@@ -767,3 +772,10 @@ void SaveManager_Init() {
     // other OnGameLoad listeners read them.
     REGISTER_LISTENER(OnGameLoad, EVENT_PRIORITY_HIGH, [](IEvent* event) { LoadGlobalData(); });
 }
+
+static void RegisterPersistBottlesBonus_Init() {
+    COND_HOOK(OnBottlesBonusComplete, EVENT_PRIORITY_NORMAL, CVarGetInteger(CVAR_NAME_BOTTLES_BONUS, 0),
+              [](IEvent* event) { SaveGlobalData(); });
+}
+
+static RegisterShipInitFunc initPersistBottlesBonus(RegisterPersistBottlesBonus_Init, { CVAR_NAME_BOTTLES_BONUS });

--- a/src/port/UI/LighthouseMenuDevTools.cpp
+++ b/src/port/UI/LighthouseMenuDevTools.cpp
@@ -76,12 +76,6 @@ void LighthouseMenu::AddMenuDevTools() {
     AddWidget(path, "Nametag Distance", WIDGET_CVAR_SLIDER_FLOAT)
         .CVar(CVAR_DEVELOPER_TOOLS("NametagDist"))
         .Options(FloatSliderOptions().DefaultValue(3000.0f).Min(1000.0f).Max(10000.0f).Step(10.0f));
-    AddWidget(path, "FPS Counter", WIDGET_WINDOW_BUTTON)
-        .CVar(CVAR_WINDOW("Stats"))
-        .WindowName("Stats")
-        .Options(WindowButtonOptions()
-                     .Tooltip("Toggle the on-screen FPS / frametime overlay for measuring performance.")
-                     .EmbedWindow(false));
     /*AddWidget(path, "Debug Mode", WIDGET_CVAR_CHECKBOX)
         .CVar(CVAR_DEVELOPER_TOOLS("DebugMode"))
         .Options(CheckboxOptions().Tooltip("Various debug features, including a level selector from the main menu."));*/
@@ -137,6 +131,24 @@ void LighthouseMenu::AddMenuDevTools() {
         .WindowName("Gameplay Tools")
         .HideInSearch(true)
         .Options(WindowButtonOptions().Tooltip("Enables the separate Gameplay Tools Window."));
+
+    // Stats
+    path.sidebarName = "Stats";
+    AddSidebarEntry("Dev Tools", path.sidebarName, 1);
+    AddWidget(path, "Popout Stats", WIDGET_WINDOW_BUTTON)
+        .CVar(CVAR_WINDOW("Stats"))
+        .WindowName("Stats")
+        .HideInSearch(true)
+        .Options(WindowButtonOptions().Tooltip(
+            "Shows the stats window, with your FPS and frametimes, and the OS you're playing on."));
+    AddWidget(path, "Adaptive FPS", WIDGET_CVAR_CHECKBOX)
+        .CVar(CVAR_SETTING("AdaptiveFPS"))
+        .RaceDisable(false)
+        .Options(CheckboxOptions()
+                     .Tooltip("Automatically lowers interpolation FPS in demanding scenes so the game logic never "
+                              "stalls, then restores it when the scene clears. Disable to always target your "
+                              "requested FPS, which may stutter on heavy scenes or weaker hardware.")
+                     .DefaultValue(true));
 
     // Console
     // path.sidebarName = "Console";

--- a/src/port/UI/LighthouseMenuEnhancements.cpp
+++ b/src/port/UI/LighthouseMenuEnhancements.cpp
@@ -63,14 +63,9 @@ void LighthouseMenu::AddMenuEnhancements() {
     AddWidget(path, "Extended Draw Distance: %dx", WIDGET_CVAR_SLIDER_INT)
         .CVar(CVAR_ENHANCEMENT("Graphics.DrawDistance"))
         .RaceDisable(false)
-        .Options(IntSliderOptions()
-                     .Min(1)
-                     .Max(6)
-                     .DefaultValue(1)
-                     .ShowButtons(true)
-                     .Format("")
-                     .Tooltip("Multiplies the draw distance for objects.\n"
-                              "Higher values render more but cost performance."));
+        .Options(IntSliderOptions().Min(1).Max(6).DefaultValue(1).ShowButtons(true).Format("").Tooltip(
+            "Multiplies the draw distance for objects.\n"
+            "Higher values render more but cost performance."));
 
     // Enhancements -> Camera
     path = { "Enhancements", "Camera", SECTION_COLUMN_1 };
@@ -84,8 +79,7 @@ void LighthouseMenu::AddMenuEnhancements() {
     AddWidget(path, "Invert Camera X", WIDGET_CVAR_CHECKBOX)
         .CVar(CVAR_ENHANCEMENT("Camera.InvertX"))
         .RaceDisable(false)
-        .Options(CheckboxOptions().Tooltip(
-            "Inverts horizontal camera."));
+        .Options(CheckboxOptions().Tooltip("Inverts horizontal camera."));
 
     AddWidget(path, "Invert Camera Y", WIDGET_CVAR_CHECKBOX)
         .CVar(CVAR_ENHANCEMENT("Camera.InvertY"))

--- a/src/port/UI/LighthouseMenuEnhancements.cpp
+++ b/src/port/UI/LighthouseMenuEnhancements.cpp
@@ -75,7 +75,27 @@ void LighthouseMenu::AddMenuEnhancements() {
     // Enhancements -> Camera
     path = { "Enhancements", "Camera", SECTION_COLUMN_1 };
     AddSidebarEntry("Enhancements", path.sidebarName, 2);
+
     path.column = SECTION_COLUMN_1;
+
+    // General Camera Settings
+    AddWidget(path, "Camera Settings", WIDGET_SEPARATOR_TEXT);
+
+    AddWidget(path, "Invert Camera X", WIDGET_CVAR_CHECKBOX)
+        .CVar(CVAR_ENHANCEMENT("Camera.InvertX"))
+        .RaceDisable(false)
+        .Options(CheckboxOptions().Tooltip(
+            "Inverts horizontal camera."));
+
+    AddWidget(path, "Invert Camera Y", WIDGET_CVAR_CHECKBOX)
+        .CVar(CVAR_ENHANCEMENT("Camera.InvertY"))
+        .RaceDisable(false)
+        .Options(CheckboxOptions().Tooltip("Inverts vertical camera in first-person."));
+
+    path.column = SECTION_COLUMN_2;
+
+    // Free Look Camera
+    AddWidget(path, "Free Look Camera", WIDGET_SEPARATOR_TEXT);
 
     AddWidget(path, "Free Look (Right Stick)", WIDGET_CVAR_CHECKBOX)
         .CVar(CVAR_ENHANCEMENT("Camera.FreeLook.Enabled"))

--- a/src/port/UI/LighthouseMenuEnhancements.cpp
+++ b/src/port/UI/LighthouseMenuEnhancements.cpp
@@ -50,20 +50,6 @@ void LighthouseMenu::AddMenuEnhancements() {
     AddSidebarEntry("Enhancements", path.sidebarName, 2);
     path.column = SECTION_COLUMN_1;
 
-    AddWidget(path, "Extended Draw Distance", WIDGET_CVAR_COMBOBOX)
-        .CVar(CVAR_ENHANCEMENT("Graphics.DrawDistance"))
-        .RaceDisable(false)
-        .Options(ComboboxOptions()
-                     .Tooltip("Extends the draw distance for objects.\nHigher values render more but cost performance.")
-                     .ComboMap({
-                         { 0, "Off" },
-                         { 1, "25%" },
-                         { 2, "50%" },
-                         { 3, "75%" },
-                         { 4, "100%" },
-                     })
-                     .DefaultIndex(0));
-
     AddWidget(path, "Disable LOD", WIDGET_CVAR_CHECKBOX)
         .CVar(CVAR_ENHANCEMENT("Graphics.DisableLOD"))
         .RaceDisable(false)
@@ -73,6 +59,18 @@ void LighthouseMenu::AddMenuEnhancements() {
         .CVar(CVAR_ENHANCEMENT("Graphics.CutsceneAspect"))
         .Options(CheckboxOptions().Tooltip("Forces game to show original aspect ratio during cutscenes to avoid seeing "
                                            "unfinished edges of scene geometry."));
+
+    AddWidget(path, "Extended Draw Distance: %dx", WIDGET_CVAR_SLIDER_INT)
+        .CVar(CVAR_ENHANCEMENT("Graphics.DrawDistance"))
+        .RaceDisable(false)
+        .Options(IntSliderOptions()
+                     .Min(1)
+                     .Max(6)
+                     .DefaultValue(1)
+                     .ShowButtons(true)
+                     .Format("")
+                     .Tooltip("Multiplies the draw distance for objects.\n"
+                              "Higher values render more but cost performance."));
 
     // Enhancements -> Camera
     path = { "Enhancements", "Camera", SECTION_COLUMN_1 };

--- a/src/port/UI/LighthouseMenuSettings.cpp
+++ b/src/port/UI/LighthouseMenuSettings.cpp
@@ -405,14 +405,6 @@ void LighthouseMenu::AddMenuSettings() {
         .CVar(CVAR_SETTING("MatchRefreshRate"))
         .RaceDisable(false)
         .Options(CheckboxOptions().Tooltip("Matches interpolation value to the refresh rate of your display."));
-    AddWidget(path, "Adaptive FPS", WIDGET_CVAR_CHECKBOX)
-        .CVar(CVAR_SETTING("AdaptiveFPS"))
-        .RaceDisable(false)
-        .Options(CheckboxOptions()
-                     .Tooltip("Automatically lowers interpolation FPS in demanding scenes so the game logic never "
-                              "stalls, then restores it when the scene clears. Disable to always target your "
-                              "requested FPS, which may stutter on heavy scenes or weaker hardware.")
-                     .DefaultValue(true));
     AddWidget(path, "Renderer API (Needs reload)", WIDGET_VIDEO_BACKEND).RaceDisable(false);
     AddWidget(path, "Enable Vsync", WIDGET_CVAR_CHECKBOX)
         .CVar(CVAR_VSYNC_ENABLED)

--- a/src/port/UI/LighthouseModMenuWindow.cpp
+++ b/src/port/UI/LighthouseModMenuWindow.cpp
@@ -937,9 +937,12 @@ void DrawInlineModExtraction() {
         try {
             std::filesystem::path produced(GameExtractor::sLastOutputPath);
             if (std::filesystem::exists(produced) && ArchiveHasGameConfig(produced)) {
-                std::filesystem::path dest = produced.parent_path() / ROMHACKS_DIR / produced.filename();
-                if (produced != dest) {
-                    std::filesystem::create_directories(dest.parent_path());
+                std::filesystem::path romhacksDir =
+                    std::filesystem::path(Ship::Context::GetPathRelativeToAppDirectory("mods")) / ROMHACKS_DIR;
+                std::filesystem::path dest = romhacksDir / produced.filename();
+                std::error_code same;
+                if (!std::filesystem::equivalent(produced, dest, same)) {
+                    std::filesystem::create_directories(romhacksDir);
                     std::error_code rec;
                     std::filesystem::remove(dest, rec); // replace a prior overlay of the same name
                     std::filesystem::rename(produced, dest);

--- a/src/port/UI/Menu.cpp
+++ b/src/port/UI/Menu.cpp
@@ -197,8 +197,8 @@ uint32_t Menu::DrawSearchResults(std::string& menuSearchText) {
     menuSearchText.erase(std::remove(menuSearchText.begin(), menuSearchText.end(), ' '), menuSearchText.end());
     ImGui::SetNextWindowSizeConstraints({ ImGui::GetContentRegionAvail().x, 0 },
                                         { ImGui::GetContentRegionAvail().x, ImGui::GetContentRegionAvail().y });
-    if (ImGui::BeginChild("Search Results Col 1", { ImGui::GetContentRegionAvail().x, 0 },
-                          ImGuiChildFlags_AutoResizeY, ImGuiWindowFlags_NoTitleBar)) {
+    if (ImGui::BeginChild("Search Results Col 1", { ImGui::GetContentRegionAvail().x, 0 }, ImGuiChildFlags_AutoResizeY,
+                          ImGuiWindowFlags_NoTitleBar)) {
         for (auto& menuLabel : menuOrder) {
             auto& menuEntry = menuEntries.at(menuLabel);
             for (auto& sidebarLabel : menuEntry.sidebarOrder) {


### PR DESCRIPTION
- Move adaptivefps toggle into Dev Tools -> Stats along with other fps related things
- Adjust draw distance to be a slider, refine maximum distance and fade effects
- Sort the Enhancements -> Graphics menu
- Add interpolation handling for shadows to fix wrong transforms
- Fix egg ejection wrongly limited on Modern and Pocket controls
- Sort the Enhancements -> Camera menu and add toggles for Invert Camera (all control modes)
- Add "Go to Grunty's Lair" option in Spiral Mountain after player has been to the Lair at least once
- Fix a romhacks extraction location bug in Linux
- Fix Bottles Bonus Persistence always on