### PR TITLE
[Rando] Spoiler Log Implementation

### DIFF
--- a/src/port/Rando/LighthouseMenuRando.cpp
+++ b/src/port/Rando/LighthouseMenuRando.cpp
@@ -73,12 +73,12 @@ void LighthouseMenu::AddMenuRando() {
 
         ImGui::BeginDisabled(!CVarGetInteger(CVAR_RANDOMIZER_SETTING("UseExistingLog"), 0));
         if (UIWidgets::CVarCombobox("Seed", CVAR_RANDOMIZER_SETTING("SpoilerFileIndex"), spoilerLogPtrs,
-            { .labelPosition = UIWidgets::LabelPositions::None, .color = WIDGET_COLOR })) {
+                                    { .labelPosition = UIWidgets::LabelPositions::None, .color = WIDGET_COLOR })) {
             if (CVarGetInteger(CVAR_RANDOMIZER_SETTING("SpoilerFileIndex"), 0) == 0) {
                 CVarSetString(CVAR_RANDOMIZER_SETTING("SpoilerFile"), "");
-            }
-            else {
-                std::string spoilerName = Rando::Spoiler::spoilerLogs[CVarGetInteger(CVAR_RANDOMIZER_SETTING("SpoilerFileIndex"), 0)];
+            } else {
+                std::string spoilerName =
+                    Rando::Spoiler::spoilerLogs[CVarGetInteger(CVAR_RANDOMIZER_SETTING("SpoilerFileIndex"), 0)];
                 CVarSetString("gRandoSettings.SpoilerFile", spoilerName.c_str());
             }
         }

--- a/src/port/Rando/LighthouseMenuRando.cpp
+++ b/src/port/Rando/LighthouseMenuRando.cpp
@@ -7,6 +7,7 @@
 
 #include "port/Rando/CustomObject/CustomObject.h"
 #include "port/Rando/Logic/Logic.h"
+#include "port/Rando/Spoiler/Spoiler.h"
 
 #include <spdlog/fmt/fmt.h>
 
@@ -59,6 +60,31 @@ void LighthouseMenu::AddMenuRando() {
         }
         UIWidgets::PopStyleCombobox();
     });
+    AddWidget(path, "Load Existing Spoiler Log", WIDGET_CVAR_CHECKBOX)
+        .CVar(CVAR_RANDOMIZER_SETTING("UseExistingLog"))
+        .RaceDisable(false)
+        .Options(CheckboxOptions().Tooltip("Uses a Spoiler Log in the randomizer folder."));
+    AddWidget(path, "Available Spoiler Logs", WIDGET_CUSTOM).CustomFunction([](WidgetInfo& info) {
+        std::vector<const char*> spoilerLogPtrs;
+        spoilerLogPtrs.reserve(Rando::Spoiler::spoilerLogs.size());
+        for (const auto& log : Rando::Spoiler::spoilerLogs) {
+            spoilerLogPtrs.push_back(log.c_str());
+        }
+
+        ImGui::BeginDisabled(!CVarGetInteger(CVAR_RANDOMIZER_SETTING("UseExistingLog"), 0));
+        if (UIWidgets::CVarCombobox("Seed", CVAR_RANDOMIZER_SETTING("SpoilerFileIndex"), spoilerLogPtrs,
+            { .labelPosition = UIWidgets::LabelPositions::None, .color = WIDGET_COLOR })) {
+            if (CVarGetInteger(CVAR_RANDOMIZER_SETTING("SpoilerFileIndex"), 0) == 0) {
+                CVarSetString(CVAR_RANDOMIZER_SETTING("SpoilerFile"), "");
+            }
+            else {
+                std::string spoilerName = Rando::Spoiler::spoilerLogs[CVarGetInteger(CVAR_RANDOMIZER_SETTING("SpoilerFileIndex"), 0)];
+                CVarSetString("gRandoSettings.SpoilerFile", spoilerName.c_str());
+            }
+        }
+        ImGui::EndDisabled();
+    });
+
     AddWidget(path, "Send Collection Notifications", WIDGET_CVAR_CHECKBOX)
         .CVar(CVAR_RANDOMIZER_SETTING("RandoNotifications"))
         .Options(CheckboxOptions().Tooltip("Sends notifications when you collect a Rando Item."));

