### PR TITLE
Hotfix for camera orbit core

### DIFF
--- a/src/port/Controller/ModernCamera.cpp
+++ b/src/port/Controller/ModernCamera.cpp
@@ -3,6 +3,8 @@
 // The right stick orbits the camera in yaw around the player (no pitch). It runs
 // on the shared orbit core; this file is just the modern-scheme policy.
 
+#include <cmath>
+
 #include <libultraship/bridge.h>
 
 #include "port/UI/cvar_prefixes.h"
@@ -24,6 +26,9 @@ int balookat_getState(void);    // nonzero while the look-around camera is activ
 int player_movementGroup(void); // enum bsgroup_e
 
 int ncDynamicCamera_getState(void);
+int func_8029147C(void);       // current ba camera mode
+void func_80291488(int mode);  // set the ba camera mode
+void func_802914CC(int state); // force a dynamic camera state (mode 1)
 
 int bainput_should_rotate_camera_left(void);
 int bainput_should_rotate_camera_right(void);
@@ -41,6 +46,9 @@ bool ModernSchemeActive() {
     return CVarGetInteger(CVAR_SETTING("Controls.Scheme"), CONTROL_SCHEME_RETRO) == CONTROL_SCHEME_MODERN;
 }
 
+constexpr int kClimbCamState = 0x10;
+constexpr int kSwivelCamMode = 8;
+constexpr int kFollowCamMode = 2;
 constexpr float kYawDeadzone = 0.2f;
 constexpr float kYawEnter = 0.3f;
 constexpr float kYawSpeed = 160.0f;
@@ -81,13 +89,34 @@ bool ManualCameraControl() {
            bainput_should_look_first_person_camera();
 }
 
+bool Climbing() {
+    return player_movementGroup() == BSGROUP_5_CLIMB;
+}
+
+// Give the mode back
+void ReleaseSwivelMode() {
+    if (func_8029147C() != kSwivelCamMode) {
+        return;
+    }
+    if (Climbing()) {
+        func_802914CC(kClimbCamState);
+    } else {
+        func_80291488(kFollowCamMode);
+    }
+}
+
+void ExitOrbit() {
+    OrbitCamera_Exit(&sModern);
+    ReleaseSwivelMode();
+}
+
 } // namespace
 
 extern "C" int port_modernCamera_handleYaw(void) {
     bool schemeOk = ModernSchemeActive() && bs_getState() != BS_CROUCH && !IsDemoMode();
     if (!schemeOk) {
         if (sModern.active) {
-            OrbitCamera_Exit(&sModern);
+            ExitOrbit();
         }
         return 0;
     }
@@ -102,8 +131,11 @@ extern "C" int port_modernCamera_handleYaw(void) {
             return 0;
         }
         if (ManualCameraControl()) {
-            OrbitCamera_Exit(&sModern);
+            ExitOrbit();
             return 0;
+        }
+        if (!Climbing()) {
+            ReleaseSwivelMode();
         }
         return 1;
     }
@@ -111,8 +143,11 @@ extern "C" int port_modernCamera_handleYaw(void) {
     float x;
     float y;
     ReadStickNorm(x, y);
-    if (x > kYawEnter || x < -kYawEnter) {
+    if (std::fabs(x) > kYawEnter) {
         OrbitCamera_Enter(&sModern);
+        if (state == kClimbCamState) {
+            func_80291488(kSwivelCamMode);
+        }
         return 1;
     }
     return 0;

--- a/src/port/Enhancements/Camera/OrbitCameraCore.cpp
+++ b/src/port/Enhancements/Camera/OrbitCameraCore.cpp
@@ -30,8 +30,9 @@ namespace {
 
 constexpr float kDistanceRate = 8.0f;
 constexpr float kReturnRateFactor = 0.2f; // collision offset relaxes this much slower than it deepens
-constexpr float kVertRate = 0.8f;         // height + aim Y follow rate; low to filter floor-height churn
-constexpr float kRotRate = 12.0f;         // look-at damping, mirroring the vanilla follow camera
+constexpr float kHeightRate = 2.0f;
+constexpr float kAimHeightRate = 8.0f;
+constexpr float kRotRate = 12.0f; // look-at damping, mirroring the vanilla follow camera
 
 float clampf(float v, float lo, float hi) {
     return v < lo ? lo : (v > hi ? hi : v);
@@ -120,7 +121,7 @@ extern "C" void OrbitCamera_Update(OrbitCamera* c, float yawDelta, float pitchDe
         pos[1] = center[1] + offset[1]; // pitch carries the vertical offset
     } else {
         // Flat orbit: height low-passes the vanilla target, filtering plank/step floor churn.
-        c->height += (func_802BD51C() - c->height) * clampf(kVertRate * dt, 0.0f, 1.0f);
+        c->height += (func_802BD51C() - c->height) * clampf(kHeightRate * dt, 0.0f, 1.0f);
         pos[1] = c->height;
     }
     ncDynamicCamera_setPosition(pos);
@@ -166,7 +167,7 @@ extern "C" void OrbitCamera_Update(OrbitCamera* c, float yawDelta, float pitchDe
         c->aimCenterY = center[1];
         c->aimValid = 1;
     } else {
-        c->aimCenterY += (center[1] - c->aimCenterY) * clampf(kVertRate * dt, 0.0f, 1.0f);
+        c->aimCenterY += (center[1] - c->aimCenterY) * clampf(kAimHeightRate * dt, 0.0f, 1.0f);
     }
     float aimCenter[3] = { center[0], c->aimCenterY, center[2] };
 

--- a/src/port/Enhancements/Camera/OrbitCameraCore.cpp
+++ b/src/port/Enhancements/Camera/OrbitCameraCore.cpp
@@ -11,6 +11,7 @@ int ncDynamicCamera_getState(void);
 void ncDynamicCamera_setState(int state);
 
 void func_802C02D4(float center[3]);                                                 // camera focus/orbit center
+void func_802C0150(int mode);                                                        // select the focus target
 void func_80256E24(float dst[3], float pitch, float yaw, float x, float y, float z); // spherical -> offset
 int func_8025801C(float vec[3], float* yaw);                                         // vector -> yaw (degrees)
 void func_802BC434(float rotOut[3], float fromPos[3], float targetPos[3]);           // look-at rotation
@@ -41,6 +42,8 @@ float clampf(float v, float lo, float hi) {
 } // namespace
 
 extern "C" void OrbitCamera_Capture(OrbitCamera* c) {
+    func_802C0150(2);
+
     float camPos[3];
     float center[3];
     ncDynamicCamera_getPosition(camPos);


### PR DESCRIPTION
https://github.com/HarbourMasters/Lighthouse/pull/252/changes/95124ae688b5464cf1278c981267262c361ba05c resolved a motion-sickness inducing jitter in orbit camera core, but part of the series of test changes made it through causing the camera's height and aim to lag ~1s vertically, tilting the view toward the floor instead of Banjo. This PR resolves it.