### PR TITLE
Extend prop count

### DIFF
--- a/include/prop.h
+++ b/include/prop.h
@@ -406,11 +406,12 @@ typedef struct cude_s{
     s32 x:5;
     s32 y:5;
     s32 z:5;
-    // [port] were :6 bitfields; the 64th prop wrapped the count to 0, which
-    // realloc'd the prop array to nothing while live markers still pointed into it.
+    // [port] were bitfields (:5/:6/:6). The 64th prop wrapped a count to 0, which
+    // realloc'd the prop array to nothing while live markers still pointed into it;
+    // unk0_4 is the front index of the node-prop partition and wrapped at 32.
+    u16 unk0_4; //node_prop_count
     u16 prop1Cnt;
     u16 prop2Cnt;
-    u32 unk0_4:5; //node_prop_count
     NodeProp *prop1Ptr;
     Prop *prop2Ptr;
 }Cube;

--- a/include/prop.h
+++ b/include/prop.h
@@ -409,7 +409,7 @@ typedef struct cude_s{
     // [port] were bitfields (:5/:6/:6). The 64th prop wrapped a count to 0, which
     // realloc'd the prop array to nothing while live markers still pointed into it;
     // unk0_4 is the front index of the node-prop partition and wrapped at 32.
-    u16 unk0_4; //node_prop_count
+    u32 unk0_4:16; //node_prop_count
     u16 prop1Cnt;
     u16 prop2Cnt;
     NodeProp *prop1Ptr;

--- a/include/prop.h
+++ b/include/prop.h
@@ -398,12 +398,18 @@ typedef struct {
     u32 pad10_0:1; 
 } OtherNode; //can be inplace of NodeProp (see code7AF80_initCubeFromFile) size: 12 (0xC) bytes
 
+// Distance scratch __cube_sort fills, one entry per prop. Cubes past this are
+// left unsorted rather than overrunning it.
+#define CUBE_SORT_SCRATCH_SIZE 0x400
+
 typedef struct cude_s{
     s32 x:5;
     s32 y:5;
     s32 z:5;
-    u32 prop1Cnt:6;
-    u32 prop2Cnt:6;
+    // [port] were :6 bitfields; the 64th prop wrapped the count to 0, which
+    // realloc'd the prop array to nothing while live markers still pointed into it.
+    u16 prop1Cnt;
+    u16 prop2Cnt;
     u32 unk0_4:5; //node_prop_count
     NodeProp *prop1Ptr;
     Prop *prop2Ptr;

--- a/src/core2/actor_cubepropsystem.c
+++ b/src/core2/actor_cubepropsystem.c
@@ -520,20 +520,20 @@ s32 func_8032D9C0(Cube *cube, Prop* prop){
     s32 tmp;
 
     sp24 = 0;
-    if(cube != NULL && cube->prop2Cnt != 0 && prop != NULL){
+    if(cube != NULL && cube->prop2Cnt != 0 && prop != NULL && cube->prop2Ptr != NULL){
         sp24 = prop->unk8_1;
-        if(func_80305D14()){
-            func_80305CD8(func_803058C0(prop->unk4[1]), -1);
-        }
-
-        // port - Rando manipulation of prop2Ptr results in mismatched data, this corrects that.
         ptrdiff_t index = prop - cube->prop2Ptr;
-        ptrdiff_t elementsAfter = (cube->prop2Cnt - 1) - index;
         // [port] A stale propPtr makes elementsAfter enormous; drop the removal instead.
         if (index < 0 || index >= (ptrdiff_t)cube->prop2Cnt) {
             port_warnPropNotInCube((s32)index, (s32)cube->prop2Cnt);
             return sp24;
         }
+        if(func_80305D14()){
+            func_80305CD8(func_803058C0(prop->unk4[1]), -1);
+        }
+
+        // port - Rando manipulation of prop2Ptr results in mismatched data, this corrects that.
+        ptrdiff_t elementsAfter = (cube->prop2Cnt - 1) - index;
         if (elementsAfter > 0) {
             memmove(prop, prop + 1, elementsAfter * sizeof(Prop));
         }

--- a/src/core2/actor_cubepropsystem.c
+++ b/src/core2/actor_cubepropsystem.c
@@ -521,13 +521,14 @@ s32 func_8032D9C0(Cube *cube, Prop* prop){
 
     sp24 = 0;
     if(cube != NULL && cube->prop2Cnt != 0 && prop != NULL && cube->prop2Ptr != NULL){
-        sp24 = prop->unk8_1;
         ptrdiff_t index = prop - cube->prop2Ptr;
         // [port] A stale propPtr makes elementsAfter enormous; drop the removal instead.
         if (index < 0 || index >= (ptrdiff_t)cube->prop2Cnt) {
             port_warnPropNotInCube((s32)index, (s32)cube->prop2Cnt);
             return sp24;
         }
+
+        sp24 = prop->unk8_1;
         if(func_80305D14()){
             func_80305CD8(func_803058C0(prop->unk4[1]), -1);
         }

--- a/src/core2/actor_cubepropsystem.c
+++ b/src/core2/actor_cubepropsystem.c
@@ -520,7 +520,7 @@ s32 func_8032D9C0(Cube *cube, Prop* prop){
     s32 tmp;
 
     sp24 = 0;
-    if(cube->prop2Cnt != 0){
+    if(cube != NULL && cube->prop2Cnt != 0 && prop != NULL){
         sp24 = prop->unk8_1;
         if(func_80305D14()){
             func_80305CD8(func_803058C0(prop->unk4[1]), -1);
@@ -953,6 +953,11 @@ static void __codeA5BC0_initPropPointerForCube(NodeProp *node, Cube *cube, s32 c
             memcpy(&cube->prop1Ptr[cube->unk0_4], &node[i], sizeof(NodeProp));
             cube->unk0_4++;
         }
+    }
+
+    // [port] unk0_4 is the front index of this partition; :5 wrapped it here.
+    if(cube->unk0_4 > 31){
+        port_warnNodePropSplit(cube->unk0_4, cnt);
     }
 
     bk_free(node);

--- a/src/core2/actor_cubepropsystem.c
+++ b/src/core2/actor_cubepropsystem.c
@@ -119,7 +119,7 @@ BKCollisionTriangle *D_80383420;
 u8  D_80383428[MARKER_BITMAP_BYTES];
 s32 D_80383444;
 int D_80383448;
-s32 D_80383450[0x40];
+s32 D_80383450[CUBE_SORT_SCRATCH_SIZE];
 bk_vector(ActorMarker *) *D_80383550;
 bk_vector(ActorMarker *) *D_80383554;
 Method_Core2_A5BC0 D_80383558;
@@ -137,6 +137,11 @@ void __cube_sort(Cube *cube, bool global) {
     Prop * var_t0;
     s32 i;
     Prop *new_var;
+
+    // [port] Sorting is only draw order; skip rather than overrun the scratch.
+    if (cube->prop2Cnt > CUBE_SORT_SCRATCH_SIZE) {
+        return;
+    }
 
     if (cube->prop2Cnt >= 2) {
         if (global == 0) {
@@ -524,6 +529,11 @@ s32 func_8032D9C0(Cube *cube, Prop* prop){
         // port - Rando manipulation of prop2Ptr results in mismatched data, this corrects that.
         ptrdiff_t index = prop - cube->prop2Ptr;
         ptrdiff_t elementsAfter = (cube->prop2Cnt - 1) - index;
+        // [port] A stale propPtr makes elementsAfter enormous; drop the removal instead.
+        if (index < 0 || index >= (ptrdiff_t)cube->prop2Cnt) {
+            port_warnPropNotInCube((s32)index, (s32)cube->prop2Cnt);
+            return sp24;
+        }
         if (elementsAfter > 0) {
             memmove(prop, prop + 1, elementsAfter * sizeof(Prop));
         }

--- a/src/core2/ch/mole.c
+++ b/src/core2/ch/mole.c
@@ -491,14 +491,16 @@ void chmole_update(Actor *this){
 
 int chmole_learnedAllSpiralMountainAbilities(void){
     // Checks if the player has learned all of the Spiral Mountain abilities.
-    return ability_isUnlocked(ABILITY_F_DIVE)
-        && ability_isUnlocked(ABILITY_4_CLAW_SWIPE)
-        && ability_isUnlocked(ABILITY_C_ROLL)
-        && ability_isUnlocked(ABILITY_B_RATATAT_RAP)
-        && ability_isUnlocked(ABILITY_0_BARGE)
-        && ability_isUnlocked(ABILITY_A_HOLD_A_JUMP_HIGHER)
-        && ability_isUnlocked(ABILITY_7_FEATHERY_FLAP)
-        && ability_isUnlocked(ABILITY_8_FLAP_FLIP)
-        && ability_isUnlocked(ABILITY_5_CLIMB)
-    ;
+    CALL_CANCELLABLE_RETURN_EVENT(OnCheckSpiralMountainAbilities) {
+        return ability_isUnlocked(ABILITY_F_DIVE)
+            && ability_isUnlocked(ABILITY_4_CLAW_SWIPE)
+            && ability_isUnlocked(ABILITY_C_ROLL)
+            && ability_isUnlocked(ABILITY_B_RATATAT_RAP)
+            && ability_isUnlocked(ABILITY_0_BARGE)
+            && ability_isUnlocked(ABILITY_A_HOLD_A_JUMP_HIGHER)
+            && ability_isUnlocked(ABILITY_7_FEATHERY_FLAP)
+            && ability_isUnlocked(ABILITY_8_FLAP_FLIP)
+            && ability_isUnlocked(ABILITY_5_CLIMB)
+            ;
+    }
 }

--- a/src/core2/fx/commonParticle.c
+++ b/src/core2/fx/commonParticle.c
@@ -183,14 +183,18 @@ s32 commonParticle_findFree(void){
 int commonParticle_new(enum common_particle_e particle_id, int arg1){
     f32 sp34[3];
     uintptr_t a0;
+    s32 slot;
 
     if(arg1 == 0)
         return -1;
     
     ml_vec3f_clear(sp34);
-    D_80384FD0 = commonParticle_findFree();
-    if(D_80384FD0 < 0)
+    // [port] Don't publish -1 to the global; every D_80384490[D_80384FD0] access
+    // downstream (accessors, commonParticle_update) would read out of bounds.
+    slot = commonParticle_findFree();
+    if(slot < 0)
         return -1;
+    D_80384FD0 = slot;
 
     
     D_80384490[D_80384FD0].projectileIndex = func_8033FA84();
@@ -249,6 +253,10 @@ void freeParticleByIndex(s32 arg0){
 
 void commonParticle_add(ActorMarker *arg0, s32 arg1, FuncUnk40 arg2){
     s32 tmp_v0 = commonParticle_findFree();
+    // [port] Pool full returns -1; writing D_80384490[-1] corrupts whatever precedes it.
+    if(tmp_v0 < 0){
+        return;
+    }
     D_80384490[tmp_v0].isInUse--;
     D_80384490[tmp_v0].unk38 = arg0;
     D_80384490[tmp_v0].unk3C = arg1;

--- a/src/core2/quiz/game.c
+++ b/src/core2/quiz/game.c
@@ -506,9 +506,6 @@ static bool port_breakable_survivesBreak(s32 markerId) {
     switch (markerId) {
         case MARKER_34_CEMETARY_POT:            // flowers
         case MARKER_66_ORANGE_PAD:              // stays, marked hit
-        case MARKER_9F_CHURCH_GATE_LEFT_LOCK:   // broken lock stays on the gate
-        case MARKER_A0_HEDGE_GATE_RIGHT_LOCK_1:
-        case MARKER_FF_HEDGE_GATE_RIGHT_LOCK_2:
             return TRUE;
         default:
             return FALSE;

--- a/src/core2/quiz/game.c
+++ b/src/core2/quiz/game.c
@@ -502,6 +502,19 @@ void port_breakable_remoteBreakAt(s32 markerId, s32 x, s32 y, s32 z) {
     }
 }
 
+static bool port_breakable_survivesBreak(s32 markerId) {
+    switch (markerId) {
+        case MARKER_34_CEMETARY_POT:            // flowers
+        case MARKER_66_ORANGE_PAD:              // stays, marked hit
+        case MARKER_9F_CHURCH_GATE_LEFT_LOCK:   // broken lock stays on the gate
+        case MARKER_A0_HEDGE_GATE_RIGHT_LOCK_1:
+        case MARKER_FF_HEDGE_GATE_RIGHT_LOCK_2:
+            return TRUE;
+        default:
+            return FALSE;
+    }
+}
+
 // [port] Iterates backward: despawn swap-removes from the end.
 void port_breakable_despawnBrokenRestores(s32 map) {
     s32 i;
@@ -512,6 +525,9 @@ void port_breakable_despawnBrokenRestores(s32 map) {
     for (i = suBaddieActorArray->cnt - 1; i >= 0; i--) {
         Actor *actor = &suBaddieActorArray->data[i];
         if (actor->marker == NULL || actor->despawn_flag) {
+            continue;
+        }
+        if (port_breakable_survivesBreak(actor->marker->id)) {
             continue;
         }
         if (port_breakable_isBroken(map, actor->marker->id, (s32)actor->position[0], (s32)actor->position[1],

--- a/src/port/Patches/Patches.h
+++ b/src/port/Patches/Patches.h
@@ -194,6 +194,9 @@ int32_t port_hutSmash_countForCurrentLevel(void);
 void port_jiggyCrane_broadcast(int32_t stage);
 void port_jiggyCrane_remoteApply(int32_t stage);
 
+// Rate-limited: a marker reached cube_removeProp with a propPtr outside its cube.
+void port_warnPropNotInCube(int32_t index, int32_t propCnt);
+
 #ifdef __cplusplus
 }
 #endif

--- a/src/port/Patches/Patches.h
+++ b/src/port/Patches/Patches.h
@@ -197,6 +197,9 @@ void port_jiggyCrane_remoteApply(int32_t stage);
 // Rate-limited: a marker reached cube_removeProp with a propPtr outside its cube.
 void port_warnPropNotInCube(int32_t index, int32_t propCnt);
 
+// Rate-limited: a cube's node-prop split index passed 31, where the old :5 field wrapped.
+void port_warnNodePropSplit(int32_t splitIndex, int32_t nodeCnt);
+
 #ifdef __cplusplus
 }
 #endif

--- a/src/port/Patches/PerfPatches.cpp
+++ b/src/port/Patches/PerfPatches.cpp
@@ -30,6 +30,7 @@ static f32 sPadFrustumY = 93.9692611694336f;
 static f32 sPadPlanes[4][4];
 static bool sPadPlanesDirty = true;
 
+// TODO: Find better place for these two warn functions
 // Capped so a bad frame can't flood the log; one print is enough to investigate.
 extern "C" void port_warnPropNotInCube(int32_t index, int32_t propCnt) {
     static int32_t sReported = 0;

--- a/src/port/Patches/PerfPatches.cpp
+++ b/src/port/Patches/PerfPatches.cpp
@@ -39,6 +39,16 @@ extern "C" void port_warnPropNotInCube(int32_t index, int32_t propCnt) {
     }
 }
 
+// Fires only for a cube the old :5 unk0_4 would have silently corrupted, so if this
+// never prints, no shipped map reaches the limit and the widening is forward-looking.
+extern "C" void port_warnNodePropSplit(int32_t splitIndex, int32_t nodeCnt) {
+    static int32_t sReported = 0;
+    if (sReported < 20) {
+        sReported++;
+        SPDLOG_WARN("cube node-prop split {} of {} exceeds the old 31 limit", splitIndex, nodeCnt);
+    }
+}
+
 // __cube_sort re-sorts every visible cube's props each tick, but only the camera
 // moves, so the order rarely changes. A stable insertion sort skims an already
 // sorted array in one pass and produces the same ordering as the vanilla sort.

--- a/src/port/Patches/PerfPatches.cpp
+++ b/src/port/Patches/PerfPatches.cpp
@@ -2,7 +2,10 @@
 #include <cmath>
 #include <cstring>
 
+#include <spdlog/spdlog.h>
+
 #include "port/Enhancements/Events/Hooks/Events.h"
+#include "port/Patches/Patches.h"
 #include "port/ShipInit.hpp"
 
 extern "C" {
@@ -10,7 +13,7 @@ extern "C" {
 #include "functions.h"
 #include "core2/lighting.h"
 
-extern s32 D_80383450[0x40];
+extern s32 D_80383450[CUBE_SORT_SCRATCH_SIZE];
 
 // core1 helpers not exposed through functions.h.
 extern void func_80256E24(f32 dst[3], f32 theta, f32 phi, f32 x, f32 y, f32 z);
@@ -26,6 +29,15 @@ static f32 sPadFrustumX = 89.21774f;
 static f32 sPadFrustumY = 93.9692611694336f;
 static f32 sPadPlanes[4][4];
 static bool sPadPlanesDirty = true;
+
+// Capped so a bad frame can't flood the log; one print is enough to investigate.
+extern "C" void port_warnPropNotInCube(int32_t index, int32_t propCnt) {
+    static int32_t sReported = 0;
+    if (sReported < 20) {
+        sReported++;
+        SPDLOG_WARN("cube_removeProp: prop not in cube (index {}, cnt {})", index, propCnt);
+    }
+}
 
 // __cube_sort re-sorts every visible cube's props each tick, but only the camera
 // moves, so the order rarely changes. A stable insertion sort skims an already

--- a/src/port/Resource/Importers/MapFactory.cpp
+++ b/src/port/Resource/Importers/MapFactory.cpp
@@ -128,19 +128,24 @@ void SerializeLegacyMapData(std::vector<uint8_t>& out, const std::vector<BKMapCu
             out.push_back(0x03);
 
             if (!cube.nodeProps.empty()) {
+                // [port] The count is one byte, so only emit what it can advertise;
+                // writing every entry would desync the reader on an oversized cube.
+                const size_t nodeCnt = std::min<size_t>(cube.nodeProps.size(), 0xFF);
                 out.push_back(0x0A);
-                out.push_back(static_cast<uint8_t>(std::min<size_t>(cube.nodeProps.size(), 0xFF)));
+                out.push_back(static_cast<uint8_t>(nodeCnt));
                 out.push_back(0x0B);
-                for (const auto& node : cube.nodeProps) {
-                    WriteNodeProp(out, node);
+                for (size_t n = 0; n < nodeCnt; n++) {
+                    WriteNodeProp(out, cube.nodeProps[n]);
                 }
             }
 
             if (!cube.props.empty()) {
+                const size_t propCnt = std::min<size_t>(cube.props.size(), 0xFF);
                 out.push_back(0x08);
-                out.push_back(static_cast<uint8_t>(std::min<size_t>(cube.props.size(), 0xFF)));
+                out.push_back(static_cast<uint8_t>(propCnt));
                 out.push_back(0x09);
-                for (const auto& prop : cube.props) {
+                for (size_t pi = 0; pi < propCnt; pi++) {
+                    const auto& prop = cube.props[pi];
                     // [port] Props are raw 12-byte N64 big-endian structs from the ROM.
                     // Layout: u32(4) + s16(2) + s16(2) + s16(2) + u16(2) = 12 bytes.
                     // Byte-swap each multi-byte field to native (little-endian) order


### PR DESCRIPTION
Extends propCnt1/propCnt2 to prevent overflow from particle creation that results in stale references trying to be freed.