### PR TITLE
Fix HD dialog-font crash on v1.1/PAL/JP bases

### DIFF
--- a/src/core2/font/print.c
+++ b/src/core2/font/print.c
@@ -5,6 +5,7 @@
 
 extern int ResourceMgr_GetDialogLanguageCount(void);
 extern int ResourceMgr_IsJapanese(void);
+extern void port_dialogFontHd_rebuild(void);
 // [port] PAL font has 75 glyphs (0x21-0x6B), overlapping NTSC control codes b,d,e,f,h,j.
 // When PAL, fmtStrings use shifted codes above the glyph range.
 #define PRINT_PAL (ResourceMgr_GetDialogLanguageCount() > 1)
@@ -478,6 +479,7 @@ void print_init(void){
     D_80380AB8[4] = assetcache_get(print_getCurrentMapBoldFontTexture());
     print_sFonts[0] =  print_getLettersFromFont(D_80380AB8[0], D_80380AB8[4]);
     print_sDialogFontGlyphCount = sprite_getFramePtr(D_80380AB8[0], 0)->chunkCnt;
+    port_dialogFontHd_rebuild();
     print_sFonts[1] =  print_getLettersFromFont(D_80380AB8[1], D_80380AB8[4]);
     if (PRINT_JP) {
         // [port] JP font index 2 = the Japanese dialog font (sprite 1770, 256 I4 glyphs).

--- a/src/port/Localization/Localization.cpp
+++ b/src/port/Localization/Localization.cpp
@@ -46,6 +46,7 @@ void* assetcache_get(int assetId);
 void assetcache_release(void* ptr);
 void bk_free(void* ptr);
 void port_refreshDialogFontGlyphCount(void);
+void port_dialogFontHd_rebuild(void);
 }
 
 // Live language change reactions
@@ -96,6 +97,8 @@ void ReloadDialogFontSlot() {
     assetcache_release(tex);
     // A pack may ship an extended dialog font; refresh the reachable glyph count to match.
     port_refreshDialogFontGlyphCount();
+    // Build cross-revision-corrected HD glyph textures for the current base (no-op without a pack).
+    port_dialogFontHd_rebuild();
 }
 
 // Per cached-model-slot generation

--- a/src/port/Resource/Alt/AltDialogFont.cpp
+++ b/src/port/Resource/Alt/AltDialogFont.cpp
@@ -1,0 +1,129 @@
+// Cross-revision HD dialog font.
+//
+// The dialog font changed between ROM revisions: US v1.0 has 62 glyphs at native 8x12; v1.1/PAL/JP
+// extended it to 75 glyphs at 8x13 (the extra 13 are the PAL accents; every glyph also grew one row).
+// A LOAD_AS_RAW alt bakes its h/v scale factors against the native dims of the ROM the pack was built
+// from, so a v1.0-built pack's glyph carries a scale computed for 12 rows.
+//
+// The pixels are fine; only the baked scale is wrong, and it is wrong purely because native dims
+// differ between revisions. Calculate and re-scale port-side so hd packs don't need per-revision art.
+
+#include <libultraship.h>
+#include <ship/Context.h>
+#include <ship/resource/ResourceManager.h>
+#include <fast/resource/type/Texture.h>
+
+#include "port/Enhancements/Events/Hooks/Events.h"
+#include "port/ShipInit.hpp"
+
+#include <cstdint>
+#include <cstring>
+#include <memory>
+#include <string>
+#include <vector>
+
+extern "C" void port_dialogFontHd_rebuild(void);
+
+namespace {
+
+constexpr const char* kFontBase = "assets/sprite/ASSET_6EB_DIALOG_FONT_ALPHAMASK";
+
+bool sBuilt = false;
+
+std::shared_ptr<Fast::Texture> loadTex(const std::string& path, bool loadExact) {
+    return std::static_pointer_cast<Fast::Texture>(
+        Ship::Context::GetRawInstance()->GetResourceManager()->LoadResourceProcess(path, loadExact));
+}
+
+// Build a corrected alt for one chunk and cache it under "alt/<basePath>". Returns false when there
+// is nothing to do: no alt shipped, the dims already reconcile, or the alt isn't an HD raw texture.
+bool correctChunk(const std::string& basePath) {
+    auto base = loadTex(basePath, true); // live native cell
+    if (base == nullptr || base->Width <= 0 || base->Height <= 0) {
+        return false;
+    }
+    auto alt = loadTex(basePath, false); // HD art, or the base itself if the pack has no alt
+    if (alt == nullptr || alt->ImageData == nullptr || alt.get() == base.get()) {
+        return false;
+    }
+    if (alt->Type != Fast::TextureType::RGBA32bpp || (alt->Flags & TEX_FLAG_LOAD_AS_RAW) == 0) {
+        return false;
+    }
+
+    const int nativeW = base->Width;
+    const int nativeH = base->Height;
+
+    // Width is revision-stable (drift is height-only), so the integer scale comes cleanly off it.
+    // Bail if the alt isn't an integer multiple of the native width, or is degenerate.
+    if (nativeW <= 0 || alt->Width % nativeW != 0) {
+        return false;
+    }
+    const int k = alt->Width / nativeW;
+    if (k < 1) {
+        return false;
+    }
+
+    const int dstW = nativeW * k;
+    const int dstH = nativeH * k;
+    if (dstH == (int)alt->Height) {
+        return false; // alt height already matches the live native cell -> no drift, nothing to fix
+    }
+
+    // Top-align the HD rows into the k-scaled native cell; the zero-filled remainder stays transparent.
+    const int copyRows = (int)alt->Height < dstH ? (int)alt->Height : dstH;
+    const int rowBytes = dstW * 4;
+
+    auto pixels = std::make_shared<std::vector<char>>((size_t)dstW * dstH * 4, 0);
+    for (int r = 0; r < copyRows; r++) {
+        std::memcpy(pixels->data() + (size_t)r * rowBytes, alt->ImageData + (size_t)r * rowBytes, (size_t)rowBytes);
+    }
+
+    // Same HD pixels, but VPixelScale re-derived against the live native rows (native_rows * k == dstH).
+    // Cache under the alt path so the resource layer returns this in place of the raw archive alt.
+    const std::string altPath = std::string("alt/") + basePath;
+    auto initData = std::make_shared<Ship::ResourceInitData>();
+    initData->Path = altPath;
+    auto tex = std::make_shared<Fast::Texture>(initData);
+    tex->Type = Fast::TextureType::RGBA32bpp;
+    tex->Width = (uint16_t)dstW;
+    tex->Height = (uint16_t)dstH;
+    tex->Flags = TEX_FLAG_LOAD_AS_RAW;
+    tex->HByteScale = alt->HByteScale;
+    tex->VPixelScale = (float)k;
+    tex->ImageDataSize = (uint32_t)pixels->size();
+    tex->mImageBuffer = pixels;
+    tex->ImageData = (uint8_t*)pixels->data();
+
+    Ship::Context::GetRawInstance()->GetResourceManager()->CacheExternalResource(altPath, tex);
+    return true;
+}
+
+} // namespace
+
+// Called when the dialog font is (re)loaded. Scans every font chunk once per boot and corrects each;
+// idempotent, and a no-op when no alt pack is mounted (a later call may still succeed).
+extern "C" void port_dialogFontHd_rebuild(void) {
+    if (sBuilt) {
+        return;
+    }
+    if (!Ship::Context::GetRawInstance()->GetResourceManager()->IsAltAssetsEnabled()) {
+        return;
+    }
+    sBuilt = true;
+
+    for (int frame = 0; frame < 64; frame++) {
+        bool anyInFrame = false;
+        for (int chunk = 0; chunk < 256; chunk++) {
+            const std::string basePath =
+                std::string(kFontBase) + "_" + std::to_string(frame) + "_" + std::to_string(chunk);
+            if (loadTex(basePath, true) == nullptr) {
+                break;
+            }
+            anyInFrame = true;
+            correctChunk(basePath);
+        }
+        if (!anyInFrame) {
+            break;
+        }
+    }
+}


### PR DESCRIPTION
HD font glyphs built on US v1.0 crash the game when run on a v1.1, PAL, or JP base. This corrects the mismatch entirely port-side, so a pack needs no per-revision art. One HD pack works across every ROM revision.

## Problem
The dialog font `ASSET_6EB_DIALOG_FONT_ALPHAMASK` changed between revisions: US v1.0 has 62 glyphs at 12 rows tall, while v1.1/PAL/JP extended it to 75 glyphs at 13 rows (an added accent row, plus the 13 French uppercase accents). A `LOAD_AS_RAW` HD alt bakes its vertical scale factor against the native dimensions of the ROM it was built from. Loaded on a base whose native cell is one row taller, the interpreter's reconstructed replacement height `native_rows * baked_scale` no longer equals the alt's own height, it falls into a partial-load path that collapses the upload, and `CreateTexture2D` throws `E_INVALIDARG`.

## Solution
A new preload `AltDialogFont.cpp` runs when the dialog font is (re)loaded. For each chunk it loads the live native cell and the HD alt, re-lays the art top-aligned into a k-scaled native cell (k derived from the revision-stable width), pads the extra row transparent, and re-derives `VPixelScale` against the live native rows so the reconstructed height matches exactly. The corrected texture is cached under its `alt/…` path, which the resource layer returns in place of the raw archive alt for every draw. Where native dims already match what the alt was baked for (a v1.0 pack on a v1.0 base), it detects no drift and skips.

<img width="2283" height="875" alt="image" src="https://github.com/user-attachments/assets/ad10b400-7c50-4d82-bdd6-9a006206a66a" />