### PR TITLE
Fix SkipSM to account for Rando.

### DIFF
--- a/src/port/Enhancements/Gameplay/SkipSMTutorial.cpp
+++ b/src/port/Enhancements/Gameplay/SkipSMTutorial.cpp
@@ -3,6 +3,7 @@
 #include "port/Enhancements/Events/Hooks/Events.h"
 #include "port/ShipInit.hpp"
 #include "port/Romhack/RomhackConfig.h"
+#include "port/Rando/Rando.h"
 
 extern "C" {
 #include "enums.h"
@@ -36,20 +37,23 @@ void RegisterSkipSMTutorial_Init() {
         }
         auto* ev = reinterpret_cast<OnNewGame*>(event);
 
-        for (ability_e ability : kSpiralMountainAbilities) {
-            ability_unlock(ability);
+        if (!IS_RANDO) {
+            for (ability_e ability : kSpiralMountainAbilities) {
+                ability_unlock(ability);
+            }
+
+            for (ability_used move : kSpiralMountainUsedMoves) {
+                ability_setHasUsed(static_cast<ability_e>(move));
+            }
+
+            for (int honeycomb = HONEYCOMB_13_SM_STUMP; honeycomb <= HONEYCOMB_18_SM_QUARRIES; honeycomb++) {
+                honeycombscore_set((honeycomb_e)honeycomb, true);
+            }
+            func_8034789C();
+            item_adjustByDiffWithoutHud(ITEM_14_HEALTH,
+                item_getCount(ITEM_15_HEALTH_TOTAL) - item_getCount(ITEM_14_HEALTH));
         }
 
-        for (ability_used move : kSpiralMountainUsedMoves) {
-            ability_setHasUsed(static_cast<ability_e>(move));
-        }
-
-        for (int honeycomb = HONEYCOMB_13_SM_STUMP; honeycomb <= HONEYCOMB_18_SM_QUARRIES; honeycomb++) {
-            honeycombscore_set((honeycomb_e)honeycomb, true);
-        }
-        func_8034789C();
-        item_adjustByDiffWithoutHud(ITEM_14_HEALTH,
-                                    item_getCount(ITEM_15_HEALTH_TOTAL) - item_getCount(ITEM_14_HEALTH));
         fileProgressFlag_set(FILEPROG_BD_ENTER_LAIR_CUTSCENE, 1);
         D_80386000[LEVEL_B_SPIRAL_MOUNTAIN] = 122.0f; // Average speedrun time for SM completion (2:02)
 

--- a/src/port/Rando/CustomObject/CustomObject.cpp
+++ b/src/port/Rando/CustomObject/CustomObject.cpp
@@ -340,7 +340,9 @@ void CustomObject::CheckObtainedEX(RandoCheckId randoCheckId, bool isInit) {
             shouldRemoveEX = true;
             RANDO_SAVE_CHECKS[pool.randoCheckId].obtained = true;
             CustomObject::RemoveSpawnedIdFromList(randoCheckId);
-            if (!isInit) {
+            if (isInit) {
+                CustomObject::ResolveCustomActorCollisionEX(randoCheckId);
+            } else {
                 Rando::StaticData::SendCollisionNotification(pool.randoCheckId);
             }
             Rando::StaticData::ModifyRandoInfFlagState(randoCheckId);

--- a/src/port/Rando/Logic/GenerateSaveData.cpp
+++ b/src/port/Rando/Logic/GenerateSaveData.cpp
@@ -187,6 +187,10 @@ void Rando::Logic::GrantStartingLoadout() {
             }
 
             CustomObject::CheckObtainedEX(smCheckId, true);
+            if (randoSaveCheck.randoItemId == RI_MOLEHILL) {
+                ability_setLearned((ability_e)randoSaveCheck.randoCollectionId, true);
+                ability_setHasUsed((ability_e)randoSaveCheck.randoCollectionId);
+            }
         }
     }
 }


### PR DESCRIPTION
Adds ability and collection flows to the Rando Side of the house and gates off some functionality for the Vanilla Side.