### PR TITLE
Fix rando savestate restore crashing and duplicating junk items

### DIFF
--- a/src/core2/actor_array.c
+++ b/src/core2/actor_array.c
@@ -1936,9 +1936,13 @@ void actors_applyFromSavestate(void *savestate_ptr, ActorListSaveState *savestat
                 pad = savestate_actor->yaw;
                 CALL_CANCELLABLE_EVENT(OnLoadActorSaveState, savestate_actor, sp50[0], sp50[1], sp50[2]) {
                     temp_v0_6 = actor_spawnWithYaw_s32(savestate_actor->modelCacheIndex, &sp50, pad);
-                    actor_copy(savestate_actor, temp_v0_6);
-                    func_80329B68(temp_v0_6);
-                    func_803299B4(temp_v0_6);
+                    // [port] The spawn is nullable: the id may not be spawnable here, and a
+                    // cancelled OnActorSpawn returns whatever the listener supplied, including NULL.
+                    if (temp_v0_6 != NULL) {
+                        actor_copy(savestate_actor, temp_v0_6);
+                        func_80329B68(temp_v0_6);
+                        func_803299B4(temp_v0_6);
+                    }
                 }
             }
             savestate_actor++;

--- a/src/port/Rando/CustomObject/CustomObject.cpp
+++ b/src/port/Rando/CustomObject/CustomObject.cpp
@@ -213,7 +213,8 @@ void CustomObject::FlushRandoSpawnQueue() {
                                                               &actorInfoMap.at(randoActorId).first,
                                                               actorInfoMap.at(randoActorId).second);
 
-        if (randoSaveCheck.obtained && RANDO_SAVE_OPTIONS[RO_SPAWN_JUNK].optionValue == RO_GENERIC_ON) {
+        if (customActor != NULL && randoSaveCheck.obtained &&
+            RANDO_SAVE_OPTIONS[RO_SPAWN_JUNK].optionValue == RO_GENERIC_ON) {
             customActor->marker->unk14_21 = true;
             customActor->scale = 1.0f;
         }

--- a/src/port/Rando/ObjectBehavior/ObjectBehavior.cpp
+++ b/src/port/Rando/ObjectBehavior/ObjectBehavior.cpp
@@ -16,7 +16,6 @@ extern "C" {
 extern ActorArray* suBaddieActorArray;
 }
 
-bool isSaveState = false;
 std::map<RandoCheckId, std::tuple<int32_t, int32_t, int32_t>> randoSaveState;
 
 // clang-format off
@@ -89,12 +88,10 @@ bool IsActorWhitelisted(int32_t actorId) {
         }
     }
 
-    if (!isSaveState) {
-        if (CVarGetInteger(Rando::StaticData::Options[RO_SPAWN_JUNK].cvar, 0) == RO_GENERIC_ON) {
-            for (auto& junk : junkItemList) {
-                if (junk == actorId) {
-                    return true;
-                }
+    if (CVarGetInteger(Rando::StaticData::Options[RO_SPAWN_JUNK].cvar, 0) == RO_GENERIC_ON) {
+        for (auto& junk : junkItemList) {
+            if (junk == actorId) {
+                return true;
             }
         }
     }
@@ -316,11 +313,10 @@ void Rando::ObjectBehavior::Init() {
     COND_HOOK(OnLoadActorSaveState, EVENT_PRIORITY_NORMAL, IS_RANDO, [](IEvent* event) {
         OnLoadActorSaveState* ev = (OnLoadActorSaveState*)event;
 
-        // Junk doesn't count as rando-managed while restoring; only real checks do.
-        isSaveState = true;
-        bool randoManaged = IsActorWhitelisted((actor_e)ev->actor->modelCacheIndex);
-        isSaveState = false;
-        if (!randoManaged) {
+        // Decide up front whether this restore is ours: anything we don't manage falls
+        // through to the vanilla restore untouched. The predicate has to be the same one
+        // the save side recorded under, junk included.
+        if (!IsActorWhitelisted((actor_e)ev->actor->modelCacheIndex)) {
             return;
         }
 
@@ -346,12 +342,16 @@ void Rando::ObjectBehavior::Init() {
             return;
         }
 
+        // The check already has a live actor. Restoring would stack a second one on
+        // top of it, so drop the restore entirely.
         if (CustomObject::CheckSpawnedIdList(randoCheckId)) {
             event->Cancelled = true;
             return;
         }
 
-        Actor* randoCustomActor = CustomObject::ShouldCreateCustomActorEX(randoCheckId, position, false, ev->actor);
+        // refActor keeps an obtained check restoring the junk actor it was saved as
+        // instead of rolling a fresh one.
+        CustomObject::ShouldCreateCustomActorEX(randoCheckId, position, false, ev->actor);
         randoSaveState.erase(randoCheckId);
         event->Cancelled = true;
     })


### PR DESCRIPTION
Resolves a crash with junk spawns in rando. `isSaveState` was only held across a single `IsActorWhitelisted` call, but the spawn it governs runs later; `OnActorSpawn` re-evaluated with the flag clear, reached the opposite verdict, and returned NULL. Now it's held for all of `actors_applyFromSavestate`, `OnLoadActorSaveState` resolves the check before deciding what to do with it so the existing "already spawned" cancel covers junk too, and two nullable spawn results are guarded.
