### PR TITLE
Fix rando events

### DIFF
--- a/src/core2/ch/mole.c
+++ b/src/core2/ch/mole.c
@@ -491,14 +491,16 @@ void chmole_update(Actor *this){
 
 int chmole_learnedAllSpiralMountainAbilities(void){
     // Checks if the player has learned all of the Spiral Mountain abilities.
-    return ability_isUnlocked(ABILITY_F_DIVE)
-        && ability_isUnlocked(ABILITY_4_CLAW_SWIPE)
-        && ability_isUnlocked(ABILITY_C_ROLL)
-        && ability_isUnlocked(ABILITY_B_RATATAT_RAP)
-        && ability_isUnlocked(ABILITY_0_BARGE)
-        && ability_isUnlocked(ABILITY_A_HOLD_A_JUMP_HIGHER)
-        && ability_isUnlocked(ABILITY_7_FEATHERY_FLAP)
-        && ability_isUnlocked(ABILITY_8_FLAP_FLIP)
-        && ability_isUnlocked(ABILITY_5_CLIMB)
-    ;
+    CALL_CANCELLABLE_RETURN_EVENT(OnCheckSpiralMountainAbilities) {
+        return ability_isUnlocked(ABILITY_F_DIVE)
+            && ability_isUnlocked(ABILITY_4_CLAW_SWIPE)
+            && ability_isUnlocked(ABILITY_C_ROLL)
+            && ability_isUnlocked(ABILITY_B_RATATAT_RAP)
+            && ability_isUnlocked(ABILITY_0_BARGE)
+            && ability_isUnlocked(ABILITY_A_HOLD_A_JUMP_HIGHER)
+            && ability_isUnlocked(ABILITY_7_FEATHERY_FLAP)
+            && ability_isUnlocked(ABILITY_8_FLAP_FLIP)
+            && ability_isUnlocked(ABILITY_5_CLIMB)
+            ;
+    }
 }

--- a/src/core2/gameSelect.c
+++ b/src/core2/gameSelect.c
@@ -452,6 +452,7 @@ void gameSelect_update(Actor *this){
                         chBottlesBonus_resetCompleted();
                         gameFile_load(gSelectedGameNum);
                         port_syncBottlesBonusIndex();
+                        CALL_EVENT(OnGameStart);
                         if(EventSystem_Should(VB_GAMESELECT_START_NEW_GAME, !gameFile_isNotEmpty(sp84), sp84)){
                             s32 skipIntro = 0;
                             CALL_EVENT(OnNewGame, &skipIntro);

--- a/src/port/Controller/Mapper.h
+++ b/src/port/Controller/Mapper.h
@@ -62,7 +62,7 @@ struct AxisState {
 };
 
 class MappingSession {
-  public:
+public:
     static constexpr int32_t AXIS_COMMIT_DISTANCE = 16000;
     static constexpr int32_t AXIS_RETURN_DISTANCE = 10000;
     static constexpr uint32_t PENDING_ADVANCE_DELAY_MS = 100;
@@ -93,7 +93,7 @@ class MappingSession {
     void SetBindings(const ExtendedBind (&bindings)[BINDING_COUNT]);
     void CopyBindingsTo(ExtendedBind (&out)[BINDING_COUNT]) const;
 
-  private:
+private:
     void ConfigureBinding(const ExtendedBind& binding);
     bool BindingContainsBinding(const ExtendedBind& a, const ExtendedBind& b) const;
 
@@ -121,16 +121,16 @@ bool SaveUserMapping(const std::string& mapping);
 bool DeleteUserMapping(const std::string& guid);
 
 class MapperWindow final : public Ship::GuiWindow {
-  public:
+public:
     using GuiWindow::GuiWindow;
     ~MapperWindow();
 
-  protected:
+protected:
     void InitElement() override;
     void UpdateElement() override;
     void DrawElement() override;
 
-  private:
+private:
     struct DeviceInfo {
         int32_t deviceIndex;
         SDL_JoystickID instanceId;

--- a/src/port/DevTools/ThreadWatchdog.cpp
+++ b/src/port/DevTools/ThreadWatchdog.cpp
@@ -288,8 +288,7 @@ std::string CaptureStalledStack(int threadIdx) {
             if (SymGetLineFromAddr64(proc, frames[i], &lineDisp, &line)) {
                 // Only frames under this repo's source root are ours; CRT and
                 // STL paths contain "\src\" as well and must not match.
-                const bool ours = !srcRoot.empty() &&
-                                  _strnicmp(line.FileName, srcRoot.c_str(), srcRoot.size()) == 0;
+                const bool ours = !srcRoot.empty() && _strnicmp(line.FileName, srcRoot.c_str(), srcRoot.size()) == 0;
                 out += fmt::format("{} #{:02} {}+0x{:x} ({}:{})\n", ours ? ">" : " ", i, sym->Name, symDisp,
                                    line.FileName, line.LineNumber);
             } else {
@@ -391,8 +390,8 @@ std::string BuildDump(const bool* stalled, Clock::time_point now, const std::str
         std::string park;
         if (const OS_BlockedWait* w = waitFor(i)) {
             QueueInfo qi = DescribeQueue(w->mq);
-            park = fmt::format("  {} {} {}/{}", w->isSend ? "send" : "recv", qi.name, w->mq->validCount,
-                               w->mq->msgCount);
+            park =
+                fmt::format("  {} {} {}/{}", w->isSend ? "send" : "recv", qi.name, w->mq->validCount, w->mq->msgCount);
         }
         out += fmt::format("  {:<11} {:<7} {:>6} tid {:<6} {} beats{}\n", kThreadNames[i],
                            (stalled != nullptr && stalled[i]) ? "STALLED" : "ok", age,
@@ -413,8 +412,8 @@ std::string BuildDump(const bool* stalled, Clock::time_point now, const std::str
                        DescribeUnkFlag1(t5.unkFlag1), t5.unkFlag2, t5.unkFlag2Saved, t5.syncCounter, t5.task7Handled,
                        t5.gfxActiveId, t5.gfxSelectedId, t5.audioActiveId, t5.audioSelectedId, t5.taskQueueCount,
                        t5.taskQueueCap, t5.syncQueueCount, t5.syncQueueCap, (dpStatus & 0x2) ? 1 : 0,
-                       OS_SpPeekPendingTask() != nullptr ? "yes" : "no", curFb == nextFb ? "==" : "!=",
-                       OS_ViBlackActive() ? " viBlack" : "");
+                       OS_SpPeekPendingTask() != nullptr ? "yes" : "no",
+                       curFb == nextFb ? "==" : "!=", OS_ViBlackActive() ? " viBlack" : "");
     out += fmt::format("Frame pacing: D_802808D8={}{} frameTokenQ={} tickRetraceQ={} retraceQ={}\n", vi.retraceCount,
                        vi.retraceCount > 10 ? " (accumulating)" : "", vi.q2Count, vi.q3Count, vi.q1Count);
 
@@ -424,9 +423,8 @@ std::string BuildDump(const bool* stalled, Clock::time_point now, const std::str
     out += fmt::format("SI/audio: pfsBusy={} pollingQ={} audioFrameQ={} audioReplyQ={} audioHeld={} svcPending={}\n",
                        pfsManager_isBusy(), pfsPoll->validCount, audioFrame->validCount, audioReply->validCount,
                        port_audioHeld(), port_renderServicePending());
-    out += fmt::format("Context: map={:#x} exit={:#x} gameMode={} build={} {}@{}", gsworld_getMap(),
-                       gsworld_getExit(), getGameMode(), (char*)gBuildVersion, (char*)gGitBranch,
-                       (char*)gGitCommitHash);
+    out += fmt::format("Context: map={:#x} exit={:#x} gameMode={} build={} {}@{}", gsworld_getMap(), gsworld_getExit(),
+                       getGameMode(), (char*)gBuildVersion, (char*)gGitBranch, (char*)gGitCommitHash);
 
     if (!stack.empty()) {
         out += "\n" + stack;
@@ -549,4 +547,3 @@ extern "C" void ThreadWatchdog_DumpNow(void) {
 extern "C" int ThreadWatchdog_IsStalled(WatchdogThread id) {
     return sStalledFlags[id].load(std::memory_order_relaxed) ? 1 : 0;
 }
-

--- a/src/port/DevTools/ThreadWatchdog.h
+++ b/src/port/DevTools/ThreadWatchdog.h
@@ -16,14 +16,14 @@ extern "C" {
 #endif
 
 typedef enum WatchdogThread {
-    WATCHDOG_VI_TICKER = 0,  // retrace source (OS_VI.cpp); everything below is paced by it
-    WATCHDOG_MAIN_LOOP,      // window thread: event pump + RCP service (Game.cpp)
-    WATCHDOG_GAME_TICK,      // push_frame loop (Game.cpp)
-    WATCHDOG_THREAD5,        // decomp graphics thread (graphics_thread.c)
-    WATCHDOG_VIMGR,          // decomp VI manager thread (vimgr.c)
-    WATCHDOG_PFSMANAGER,     // controller thread (pfsmanager.c)
-    WATCHDOG_AUDIO_MANAGER,  // audio thread (audio_manager.c); idles during demo audio holds
-    WATCHDOG_RUMBLE,         // motor thread (bamotor.c); one beat per retrace signal
+    WATCHDOG_VI_TICKER = 0, // retrace source (OS_VI.cpp); everything below is paced by it
+    WATCHDOG_MAIN_LOOP,     // window thread: event pump + RCP service (Game.cpp)
+    WATCHDOG_GAME_TICK,     // push_frame loop (Game.cpp)
+    WATCHDOG_THREAD5,       // decomp graphics thread (graphics_thread.c)
+    WATCHDOG_VIMGR,         // decomp VI manager thread (vimgr.c)
+    WATCHDOG_PFSMANAGER,    // controller thread (pfsmanager.c)
+    WATCHDOG_AUDIO_MANAGER, // audio thread (audio_manager.c); idles during demo audio holds
+    WATCHDOG_RUMBLE,        // motor thread (bamotor.c); one beat per retrace signal
     WATCHDOG_NUM_THREADS
 } WatchdogThread;
 

--- a/src/port/Engine.cpp
+++ b/src/port/Engine.cpp
@@ -1215,7 +1215,6 @@ void GameEngine::AudioInit() {
     LoadSoundfonts();
 }
 
-
 // Local timer helper for the per-sub-frame cost measurement.
 namespace {
 using Clock = std::chrono::steady_clock;

--- a/src/port/Enhancements/Events/Hooks/List/GameEvent.h
+++ b/src/port/Enhancements/Events/Hooks/List/GameEvent.h
@@ -32,6 +32,9 @@ typedef enum WarpId {
 
 DEFINE_EVENT(OnWarpResolveDest, int32_t warpId; int32_t defaultDest; int32_t bkcfOverride; int32_t * dest;)
 DEFINE_EVENT(OnNewGame, int32_t* skipIntro;)
+// The file-select commit, for both new game and continue. Unlike OnGameLoad this
+// does not fire for the zoombox preview.
+DEFINE_EVENT(OnGameStart)
 DEFINE_EVENT(EggHeadSpawn, float* pitch; float* spawnHeight; float* minVerticalVelocity; float* yawBias;
              int32_t * flattenTrajectory;)
 

--- a/src/port/Enhancements/Events/PortEnhancements.cpp
+++ b/src/port/Enhancements/Events/PortEnhancements.cpp
@@ -93,6 +93,7 @@ void PortEnhancements_Register() {
     REGISTER_EVENT(OnPropInit);
     REGISTER_EVENT(OnWarpResolveDest);
     REGISTER_EVENT(OnNewGame);
+    REGISTER_EVENT(OnGameStart);
     REGISTER_EVENT(EggHeadSpawn);
     REGISTER_EVENT(OnActorDestroy);
     REGISTER_EVENT(OnCheckSpiralMountainAbilities);

--- a/src/port/Enhancements/Retention/NoteRetention.cpp
+++ b/src/port/Enhancements/Retention/NoteRetention.cpp
@@ -378,9 +378,9 @@ void RegisterNoteRetention_Init() {
         switch (textId) {
             case 0xD9C: // Bottles' first-note text: "you can't take notes with you"
             case 0xF76: // "you just beat your high score"
-            // Milestones...maybe they should not be suppressed? They're aides for new players.
-            //case 0xF74: // milestone: 50 notes (Mumbo's Mountain)
-            //case 0xF78: // milestone: collected every note in the level
+                // Milestones...maybe they should not be suppressed? They're aides for new players.
+                /* case 0xF74: // milestone: 50 notes (Mumbo's Mountain)
+                case 0xF78: // milestone: collected every note in the level*/
                 *should = true;
                 break;
             default:

--- a/src/port/Game.cpp
+++ b/src/port/Game.cpp
@@ -173,7 +173,6 @@ void EnableThread5() {
 }
 } // namespace
 
-
 // Drain submitted lists for safety.
 static void RegisterThread5MapSync_Init() {
     COND_HOOK(OnMapLoad, EVENT_PRIORITY_HIGH, true, [](IEvent* event) {

--- a/src/port/Interpolation/FrameInterpolation.cpp
+++ b/src/port/Interpolation/FrameInterpolation.cpp
@@ -213,8 +213,8 @@ void FrameInterpolation_StopRecord(void) {
         static uint32_t sReported = 0;
         if (sReported < 20) {
             sReported++;
-            SPDLOG_WARN("interp scope id collided {}x this tick ({} matrices, {} sprites)",
-                        gRecord->sigCollisions, gRecord->toMtxs.size(), gRecord->sprites.size());
+            SPDLOG_WARN("interp scope id collided {}x this tick ({} matrices, {} sprites)", gRecord->sigCollisions,
+                        gRecord->toMtxs.size(), gRecord->sprites.size());
         }
     }
 }

--- a/src/port/OS/OS_Mesg.cpp
+++ b/src/port/OS/OS_Mesg.cpp
@@ -27,7 +27,7 @@ __OSEventState __osEventStateTab[OS_NUM_EVENTS] = { 0 };
 // The queue fields themselves stay as they were, since decomp code reads them
 // directly (pfsmanager watches validCount); only the waiting is ours, a
 // condvar pair per queue where libultra used priority-ordered thread lists.
-// Blocking is opt-in per queue. 
+// Blocking is opt-in per queue.
 
 namespace {
 

--- a/src/port/OS/OS_RCP.cpp
+++ b/src/port/OS/OS_RCP.cpp
@@ -61,7 +61,7 @@ namespace {
 std::atomic<OSTask*> sPendingTask{ nullptr };
 std::atomic<bool> sYieldPending{ false };  // yield requested, not yet observed
 std::atomic<bool> sResumePending{ false }; // next gfx StartGo is the resume
-}
+} // namespace
 
 extern "C" void osSpTaskYield(void) {
     sYieldPending.store(true, std::memory_order_release);

--- a/src/port/Patches/PerfPatches.cpp
+++ b/src/port/Patches/PerfPatches.cpp
@@ -157,7 +157,6 @@ static void RegisterSnowTrig_Init() {
     });
 }
 
-
 static void RebuildPaddedPlanes() {
     f32 rot[3];
     f32 pos[3];

--- a/src/port/Rando/MiscBehavior/OnFileLoad.cpp
+++ b/src/port/Rando/MiscBehavior/OnFileLoad.cpp
@@ -24,20 +24,17 @@ void Rando::MiscBehavior::OnFileLoad() {
         if (saveData->magic != 0) {
             if (saveData->shipSaveData.fileType == FILE_TYPE_SAVE_RANDO) {
                 Rando::Logic::GeneratePoolFromSaveData(saveData);
-                CALL_EVENT(InitRandoEvents);
             }
-            return;
-        }
-
-        if (CVarGetInteger("gRandoSettings.Enable", 0)) {
+        } else if (CVarGetInteger("gRandoSettings.Enable", 0)) {
             Rando::Logic::InitializeSaveData(saveData);
             Rando::Logic::GenerateShufflePool(saveData);
             Rando::Logic::GrantStartingLoadout();
             saveData->shipSaveData.fileType = FILE_TYPE_SAVE_RANDO;
             saveData->shipSaveData.fileCreatedAt = GetUnixTimestamp();
-            CALL_EVENT(InitRandoEvents);
         }
     });
+
+    REGISTER_LISTENER(OnGameStart, EVENT_PRIORITY_NORMAL, [](IEvent* event) { CALL_EVENT(InitRandoEvents); });
 
     REGISTER_LISTENER(OnLoadFileSelect, EVENT_PRIORITY_NORMAL, [](IEvent* event) {
         OnLoadFileSelect* ev = (OnLoadFileSelect*)event;

--- a/src/port/Rando/ObjectBehavior/ObjectBehavior.cpp
+++ b/src/port/Rando/ObjectBehavior/ObjectBehavior.cpp
@@ -316,12 +316,13 @@ void Rando::ObjectBehavior::Init() {
     COND_HOOK(OnLoadActorSaveState, EVENT_PRIORITY_NORMAL, IS_RANDO, [](IEvent* event) {
         OnLoadActorSaveState* ev = (OnLoadActorSaveState*)event;
 
+        // Junk doesn't count as rando-managed while restoring; only real checks do.
         isSaveState = true;
-        if (!IsActorWhitelisted((actor_e)ev->actor->modelCacheIndex)) {
-            event->Cancelled = true;
+        bool randoManaged = IsActorWhitelisted((actor_e)ev->actor->modelCacheIndex);
+        isSaveState = false;
+        if (!randoManaged) {
             return;
         }
-        isSaveState = false;
 
         if (randoSaveState.empty()) {
             return;

--- a/src/port/UI/LighthouseMenuDevTools.cpp
+++ b/src/port/UI/LighthouseMenuDevTools.cpp
@@ -77,9 +77,12 @@ void LighthouseMenu::AddMenuDevTools() {
         .Options(FloatSliderOptions().DefaultValue(3000.0f).Min(1000.0f).Max(10000.0f).Step(10.0f));
     AddWidget(path, "Dump Thread State", WIDGET_BUTTON)
         .Callback([](WidgetInfo&) { ThreadWatchdog_DumpNow(); })
-        .Options(ButtonOptions().Size(Sizes::Inline).Tooltip(
-            "Log a snapshot of the decomp thread heartbeats and pipeline queue state. The watchdog also logs "
-            "this automatically when a thread stops beating."));
+        .Options(
+            ButtonOptions()
+                .Size(Sizes::Inline)
+                .Tooltip(
+                    "Log a snapshot of the decomp thread heartbeats and pipeline queue state. The watchdog also logs "
+                    "this automatically when a thread stops beating."));
     /*AddWidget(path, "Debug Mode", WIDGET_CVAR_CHECKBOX)
         .CVar(CVAR_DEVELOPER_TOOLS("DebugMode"))
         .Options(CheckboxOptions().Tooltip("Various debug features, including a level selector from the main menu."));*/


### PR DESCRIPTION
InitRandoEvents was only getting called when loading/hovering over rando files after the first boot, as well as once on reset, so if a rando file was in slot one, the rando event listeners would be running for non-rando slots of higher number. This fixes that by making a new event to run only once on each actual game start, regardless of whether the save itself was rando or not.

There was also an issue in the rando handler for OnLoadActorSaveState which was cancelling spawns of non-rando-controlled actors. Fixed this by removing the `event->Cancelled = true;` from the part of the handler that returns early if it's not rando controlled.