--- a/src/port/Rando/Logic/GenerateSaveData.cpp
+++ b/src/port/Rando/Logic/GenerateSaveData.cpp
@@ -170,25 +170,30 @@ void Rando::Logic::GrantStartingLoadout() {
             item_setMaxCount(item);
         }
     }
+}
 
-    // Set progress flag for tutorial dialogue, skipping them
+void Rando::Logic::GrantFileProgressFlags() {
     for (auto& fileprog : progressLoadout) {
         fileProgressFlag_set(fileprog, 1);
     }
+}
 
-    if (CVarGetInteger(CVAR_ENHANCEMENT("Gameplay.SkipSMTutorial"), 0)) {
-        for (auto& smCheckId : smRandoCheckIdList) {
-            RandoSaveCheck randoSaveCheck = RANDO_SAVE_CHECKS[smCheckId];
+void Rando::Logic::GrantSpiralMountainChecks() {
+    if (!CVarGetInteger(CVAR_ENHANCEMENT("Gameplay.SkipSMTutorial"), 0)) {
+        return;
+    }
 
-            if (!randoSaveCheck.isShuffled) {
-                continue;
-            }
+    for (auto& smCheckId : smRandoCheckIdList) {
+        RandoSaveCheck randoSaveCheck = RANDO_SAVE_CHECKS[smCheckId];
 
-            CustomObject::CheckObtainedEX(smCheckId, true);
-            if (randoSaveCheck.randoItemId == RI_MOLEHILL) {
-                ability_setLearned((ability_e)randoSaveCheck.randoCollectionId, true);
-                ability_setHasUsed((ability_e)randoSaveCheck.randoCollectionId);
-            }
+        if (!randoSaveCheck.isShuffled) {
+            continue;
+        }
+
+        CustomObject::CheckObtainedEX(smCheckId, true);
+        if (randoSaveCheck.randoItemId == RI_MOLEHILL) {
+            ability_setLearned((ability_e)randoSaveCheck.randoCollectionId, true);
+            ability_setHasUsed((ability_e)randoSaveCheck.randoCollectionId);
         }
     }
 }

--- a/src/port/Rando/Logic/Logic.h
+++ b/src/port/Rando/Logic/Logic.h
@@ -19,6 +19,8 @@ extern int32_t randoFinalSeed;
 
 extern std::map<ability_e, std::pair<const char*, const char*>> abilityLoadoutMap;
 extern std::map<item_e, std::pair<const char*, const char*>> itemLoadoutMap;
+extern std::vector<file_progress_e> progressLoadout;
+extern std::vector<RandoCheckId> smRandoCheckIdList;
 
 extern Rando::StaticData::RandoLogicData reachableRegions[RR_MAX];
 extern Rando::StaticData::RandoLogicData reachableEvents[RA_MAX];
@@ -54,6 +56,8 @@ void GeneratePoolFromSaveData(SaveData* saveData);
 void InitializeSaveData(SaveData* saveData);
 void GenerateSaveData(SaveData* saveData);
 void GrantStartingLoadout();
+void GrantFileProgressFlags();
+void GrantSpiralMountainChecks();
 
 void RefreshReachableRegions();
 

--- a/src/port/Rando/MiscBehavior/OnFileLoad.cpp
+++ b/src/port/Rando/MiscBehavior/OnFileLoad.cpp
@@ -32,7 +32,8 @@ void Rando::MiscBehavior::OnFileLoad() {
 
         if (CVarGetInteger(CVAR_RANDOMIZER_SETTING("Enable"), 0)) {
             Rando::Logic::InitializeSaveData(saveData);
-            if (CVarGetInteger(CVAR_RANDOMIZER_SETTING("UseExistingLog"), 0) && CVarGetString(CVAR_RANDOMIZER_SETTING("SpoilerFile"), "")) {
+            if (CVarGetInteger(CVAR_RANDOMIZER_SETTING("UseExistingLog"), 0) &&
+                CVarGetString(CVAR_RANDOMIZER_SETTING("SpoilerFile"), "")) {
                 std::string spoilerPath = CVarGetString(CVAR_RANDOMIZER_SETTING("SpoilerFile"), "");
                 Rando::Spoiler::GenerateFromSpoiler(Rando::Spoiler::LoadFromFile(spoilerPath.c_str()));
             } else {

--- a/src/port/Rando/MiscBehavior/OnFileLoad.cpp
+++ b/src/port/Rando/MiscBehavior/OnFileLoad.cpp
@@ -1,12 +1,13 @@
 #include "MiscBehavior.h"
 #include <libultraship/bridge/consolevariablebridge.h>
+#include "ship/Context.h"
 #include "port/Enhancements/Events/Hooks/Events.h"
 #include "port/UI/Notification.h"
 
 #include "port/Save/Types.h"
 
 #include "port/Rando/Logic/Logic.h"
-// #include "port/Rando/Spoiler/Spoiler.h"
+#include "port/Rando/Spoiler/Spoiler.h"
 
 void Rando::MiscBehavior::OnFileLoad() {
     REGISTER_LISTENER(OnGameLoad, EVENT_PRIORITY_NORMAL, [](IEvent* event) {
@@ -29,10 +30,22 @@ void Rando::MiscBehavior::OnFileLoad() {
             return;
         }
 
-        if (CVarGetInteger("gRandoSettings.Enable", 0)) {
+        if (CVarGetInteger(CVAR_RANDOMIZER_SETTING("Enable"), 0)) {
             Rando::Logic::InitializeSaveData(saveData);
-            Rando::Logic::GenerateShufflePool(saveData);
-            Rando::Logic::GrantStartingLoadout();
+            if (CVarGetInteger(CVAR_RANDOMIZER_SETTING("UseExistingLog"), 0) && CVarGetString(CVAR_RANDOMIZER_SETTING("SpoilerFile"), "")) {
+                std::string spoilerPath = CVarGetString(CVAR_RANDOMIZER_SETTING("SpoilerFile"), "");
+                Rando::Spoiler::GenerateFromSpoiler(Rando::Spoiler::LoadFromFile(spoilerPath.c_str()));
+            } else {
+                Rando::Logic::GenerateShufflePool(saveData);
+                Rando::Logic::GrantStartingLoadout();
+                Rando::Logic::GrantFileProgressFlags();
+                Rando::Logic::GrantSpiralMountainChecks();
+                std::string spoilerName = std::to_string(saveData->shipSaveData.randoSaveData.seedId).c_str();
+                std::erase(spoilerName, '-');
+                spoilerName += ".json";
+                Rando::Spoiler::SaveToFile(spoilerName, Rando::Spoiler::GenerateFromPoolGeneration());
+            }
+
             saveData->shipSaveData.fileType = FILE_TYPE_SAVE_RANDO;
             saveData->shipSaveData.fileCreatedAt = GetUnixTimestamp();
             CALL_EVENT(InitRandoEvents);

--- a/src/port/Rando/Rando.cpp
+++ b/src/port/Rando/Rando.cpp
@@ -5,7 +5,7 @@
 #include "MiscBehavior/MiscBehavior.h"
 #include "port/Rando/CheckTracker/CheckTracker.h"
 // #include "port/Rando/EntranceTracker/EntranceTracker.h"
-// #include "port/Rando/Spoiler/Spoiler.h"
+#include "port/Rando/Spoiler/Spoiler.h"
 #include "port/ShipInit.hpp"
 
 #include "spdlog/spdlog.h"
@@ -23,7 +23,7 @@ void Rando::Init() {
         fs::create_directory(randomizerFolderPath);
     }
 
-    // Rando::Spoiler::RefreshSpoilerLogs();
+    Rando::Spoiler::RefreshSpoilerLogs();
     Rando::MiscBehavior::Init();
     // Rando::EntranceTracker::Init();
     // Ship::Context::GetInstance()->GetFileDropMgr()->RegisterDropHandler(Rando::Spoiler::HandleFileDropped);

--- a/src/port/Rando/Spoiler/File.cpp
+++ b/src/port/Rando/Spoiler/File.cpp
@@ -19,7 +19,6 @@ void SaveToFile(const std::string& fileName, nlohmann::ordered_json spoiler) {
         fs::create_directories(testDirectory);
     }
 
-
     std::ofstream fileStream(filePath);
     if (!fileStream.is_open()) {
         Notification::Emit(

--- a/src/port/Rando/Spoiler/File.cpp
+++ b/src/port/Rando/Spoiler/File.cpp
@@ -1,0 +1,72 @@
+#include "Spoiler.h"
+#include "port/ui/Notification.h"
+#include "ship/Context.h"
+#include <fstream>
+
+extern std::string CollapsedJSONArray(const nlohmann::ordered_json& jsonFile);
+
+namespace fs = std::filesystem;
+
+namespace Rando {
+
+namespace Spoiler {
+
+void SaveToFile(const std::string& fileName, nlohmann::ordered_json spoiler) {
+    std::string testDirectory = Ship::Context::GetPathRelativeToAppDirectory("randomizer/", "bk64");
+    std::string filePath = Ship::Context::GetPathRelativeToAppDirectory("randomizer/" + fileName, "bk64");
+
+    if (!fs::exists(testDirectory)) {
+        fs::create_directories(testDirectory);
+    }
+
+
+    std::ofstream fileStream(filePath);
+    if (!fileStream.is_open()) {
+        Notification::Emit(
+            { .message = "Error: Failed to open spoiler file.", .messageColor = ImVec4(0.85f, 0.3f, 0, 1) });
+        return;
+    }
+
+    std::string collapsedString = CollapsedJSONArray(spoiler);
+    if (fileStream.is_open()) {
+        fileStream << collapsedString;
+        fileStream.close();
+    } else {
+        Notification::Emit(
+            { .message = "Error: Failed to open save file.", .messageColor = ImVec4(0.85f, 0.3f, 0, 1) });
+    }
+
+    fileStream << spoiler.dump(4);
+}
+
+nlohmann::json LoadFromFile(const std::string& fileName) {
+    nlohmann::json spoiler;
+    std::string spoilerFilePath = Ship::Context::GetPathRelativeToAppDirectory("randomizer/" + fileName, "bk64");
+    std::ifstream fileStream(spoilerFilePath);
+
+    if (!fs::exists(spoilerFilePath)) {
+        return spoiler;
+    }
+
+    if (!fileStream.is_open()) {
+        Notification::Emit(
+            { .message = "Error: Failed to open spoiler file.", .messageColor = ImVec4(0.85f, 0.3f, 0, 1) });
+        return spoiler;
+    }
+
+    try {
+        fileStream >> spoiler;
+    } catch (nlohmann::json::exception& e) {
+        throw std::runtime_error("Failed to parse spoiler file: " + std::string(e.what()));
+    }
+
+    if (!spoiler.contains("type") || spoiler["type"] != "LIGHTHOUSE_RANDO_SPOILER") {
+        throw std::runtime_error("Spoiler file is not a valid spoiler file");
+    }
+
+    return spoiler;
+}
+
+} // namespace Spoiler
+
+} // namespace Rando

--- a/src/port/Rando/Spoiler/Generate.cpp
+++ b/src/port/Rando/Spoiler/Generate.cpp
@@ -66,7 +66,7 @@ void GenerateFromSpoiler(nlohmann::json spoiler) {
             RandoSaveCheck checkEntry = RandoSaveCheck_from_json(data.value(), checkEntry);
             checkEntry.name = Rando::StaticData::Checks[checkEntry.randoCheckId].name;
             RANDO_SAVE_CHECKS[checkEntry.randoCheckId] = checkEntry;
-            
+
             Rando::Logic::shuffledPool.push_back(checkEntry);
         }
     }

--- a/src/port/Rando/Spoiler/Generate.cpp
+++ b/src/port/Rando/Spoiler/Generate.cpp
@@ -100,7 +100,7 @@ void GenerateFromSpoiler(nlohmann::json spoiler) {
     Rando::Logic::GrantFileProgressFlags();
     Rando::Logic::GrantSpiralMountainChecks();
 
-    Notification::Emit({ .message = "Loaded from Spoiler Log.", .messageColor = ImVec4(0.85f, 0.3f, 0, 1) });
+    Notification::Emit({ .message = "Loaded from Spoiler Log.", .messageColor = ImVec4(0, 0.85f, 0, 1) });
 }
 
 } // namespace Spoiler

--- a/src/port/Rando/Spoiler/Generate.cpp
+++ b/src/port/Rando/Spoiler/Generate.cpp
@@ -1,0 +1,108 @@
+#include "Spoiler.h"
+#include <libultraship/bridge/consolevariablebridge.h>
+#include "port/Rando/Logic/Logic.h"
+#include "port/ui/Notification.h"
+
+extern void RandoSaveCheck_to_json(nlohmann::json& j, const RandoSaveCheck& randoSaveCheck);
+extern RandoSaveCheck RandoSaveCheck_from_json(const nlohmann::json& j, RandoSaveCheck& randoSaveCheck);
+
+namespace Rando {
+
+namespace Spoiler {
+nlohmann::ordered_json GenerateFromPoolGeneration() {
+    nlohmann::ordered_json orderedSpoiler = nlohmann::ordered_json::object();
+
+    orderedSpoiler["type"] = "LIGHTHOUSE_RANDO_SPOILER";
+    orderedSpoiler["seed"] = 0; // TODO: Add once Manual Seed Input is finished.
+
+    orderedSpoiler["options"] = nlohmann::json::object();
+    for (auto& optionEntry : RANDO_SAVE_OPTIONS) {
+        orderedSpoiler["options"][optionEntry.name] = optionEntry.optionValue;
+    }
+
+    orderedSpoiler["checks"] = nlohmann::json::object();
+
+    for (auto& checkEntry : RANDO_SAVE_CHECKS) {
+        nlohmann::json check = nlohmann::json::object();
+        RandoSaveCheck_to_json(check, checkEntry);
+
+        if (checkEntry.randoCheckId == RC_UNKNOWN) {
+            checkEntry.name = "RC_UNKNOWN";
+        }
+
+        orderedSpoiler["checks"][checkEntry.name] = check;
+    }
+
+    orderedSpoiler["loadout"] = nlohmann::json::object();
+
+    orderedSpoiler["loadout"]["abilities"] = nlohmann::json::array();
+    orderedSpoiler["loadout"]["abilities"].push_back(ABILITY_A_HOLD_A_JUMP_HIGHER);
+    orderedSpoiler["loadout"]["abilities"].push_back(ABILITY_13_1ST_NOTEDOOR);
+    for (auto& [abilityId, abilityInfo] : abilityLoadoutMap) {
+        if (CVarGetInteger(abilityInfo.second, 0)) {
+            orderedSpoiler["loadout"]["abilities"].push_back(abilityId);
+        }
+    }
+
+    orderedSpoiler["loadout"]["items"] = nlohmann::json::array();
+    for (auto& [item, itemInfo] : itemLoadoutMap) {
+        if (CVarGetInteger(itemInfo.second, 0)) {
+            orderedSpoiler["loadout"]["items"].push_back(item);
+        }
+    }
+
+    return orderedSpoiler;
+}
+
+void GenerateFromSpoiler(nlohmann::json spoiler) {
+    Rando::Logic::shuffledPool.clear();
+
+    if (!spoiler.contains("type") || spoiler["type"] != "LIGHTHOUSE_RANDO_SPOILER") {
+        Notification::Emit({ .message = "Error: Invalid Spoiler Log.", .messageColor = ImVec4(0.85f, 0.3f, 0, 1) });
+    }
+
+    if (spoiler.contains("checks") && !spoiler["checks"].empty()) {
+        for (auto& data : spoiler["checks"].items()) {
+            RandoSaveCheck checkEntry = RandoSaveCheck_from_json(data.value(), checkEntry);
+            checkEntry.name = Rando::StaticData::Checks[checkEntry.randoCheckId].name;
+            RANDO_SAVE_CHECKS[checkEntry.randoCheckId] = checkEntry;
+            
+            Rando::Logic::shuffledPool.push_back(checkEntry);
+        }
+    }
+
+    if (spoiler.contains("options") && !spoiler["options"].empty()) {
+        for (auto& data : spoiler["options"].items()) {
+            for (auto& [optionId, staticOption] : Rando::StaticData::Options) {
+                if (staticOption.name == data.key()) {
+                    RANDO_SAVE_OPTIONS[optionId].optionValue = data.value().get<int32_t>();
+                    break;
+                }
+            }
+        }
+    }
+
+    if (spoiler.contains("loadout") && !spoiler["loadout"].empty()) {
+        if (spoiler["loadout"].contains("abilities") && !spoiler["loadout"]["abilities"].empty()) {
+            for (auto& data : spoiler["loadout"]["abilities"].items()) {
+                ability_setLearned(data.value(), true);
+                ability_setHasUsed(data.value());
+            }
+        }
+
+        if (spoiler["loadout"].contains("items") && !spoiler["loadout"]["items"].empty()) {
+            for (auto& data : spoiler["loadout"]["items"].items()) {
+                item_setMaxCount(data.value());
+            }
+        }
+    }
+
+    Rando::Logic::GrantFileProgressFlags();
+    Rando::Logic::GrantSpiralMountainChecks();
+
+    Notification::Emit({ .message = "Loaded from Spoiler Log.", .messageColor = ImVec4(0.85f, 0.3f, 0, 1) });
+}
+
+} // namespace Spoiler
+
+} // namespace Rando

--- a/src/port/Rando/Spoiler/RefreshOptions.cpp
+++ b/src/port/Rando/Spoiler/RefreshOptions.cpp
@@ -1,0 +1,40 @@
+#include "Spoiler.h"
+#include <libultraship/bridge/consolevariablebridge.h>
+#include "ship/Context.h"
+#include <filesystem>
+
+#include <libultraship/libultra/types.h>
+
+std::vector<std::string> Rando::Spoiler::spoilerLogs;
+const std::filesystem::path randomizerFolderPath(Ship::Context::GetPathRelativeToAppDirectory("randomizer", "bk64"));
+
+void Rando::Spoiler::RefreshSpoilerLogs() {
+    Rando::Spoiler::spoilerLogs.clear();
+
+    Rando::Spoiler::spoilerLogs.push_back("Generate New Seed");
+    s32 spoilerFileIndex = -1;
+
+    if (!std::filesystem::exists(randomizerFolderPath)) {
+        std::filesystem::create_directory(randomizerFolderPath);
+    }
+
+    for (const auto& entry : std::filesystem::directory_iterator(randomizerFolderPath)) {
+        if (entry.is_regular_file()) {
+            std::string fileName = entry.path().filename().string();
+
+            Rando::Spoiler::spoilerLogs.push_back(fileName);
+
+            // Check if the current file is the one set in the cvar
+            if (fileName == CVarGetString("gRandoSettings.SpoilerFile", "")) {
+                spoilerFileIndex = Rando::Spoiler::spoilerLogs.size() - 1;
+            }
+        }
+    }
+
+    if (spoilerFileIndex == -1) {
+        CVarSetInteger("gRandoSettings.SpoilerFileIndex", 0);
+        CVarSetString("gRandoSettings.SpoilerFile", "");
+    } else {
+        CVarSetInteger("gRandoSettings.SpoilerFileIndex", spoilerFileIndex);
+    }
+}

--- a/src/port/Rando/Spoiler/Spoiler.h
+++ b/src/port/Rando/Spoiler/Spoiler.h
@@ -1,0 +1,26 @@
+#ifndef RANDO_SPOILER_H
+#define RANDO_SPOILER_H
+
+#include <vector>
+#include <string>
+#include "port/Rando/Logic/Logic.h"
+#include <filesystem>
+
+namespace Rando {
+
+namespace Spoiler {
+extern std::vector<std::string> spoilerLogs;
+
+nlohmann::ordered_json GenerateFromPoolGeneration();
+
+void GenerateFromSpoiler(nlohmann::json spoiler);
+void SaveToFile(const std::string& fileName, nlohmann::ordered_json spoiler);
+nlohmann::json LoadFromFile(const std::string& filePath);
+
+void RefreshSpoilerLogs();
+
+} // namespace Spoiler
+
+} // namespace Rando
+
+#endif


### PR DESCRIPTION
Implements Spoiler Logs.

- A Spoiler Log will be written upon successful seed generation.
- If the box is checked and a spoiler log selected prior to generating a new file, it will load the data from the spoiler log instead.