### PR TITLE
Interpolation and shadows

### DIFF
--- a/src/core2/fx/badShad.c
+++ b/src/core2/fx/badShad.c
@@ -56,9 +56,9 @@ Actor *chBadShad_draw(ActorMarker *marker, Gfx **gfx, Mtx **mtx, Vtx **vtx){
         modelRender_setAlpha(other->alpha_124_19);
     sp40 = ml_map_f(this->actor_specific_1_f, 0.0f , 800.0f, 0.53f, 0.18f)*this->unk1C[1];
     modelRender_setDepthMode(MODEL_RENDER_DEPTH_COMPARE);
-    FrameInterpolation_NoInterpolatePush();
+    FrameInterpolation_CameraRelativePush();
     modelRender_draw(gfx, mtx, this->position, sp44, sp40, NULL, marker_loadModelBin(marker));
-    FrameInterpolation_NoInterpolatePop();
+    FrameInterpolation_CameraRelativePop();
     return this;
 }
 

--- a/src/core2/model/modelRender.c
+++ b/src/core2/model/modelRender.c
@@ -1289,6 +1289,8 @@ BKModelBin *modelRender_draw(Gfx **gfx, Mtx **mtx, f32 position[3], f32 rotation
 
     if(model_bin->anim_vertices_list_offset != 0 && D_8038371C != NULL){
         animVerticesList_transform((BKAnimVerticesList *)((uintptr_t)modelRenderModelBin + (uintptr_t)(u32)modelRenderModelBin->anim_vertices_list_offset), modelRendervertexList, D_8038371C);
+        // [port] The transform just posed the model's shared vertex array. Hand this draw a private copy.
+        port_modelRender_snapshotAnimVertices(gfx, vtxList_getVertices(modelRendervertexList), vtxList_getVtxCount(modelRendervertexList));
     }
 
     mlMtxIdent();

--- a/src/port/Engine.cpp
+++ b/src/port/Engine.cpp
@@ -1269,6 +1269,12 @@ void GameEngine::RunCommands(Gfx* Commands, const std::vector<std::unordered_map
             break;
         }
         const auto& m = mtx_replacements[frameIdx];
+        // Vertex-animated models blend into one buffer per draw, so unlike the
+        // matrix maps this can't be precomputed per sub-frame. It has to land
+        // right before the pass that reads it.
+        if (frameCount > 1) {
+            FrameInterpolation_ApplyAnimVertices((float)(frameIdx + 1) / (float)frameCount);
+        }
         bool isFinalFrame = (frameIdx == frameCount - 1);
         if (frameCount > 1 || wndBase->IsFrameReady()) {
             // Sample the full CPU cost of producing this sub-frame.

--- a/src/port/Enhancements/Retention/NoteRetention.cpp
+++ b/src/port/Enhancements/Retention/NoteRetention.cpp
@@ -291,6 +291,9 @@ void RegisterNoteRetention_Init() {
             pos[1] = q.pos[1];
             pos[2] = q.pos[2];
             Actor* note = actor_new(pos, 0, &sumusicNote, ACTOR_FLAG_UNKNOWN_21);
+            if (note != nullptr) {
+                note->unk124_6 = 0;
+            }
             ActorMarker* marker = (note != nullptr) ? note->marker : nullptr;
             if (marker != nullptr) {
                 // Key on the marker (stable across the actor's life).

--- a/src/port/Game.cpp
+++ b/src/port/Game.cpp
@@ -244,6 +244,7 @@ void push_frame() {
     }
 
     GameEngine::Instance->StartFrame();
+    port_animVtx_beginTick();
     // Demo/playback modes render at native rate with no interpolation, so skip recording it.
     const bool recordInterpolation = GameEngine::IsInterpolationEnabled() && !func_802E4A08();
     if (recordInterpolation) {

--- a/src/port/Interpolation/FrameInterpolation.cpp
+++ b/src/port/Interpolation/FrameInterpolation.cpp
@@ -24,6 +24,7 @@ struct ToMtxData {
     float src[4][4];
     uint64_t pathSig;
     bool noInterpolate;
+    bool camRelFixup;
     bool ambiguousSig;
 };
 
@@ -103,6 +104,9 @@ struct InterpolationCache {
     bool valid = false;
     std::vector<PairedToMtx> pairedToMtxs;
     std::vector<PairedSprite> pairedSprites;
+    std::vector<uint32_t> camRelFixups;
+    float cameraDelta[3] = { 0.0f, 0.0f, 0.0f };
+    bool hasCameraDelta = false;
     bool prevHasCameraPos = false;
     float prevCameraPos[3] = { 0.0f, 0.0f, 0.0f };
 
@@ -111,6 +115,8 @@ struct InterpolationCache {
         valid = false;
         pairedToMtxs.clear();
         pairedSprites.clear();
+        camRelFixups.clear();
+        hasCameraDelta = false;
         prevHasCameraPos = false;
     }
 };
@@ -128,6 +134,7 @@ bool gRenderShould = false;
 bool gRecording = false;
 bool gShouldInterpolate = true;
 int gNoInterpolateDepth = 0;
+int gCameraRelativeDepth = 0;
 
 std::unordered_map<const void*, uint64_t> gIdMap;
 uint64_t gNextId = 1;
@@ -203,6 +210,7 @@ void FrameInterpolation_StartRecord(void) {
     gRecord->scopeStack.push_back({ kFnvSeed, 0, 0, "root", 0 });
     gShouldInterpolate = true;
     gNoInterpolateDepth = 0;
+    gCameraRelativeDepth = 0;
     gRecording = true;
 }
 
@@ -322,7 +330,8 @@ void FrameInterpolation_RecordMatrixToMtx(void* dst, const float src[4][4]) {
     d.dst = dst;
     std::memcpy(d.src, src, sizeof(float) * 16);
     d.pathSig = sig;
-    d.noInterpolate = (gNoInterpolateDepth > 0);
+    d.noInterpolate = (gNoInterpolateDepth > 0 || gCameraRelativeDepth > 0);
+    d.camRelFixup = (gCameraRelativeDepth > 0);
     d.ambiguousSig = false;
     recordSigCollision(gRecord->sigToToMtx, gRecord->toMtxs, sig, idx, gRecord->sigCollisions, gRecord->scopeStack);
 }
@@ -359,6 +368,16 @@ void FrameInterpolation_NoInterpolatePush(void) {
 void FrameInterpolation_NoInterpolatePop(void) {
     if (gNoInterpolateDepth > 0) {
         gNoInterpolateDepth--;
+    }
+}
+
+void FrameInterpolation_CameraRelativePush(void) {
+    gCameraRelativeDepth++;
+}
+
+void FrameInterpolation_CameraRelativePop(void) {
+    if (gCameraRelativeDepth > 0) {
+        gCameraRelativeDepth--;
     }
 }
 
@@ -460,6 +479,16 @@ void BuildInterpolationCache() {
         gCache.prevCameraPos[2] = gRenderPrev->cameraPos[2];
     }
 
+    // Same two positions the cut heuristic below compares, so a fixup can never
+    // shift further than the cut threshold before Interpolate() bails outright.
+    gCache.hasCameraDelta = false;
+    if (gRenderPrev->hasCameraPos && gRenderCurr->hasCameraPos) {
+        for (int k = 0; k < 3; k++) {
+            gCache.cameraDelta[k] = gRenderCurr->cameraPos[k] - gRenderPrev->cameraPos[k];
+            gCache.hasCameraDelta |= (gCache.cameraDelta[k] != 0.0f);
+        }
+    }
+
     const std::vector<ToMtxData>& currToMtxs = gRenderCurr->toMtxs;
     const std::vector<ToMtxData>& prevToMtxs = gRenderPrev->toMtxs;
     const std::vector<SpriteDrawData>& currSprites = gRenderCurr->sprites;
@@ -476,7 +505,17 @@ void BuildInterpolationCache() {
     // matrix didn't change, can simply be dropped here.
     for (uint32_t i = 0; i < currToMtxs.size(); i++) {
         const ToMtxData& c = currToMtxs[i];
-        if (c.dst == nullptr || c.noInterpolate || c.ambiguousSig) {
+        if (c.dst == nullptr) {
+            continue;
+        }
+        // Camera-relative fixups skip pairing entirely.
+        if (c.camRelFixup) {
+            if (gCache.hasCameraDelta) {
+                gCache.camRelFixups.push_back(i);
+            }
+            continue;
+        }
+        if (c.noInterpolate || c.ambiguousSig) {
             continue;
         }
         auto it = prevSigMap.find(c.pathSig);
@@ -639,8 +678,19 @@ void FrameInterpolation_Interpolate(float t, std::unordered_map<Mtx*, MtxF>& rep
     const std::vector<SpriteDrawData>& prevSpritesData = gRenderPrev->sprites;
     const std::vector<SpriteDrawData>& currSpritesData = gRenderCurr->sprites;
 
-    replacements.reserve(gCache.pairedToMtxs.size() + gCache.pairedSprites.size() + gRenderCurr->projRots.size() * 3);
+    replacements.reserve(gCache.pairedToMtxs.size() + gCache.pairedSprites.size() + gCache.camRelFixups.size() +
+                         gRenderCurr->projRots.size() * 3);
     const float w = 1.0f - t;
+
+    // Re-aim the frozen matrix at the sub-frame's camera.
+    for (uint32_t idx : gCache.camRelFixups) {
+        const ToMtxData& c = currToMtxs[idx];
+        MtxF& out = replacements[reinterpret_cast<Mtx*>(c.dst)];
+        std::memcpy(out.mf, c.src, sizeof(out.mf));
+        for (int k = 0; k < 3; k++) {
+            out.mf[3][k] += w * gCache.cameraDelta[k];
+        }
+    }
 
     for (const PairedToMtx& pair : gCache.pairedToMtxs) {
         const ToMtxData& c = currToMtxs[pair.currIdx];

--- a/src/port/Interpolation/FrameInterpolation.cpp
+++ b/src/port/Interpolation/FrameInterpolation.cpp
@@ -9,12 +9,15 @@
 #include <unordered_map>
 
 #include <libultraship/libultra/gu.h>
+#include <libultraship/libultra/gbi.h>
 
 namespace {
 
 constexpr uint64_t kFnvSeed = 0xcbf29ce484222325ULL;
 constexpr uint64_t kSigKindToMtx = 0x1ULL;
 constexpr uint64_t kSigKindSprite = 0x2ULL;
+constexpr uint64_t kSigKindAnimVtx = 0x3ULL;
+constexpr float kAnimVtxSnapRatio = 0.5f;
 constexpr float kSpriteSnapDistSq = 300.0f * 300.0f;
 constexpr int kRingSlots = 4;
 constexpr uint32_t kAmbiguousSig = UINT32_MAX;
@@ -26,6 +29,14 @@ struct ToMtxData {
     bool noInterpolate;
     bool camRelFixup;
     bool ambiguousSig;
+};
+
+struct AnimVtxData {
+    void* dst;
+    uint32_t count;
+    uint64_t pathSig;
+    bool ambiguousSig;
+    std::vector<int16_t> pos;
 };
 
 struct SpriteDrawData {
@@ -55,6 +66,7 @@ struct ScopeFrame {
     uint64_t pathHash;
     uint32_t toMtxIdx;
     uint32_t spriteIdx;
+    uint32_t animVtxIdx;
     const char* key;
     uintptr_t id;
 };
@@ -63,8 +75,10 @@ struct FrameTree {
     std::vector<ToMtxData> toMtxs;
     std::vector<CameraProjRotData> projRots;
     std::vector<SpriteDrawData> sprites;
+    std::vector<AnimVtxData> animVtxs;
     std::unordered_map<uint64_t, uint32_t> sigToToMtx;
     std::unordered_map<uint64_t, uint32_t> sigToSprite;
+    std::unordered_map<uint64_t, uint32_t> sigToAnimVtx;
     std::vector<ScopeFrame> scopeStack;
     float cameraPos[3] = { 0.0f, 0.0f, 0.0f };
     bool hasCameraPos = false;
@@ -77,8 +91,10 @@ struct FrameTree {
         toMtxs.clear();
         projRots.clear();
         sprites.clear();
+        animVtxs.clear();
         sigToToMtx.clear();
         sigToSprite.clear();
+        sigToAnimVtx.clear();
         scopeStack.clear();
         cameraPos[0] = cameraPos[1] = cameraPos[2] = 0.0f;
         hasCameraPos = false;
@@ -99,11 +115,18 @@ struct PairedSprite {
     bool snap;
 };
 
+struct PairedAnimVtx {
+    uint32_t currIdx;
+    uint32_t prevIdx;
+    bool snap;
+};
+
 struct InterpolationCache {
     bool built = false;
     bool valid = false;
     std::vector<PairedToMtx> pairedToMtxs;
     std::vector<PairedSprite> pairedSprites;
+    std::vector<PairedAnimVtx> pairedAnimVtxs;
     std::vector<uint32_t> camRelFixups;
     float cameraDelta[3] = { 0.0f, 0.0f, 0.0f };
     bool hasCameraDelta = false;
@@ -115,6 +138,7 @@ struct InterpolationCache {
         valid = false;
         pairedToMtxs.clear();
         pairedSprites.clear();
+        pairedAnimVtxs.clear();
         camRelFixups.clear();
         hasCameraDelta = false;
         prevHasCameraPos = false;
@@ -207,7 +231,7 @@ void FrameInterpolation_StartRecord(void) {
     gRecord->sprites.reserve(256);
     gRecord->sigToToMtx.reserve(512);
     gRecord->sigToSprite.reserve(64);
-    gRecord->scopeStack.push_back({ kFnvSeed, 0, 0, "root", 0 });
+    gRecord->scopeStack.push_back({ kFnvSeed, 0, 0, 0, "root", 0 });
     gShouldInterpolate = true;
     gNoInterpolateDepth = 0;
     gCameraRelativeDepth = 0;
@@ -293,7 +317,7 @@ void FrameInterpolation_RecordOpenChild(const void* key, uintptr_t id) {
     uint64_t h = gRecord->scopeStack.back().pathHash;
     h = fnvMix(h, reinterpret_cast<uintptr_t>(key));
     h = fnvMix(h, static_cast<uint64_t>(id));
-    gRecord->scopeStack.push_back({ h, 0, 0, static_cast<const char*>(key), id });
+    gRecord->scopeStack.push_back({ h, 0, 0, 0, static_cast<const char*>(key), id });
 }
 
 void FrameInterpolation_RecordCloseChild(void) {
@@ -410,6 +434,34 @@ void FrameInterpolation_RecordSpriteDraw(int kind, void* dst, const float camRel
     d.mirrored = (mirrored != 0);
     d.ambiguousSig = false;
     recordSigCollision(gRecord->sigToSprite, gRecord->sprites, sig, idx, gRecord->sigCollisions, gRecord->scopeStack);
+}
+
+void FrameInterpolation_RecordAnimVertices(void* dst, const void* vertices, int32_t count) {
+    if (!gRecording || dst == nullptr || vertices == nullptr || count <= 0) {
+        return;
+    }
+    ScopeFrame& scope = gRecord->scopeStack.back();
+    uint64_t sig = fnvMix(fnvMix(scope.pathHash, kSigKindAnimVtx), scope.animVtxIdx);
+    scope.animVtxIdx++;
+
+    uint32_t idx = static_cast<uint32_t>(gRecord->animVtxs.size());
+    gRecord->animVtxs.emplace_back();
+    AnimVtxData& d = gRecord->animVtxs.back();
+    d.dst = dst;
+    d.count = static_cast<uint32_t>(count);
+    d.pathSig = sig;
+    d.ambiguousSig = false;
+    d.pos.resize(static_cast<size_t>(count) * 3);
+
+    // Only ob[] moves; everything else in the Vtx (uv, colour/normal) is what
+    // the tick's own copy already put in dst.
+    const Vtx* src = static_cast<const Vtx*>(vertices);
+    for (int32_t i = 0; i < count; i++) {
+        d.pos[i * 3 + 0] = src[i].v.ob[0];
+        d.pos[i * 3 + 1] = src[i].v.ob[1];
+        d.pos[i * 3 + 2] = src[i].v.ob[2];
+    }
+    recordSigCollision(gRecord->sigToAnimVtx, gRecord->animVtxs, sig, idx, gRecord->sigCollisions, gRecord->scopeStack);
 }
 
 void FrameInterpolation_DontInterpolateCamera(void) {
@@ -560,6 +612,46 @@ void BuildInterpolationCache() {
         gCache.pairedSprites.push_back({ i, it->second, snap });
     }
 
+    // Same pairing as the sprite path. A vertex blend can't go degenerate the way
+    // a matrix lerp does, but blending across an animation cut still drags the
+    // model through itself, so measure the jump against the model's own size.
+    const std::vector<AnimVtxData>& currAnimVtxs = gRenderCurr->animVtxs;
+    const std::vector<AnimVtxData>& prevAnimVtxs = gRenderPrev->animVtxs;
+    const std::unordered_map<uint64_t, uint32_t>& prevAnimVtxMap = gRenderPrev->sigToAnimVtx;
+    gCache.pairedAnimVtxs.reserve(currAnimVtxs.size());
+    for (uint32_t i = 0; i < currAnimVtxs.size(); i++) {
+        const AnimVtxData& c = currAnimVtxs[i];
+        if (c.dst == nullptr || c.ambiguousSig) {
+            continue;
+        }
+        auto it = prevAnimVtxMap.find(c.pathSig);
+        if (it == prevAnimVtxMap.end() || it->second >= prevAnimVtxs.size()) {
+            continue;
+        }
+        const AnimVtxData& p = prevAnimVtxs[it->second];
+        // A different vertex count means the sig landed on a different model.
+        if (p.count != c.count || p.pos.size() != c.pos.size()) {
+            continue;
+        }
+        if (p.pos == c.pos) {
+            continue; // pose held still; dst already has it
+        }
+        int32_t maxExtent = 0;
+        int32_t maxDelta = 0;
+        for (size_t k = 0; k < c.pos.size(); k++) {
+            int32_t a = std::abs(static_cast<int32_t>(c.pos[k]));
+            int32_t d = std::abs(static_cast<int32_t>(c.pos[k]) - static_cast<int32_t>(p.pos[k]));
+            if (a > maxExtent) {
+                maxExtent = a;
+            }
+            if (d > maxDelta) {
+                maxDelta = d;
+            }
+        }
+        bool snap = maxExtent > 0 && static_cast<float>(maxDelta) > kAnimVtxSnapRatio * static_cast<float>(maxExtent);
+        gCache.pairedAnimVtxs.push_back({ i, it->second, snap });
+    }
+
     // A tree recycled while we walked it means every index above is suspect.
     // Drop the pass to uninterpolated and say which slot collided.
     if (gRenderPrev->generation.load(std::memory_order_acquire) != prevGen ||
@@ -648,6 +740,46 @@ void emitSprite(const SpriteDrawData& L, std::unordered_map<Mtx*, MtxF>& replace
 }
 
 } // namespace
+
+void FrameInterpolation_ApplyAnimVertices(float t) {
+    if (!gRenderShould) {
+        return;
+    }
+    if (!gCache.built) {
+        BuildInterpolationCache();
+    }
+    if (!gCache.valid) {
+        return;
+    }
+    if (gCache.prevHasCameraPos && gRenderCurr->hasCameraPos) {
+        float dx = gRenderCurr->cameraPos[0] - gCache.prevCameraPos[0];
+        float dy = gRenderCurr->cameraPos[1] - gCache.prevCameraPos[1];
+        float dz = gRenderCurr->cameraPos[2] - gCache.prevCameraPos[2];
+        constexpr float kCutDistSq = 1000.0f * 1000.0f;
+        if (dx * dx + dy * dy + dz * dz > kCutDistSq) {
+            return;
+        }
+    }
+
+    const std::vector<AnimVtxData>& currAnimVtxs = gRenderCurr->animVtxs;
+    const std::vector<AnimVtxData>& prevAnimVtxs = gRenderPrev->animVtxs;
+    const float w = 1.0f - t;
+
+    for (const PairedAnimVtx& pair : gCache.pairedAnimVtxs) {
+        const AnimVtxData& c = currAnimVtxs[pair.currIdx];
+        if (pair.snap) {
+            continue; // never written, so dst still holds this tick's pose
+        }
+        const AnimVtxData& p = prevAnimVtxs[pair.prevIdx];
+        Vtx* dst = reinterpret_cast<Vtx*>(c.dst);
+        for (uint32_t i = 0; i < c.count; i++) {
+            for (int k = 0; k < 3; k++) {
+                float blended = w * static_cast<float>(p.pos[i * 3 + k]) + t * static_cast<float>(c.pos[i * 3 + k]);
+                dst[i].v.ob[k] = static_cast<int16_t>(std::lrintf(blended));
+            }
+        }
+    }
+}
 
 void FrameInterpolation_Interpolate(float t, std::unordered_map<Mtx*, MtxF>& replacements) {
     replacements.clear();

--- a/src/port/Interpolation/FrameInterpolation.h
+++ b/src/port/Interpolation/FrameInterpolation.h
@@ -66,6 +66,10 @@ void FrameInterpolation_RecordCameraPosition(const float pos[3]);
 void FrameInterpolation_NoInterpolatePush(void);
 void FrameInterpolation_NoInterpolatePop(void);
 
+// Like NoInterpolatePush, but keeps the camera half of the transform live.
+void FrameInterpolation_CameraRelativePush(void);
+void FrameInterpolation_CameraRelativePop(void);
+
 // kind matches the three sprite paths in sprite/render.c:
 //   BILLBOARD       — func_80344138. camYaw/camPitch, no spriteRoll.
 //   BILLBOARD_ROLL  — func_80344424. camYaw/camPitch + spriteRoll forward.

--- a/src/port/Interpolation/FrameInterpolation.h
+++ b/src/port/Interpolation/FrameInterpolation.h
@@ -83,6 +83,9 @@ void FrameInterpolation_RecordSpriteDraw(int kind, void* dst, const float camRel
                                          float camYaw, float camPitch, float spriteRoll, const float rotation[3],
                                          int mirrored);
 
+void FrameInterpolation_RecordAnimVertices(void* dst, const void* vertices, int32_t count);
+void FrameInterpolation_ApplyAnimVertices(float t);
+
 // Drop the prev tree at known camera cuts (map load, camera type change).
 void FrameInterpolation_DontInterpolateCamera(void);
 

--- a/src/port/Patches/AnimVertexPatches.cpp
+++ b/src/port/Patches/AnimVertexPatches.cpp
@@ -9,6 +9,8 @@ extern "C" {
 #include "port/Patches/Patches.h"
 }
 
+#include "port/Interpolation/FrameInterpolation.h"
+
 namespace {
 
 // A single anim-vertex model runs 500-750 vertices. This covers roughly 20-25
@@ -44,5 +46,9 @@ extern "C" void port_modelRender_snapshotAnimVertices(Gfx** gfx, void* vertices,
     Vtx* copy = arena + gUsed;
     gUsed += (size_t)count;
     std::memcpy(copy, vertices, (size_t)count * sizeof(Vtx));
+
+    // Hand the pose to interpolation. It owns the blend from here: this buffer
+    // is private to this draw, so replay can rewrite it per sub-frame.
+    FrameInterpolation_RecordAnimVertices(copy, vertices, count);
     gSPSegment((*gfx)++, 0x01, osVirtualToPhysical(copy));
 }

--- a/src/port/Patches/AnimVertexPatches.cpp
+++ b/src/port/Patches/AnimVertexPatches.cpp
@@ -1,0 +1,48 @@
+#include <cstring>
+#include <new>
+#include <spdlog/spdlog.h>
+
+extern "C" {
+#include <ultra64.h>
+#include "functions.h"
+#include "libultraship/libultra/gbi.h"
+#include "port/Patches/Patches.h"
+}
+
+namespace {
+
+// A single anim-vertex model runs 500-750 vertices. This covers roughly 20-25
+// of them on screen at once; past that a draw falls back to the shared buffer,
+// which is exactly the behaviour that existed before this file.
+constexpr size_t kVerticesPerSlot = 16384;
+constexpr int kSlots = 2;
+
+Vtx* gArena[kSlots] = {};
+size_t gUsed = 0;
+int gSlot = 0;
+bool gWarnedExhausted = false;
+
+} // namespace
+
+extern "C" void port_animVtx_beginTick(void) {
+    gSlot = (gSlot + 1) % kSlots;
+    gUsed = 0;
+    if (gArena[gSlot] == nullptr) {
+        gArena[gSlot] = new (std::nothrow) Vtx[kVerticesPerSlot];
+    }
+}
+
+extern "C" void port_modelRender_snapshotAnimVertices(Gfx** gfx, void* vertices, int32_t count) {
+    if (gfx == nullptr || vertices == nullptr || count <= 0) {
+        return;
+    }
+    Vtx* arena = gArena[gSlot];
+    if (arena == nullptr || gUsed + (size_t)count > kVerticesPerSlot) {
+        return;
+    }
+
+    Vtx* copy = arena + gUsed;
+    gUsed += (size_t)count;
+    std::memcpy(copy, vertices, (size_t)count * sizeof(Vtx));
+    gSPSegment((*gfx)++, 0x01, osVirtualToPhysical(copy));
+}

--- a/src/port/Patches/Patches.h
+++ b/src/port/Patches/Patches.h
@@ -83,6 +83,14 @@ int port_spriteSizeCulled(float depth, float size, float baseThreshold, int disa
 float port_hudOrthoShift(float refX);
 void port_modelRenderResetTLUT(Gfx** gfx);
 
+// Vertex-animated models (AnimVertexPatches.cpp)
+
+// Recycles the per-draw vertex arena; once per tick, before the display list is built.
+void port_animVtx_beginTick(void);
+// Copies the just-posed vertices somewhere only this draw points at, and repoints
+// segment 0x01 at the copy.
+void port_modelRender_snapshotAnimVertices(Gfx** gfx, void* vertices, int32_t count);
+
 // Mirror (MirrorPatches.cpp)
 
 int port_mirror_active(void);


### PR DESCRIPTION
Resolves #306: vertex-animated models are now given unique identities and interpolation steps
Resolves #307: shadows properly interpolate on camera angle changes
Resolves #309: Removes the bitflag for shadows in note retention, restoring vanilla behavior