### PR TITLE
Fix a rare crash with the tooie jiggy animation

### DIFF
--- a/src/port/Enhancements/Backports/TooieJiggyDance.cpp
+++ b/src/port/Enhancements/Backports/TooieJiggyDance.cpp
@@ -136,6 +136,7 @@ void spawnOrbit() {
     }
     actor->state = 0;
     actor_collisionOff(actor);
+    actor->unk44_2 = 1;
     sfxsource_playHighPriority(SFX_3E9_UNKNOWN);
     sMarker = (void*)actor->marker;
 }


### PR DESCRIPTION
Tooie Jiggy Animation spawns a jiggy actor for the animation, but it needs a bit set to avoid being dropped int map savestate if the player transitions to a new map while the animation is playing. Otherwise, on re-entering the saved state, an invalid jiggy id is referenced.

This could be easily reproduced in Mumbo's Mountain if you grabbed the shaman's eye jiggy and entered the hut immediately.