### PR TITLE
Fix occlusion for stonehenge

### DIFF
--- a/src/port/DevTools/OcclusionDebug.cpp
+++ b/src/port/DevTools/OcclusionDebug.cpp
@@ -41,8 +41,7 @@ const char* CmdTypeName(int type) {
     }
 }
 
-// Each command is keyed by (model part, byte offset within the model bin). The offset is
-// fixed per asset, so it never shifts when force-drawing reveals more geometry.
+// Each command is keyed by (model part, byte offset within the model's geo command list).
 struct Key {
     int part;
     int offset;

--- a/src/port/Patches/GeoCull.cpp
+++ b/src/port/Patches/GeoCull.cpp
@@ -2,6 +2,10 @@
 
 #include "port/Enhancements/Events/Hooks/Events.h"
 
+extern "C" {
+#include "model.h"
+}
+
 static int sConsumerMask = 0;
 
 extern "C" void GeoCull_SetConsumer(int consumerBit, int active) {
@@ -21,7 +25,13 @@ extern "C" int port_geoCullDraw(int type, const void* cmd, const void* modelBin,
         return drawnVanilla;
     }
 
-    int offset = (int)((const unsigned char*)cmd - (const unsigned char*)modelBin);
+    // Key commands by their offset within the geo command list.
+    const auto* bin = static_cast<const BKModelBin*>(modelBin);
+    const unsigned char* geoBase = (const unsigned char*)modelBin;
+    if (bin != nullptr) {
+        geoBase += bin->geo_list_offset;
+    }
+    int offset = (int)((const unsigned char*)cmd - geoBase);
     bool forceDraw = false;
     CALL_EVENT(OnGeoCull, type, offset, modelBin, areaIds, areaCount, detail0, detail1, drawnVanilla, &forceDraw);
     return (drawnVanilla || forceDraw) ? 1 : 0;

--- a/src/port/Patches/GeoCull.h
+++ b/src/port/Patches/GeoCull.h
@@ -22,10 +22,6 @@ extern "C" {
 #define GEOCULL_CONSUMER_DEBUG 1
 #define GEOCULL_CONSUMER_ENHANCEMENT 2
 
-// Called from each conditional cull command in render.c. `cmd`/`modelBin` give the command's
-// stable byte offset; `drawnVanilla` is the unmodified recurse decision. areaIds/areaCount
-// apply to CAMERA only (NULL/0 otherwise); detail0/detail1 are kind-specific extras (CAMERA:
-// flags; LOD: min,max). Returns the final draw decision (1 = draw).
 int port_geoCullDraw(int type, const void* cmd, const void* modelBin, int drawnVanilla, const unsigned char* areaIds,
                      int areaCount, int detail0, int detail1);
 

--- a/src/port/Patches/GraphicsPatches.cpp
+++ b/src/port/Patches/GraphicsPatches.cpp
@@ -114,7 +114,9 @@ static void OnGeoCull_LevelOcclusion(IEvent* event) {
     if (ev->type != OCCLUSION_CMD_CAMERA) {
         return;
     }
-    if (gsworld_getMap() == MAP_2_MM_MUMBOS_MOUNTAIN && ev->offset == 0x2CD0 &&
+    // Offset into the opaque map model's geo command list (the "outside areas {1,2}" CAMERA
+    // command). Read it off the Occlusion Debugger, which reports the same geo-relative key.
+    if (gsworld_getMap() == MAP_2_MM_MUMBOS_MOUNTAIN && ev->offset == 0x2C98 &&
         ev->modelBin == (const void*)mapModel_getModelBin(0)) {
         *ev->forceDraw = true;
     }


### PR DESCRIPTION
Resolve #319, occlusion now keys commands by offset within the geo command list rather than the model bin, so the key depends only on the asset.