### PR TITLE
Uncap render fps for cutscenes and demos

### DIFF
--- a/src/core2/font/print.c
+++ b/src/core2/font/print.c
@@ -6,6 +6,7 @@
 
 #include "port/Patches/Patches.h"
 #include "port/ResourceHelpers.h"
+#include "port/Interpolation/FrameInterpolation.h"
 
 #define PRINT_JP (ResourceMgr_IsJapanese())
 
@@ -906,6 +907,7 @@ void printbuffer_draw(Gfx **gfx, Mtx **mtx, Vtx **vtx) {
     f32 _y;
     f32 width;
 
+    FrameInterpolation_RecordOpenChild("printbuffer", 0);
     gSPDisplayList((*gfx)++, D_80369238);
     for(print_sCurrentPtr = print_sPrintBuffer; print_sCurrentPtr < print_sPrintBuffer + 0x20; print_sCurrentPtr++){
         if (print_sCurrentPtr->string != 0) {
@@ -961,6 +963,7 @@ void printbuffer_draw(Gfx **gfx, Mtx **mtx, Vtx **vtx) {
     gDPSetTexturePersp((*gfx)++, G_TP_PERSP);
     gDPSetTextureFilter((*gfx)++, G_TF_BILERP);
     viewport_setRenderViewportAndPerspectiveMatrix(gfx, mtx);
+    FrameInterpolation_RecordCloseChild();
 }//*/
 
 //adds a new string to the print buffer and updates string buffer end ptr

--- a/src/core2/frame/rendermem.c
+++ b/src/core2/frame/rendermem.c
@@ -5,6 +5,7 @@
 #include "variables.h"
 
 #include "bk_time.h"
+#include "port/Interpolation/FrameInterpolation.h"
 
 extern void func_8023DFF0(s32);
 extern void coMusicPlayer_update(void);
@@ -54,13 +55,17 @@ void func_802E329C(s32 arg0, Gfx **gfx_begin, Gfx **gfx_end) {
         drawRectangle2D(&gfx, 0, 0, (s32) (f32) gFramebufferWidth, (s32) (f32) gFramebufferHeight, 0, 0, 0);
     }
     if ((D_8037E8C0.unk14 == 0) || (D_8037E8C0.unk14 == 3)) {
+        FrameInterpolation_RecordOpenChild("rendermem_bound", 0);
         viewport_setRenderViewportAndPerspectiveMatrix(&gfx, &mtx);
         gcbound_draw(&gfx);
+        FrameInterpolation_RecordCloseChild();
     }
     if (D_8037E8C0.unk14 == 1) {
+        FrameInterpolation_RecordOpenChild("rendermem_pause", 0);
         drawRectangle2D(&gfx, 0, 0, (s32) (f32) gFramebufferWidth, (s32) (f32) gFramebufferHeight, 0, 0, 0);
         viewport_setRenderViewportAndPerspectiveMatrix(&gfx, &mtx);
         func_802F1858(D_8037E8C0.unk10, &gfx, &mtx, &vtx);
+        FrameInterpolation_RecordCloseChild();
     }
     core1_15B30_finishDList(&gfx);
     graphicsCache_checkFrame(gfx_start, gfx, mtx_start, mtx, vtx_start, vtx);

--- a/src/core2/gameloop.c
+++ b/src/core2/gameloop.c
@@ -484,6 +484,9 @@ void func_802E4384(void){
     }
     else{
         func_8033DC18();
+        // [port] Latch this cutscene frame's stutter before anything reads it, so the
+        // time delta below and the renderer's frame budget agree for the whole tick.
+        port_tickCutsceneStutter();
         // [port] Use a fixed 2-VI timestep for normal gameplay.
         s32 viDivisor = viMgr_func_8024BFA0();
         func_8033DC20(); // always consume wall-clock to keep last_ticks fresh

--- a/src/core2/gc/transition.c
+++ b/src/core2/gc/transition.c
@@ -6,6 +6,7 @@
 #include "gc/gctransition.h"
 #include "port/Patches/Patches.h"
 #include "port/Engine.h"
+#include "port/Interpolation/FrameInterpolation.h"
 
 void anctrl_setAnimTimer(AnimCtrl*, f32);
 void func_8025AC20(s32, s32, s32, f32, char*, s32);
@@ -253,6 +254,7 @@ void gctransition_draw(Gfx **gfx, Mtx **mtx, Vtx **vtx) {
     if(s_current_transition.state == 0)
         return;
 
+    FrameInterpolation_RecordOpenChild("transition", 0);
     viewport_backupState();
     if(s_current_transition.anctrl != NULL){
         vp_position[0] = 0.0f;
@@ -377,7 +379,7 @@ void gctransition_draw(Gfx **gfx, Mtx **mtx, Vtx **vtx) {
     }
     viewport_restoreState();
     viewport_setRenderViewportAndPerspectiveMatrix(gfx, mtx);
-    
+    FrameInterpolation_RecordCloseChild();
 }
 
 void gctransition_8030BD4C(void){

--- a/src/port/Engine.cpp
+++ b/src/port/Engine.cpp
@@ -75,9 +75,6 @@ extern s32 D_80275610;
 bool prevAltAssets = false;
 // bool gEnableGammaBoost = true;
 
-// Game mode helper
-bool func_802E4A08(void);
-
 // Soundfont ROM symbols — loaded from OTR in LoadSoundfonts()
 u8* soundfont1ctl_ROM_START = NULL;
 u8* soundfont1ctl_ROM_END = NULL;
@@ -1317,20 +1314,11 @@ namespace {
 struct SubframePacing {
     int subframes; // renders to emit this tick (>= 1)
     int fps;       // target present fps for this tick
+    int viPerTick; // VIs of game time this tick covers
 };
 
 SubframePacing ComputeSubframePacing() {
     int target_fps = (int)GameEngine::Instance->GetInterpolationFPS();
-
-    // Demo/replay modes render at the native rate
-    const bool replayMode = func_802E4A08();
-    if (!replayMode) {
-        // Some music-synced cutscenes cap interpolation at native 30
-        int fpsCap = port_getInterpolationFpsCap();
-        if (fpsCap > 0 && target_fps > fpsCap) {
-            target_fps = fpsCap;
-        }
-    }
 
     // Game-logic VI per tick: gVIsPerFrame (=2 -> 30 Hz) normally; demo
     // replay and cutscene stutter raise it for slow N64 frames.
@@ -1340,6 +1328,12 @@ SubframePacing ComputeSubframePacing() {
     }
     if (viPerTick < gVIsPerFrame) {
         viPerTick = gVIsPerFrame;
+    }
+    // time_setDeltaReal_frames() clamps the demo's recorded VI count to 15, so the
+    // tick never advances more than that no matter what the demo asks for. Match it
+    // here or a bogus recorded value would scale the sub-frame count with it.
+    if (viPerTick > 15) {
+        viPerTick = 15;
     }
 
     int effective_logic_fps = 60 / viPerTick;
@@ -1355,18 +1349,16 @@ SubframePacing ComputeSubframePacing() {
         subframesPerTick = 1;
     }
 
-    // Replay modes never interpolate: one render per tick, held to viPerTick/60 by the floor.
-    if (replayMode) {
-        subframesPerTick = 1;
+    // paceFps drives DXGI's per-present wait so that subframes * 1/paceFps =
+    // viPerTick/60 wall (= game time per tick). Derived from viPerTick rather than
+    // effective_logic_fps: the latter is truncated (VI=7 -> 8, not 8.57), which would
+    // stretch wall time on the odd VI counts demo playback hands us every tick.
+    int fps = subframesPerTick * 60 / viPerTick;
+    if (fps < 1) {
+        fps = 1;
     }
 
-    // paceFps drives DXGI's per-present wait so that subframes * 1/paceFps =
-    // viPerTick/60 wall (= game time per tick). When viPerTick == gVIsPerFrame
-    // and target_fps is a multiple of eff, paceFps == target_fps and stays
-    // constant. Otherwise it varies per tick to keep wall == game.
-    int fps = subframesPerTick * effective_logic_fps;
-
-    return { subframesPerTick, fps };
+    return { subframesPerTick, fps, viPerTick };
 }
 } // namespace
 
@@ -1415,7 +1407,8 @@ void GameEngine::ProcessGfxCommands(Gfx* commands) {
         activeFrames++;
     }
 
-    sPassBudgetNs = 1000000000LL * subframesPerTick / fps;
+    // Wall time this tick is worth, straight from its VI count.
+    sPassBudgetNs = 1000000000LL * pacing.viPerTick / 60;
 
     if (wnd != nullptr) {
         wnd->SetTargetFps(fps);

--- a/src/port/Game.cpp
+++ b/src/port/Game.cpp
@@ -40,8 +40,6 @@ void audioManagerThread_entry(void* arg);
 void core1_15B30_sendMesg3ToRenderThread(void);
 OSMesgQueue* thread5_getTaskQueue(void);
 OSMesgQueue* thread5_getSyncQueue(void);
-// Non-interactive demo/playback modes (attract demo, file playback, etc.) -- decomp gameloop.c
-bool func_802E4A08(void);
 }
 
 // The game tick runs on its own thread and submits display lists through the
@@ -245,8 +243,7 @@ void push_frame() {
 
     GameEngine::Instance->StartFrame();
     port_animVtx_beginTick();
-    // Demo/playback modes render at native rate with no interpolation, so skip recording it.
-    const bool recordInterpolation = GameEngine::IsInterpolationEnabled() && !func_802E4A08();
+    const bool recordInterpolation = GameEngine::IsInterpolationEnabled();
     if (recordInterpolation) {
         FrameInterpolation_StartRecord();
     }

--- a/src/port/Interpolation/FrameInterpolation.cpp
+++ b/src/port/Interpolation/FrameInterpolation.cpp
@@ -17,6 +17,7 @@ constexpr uint64_t kFnvSeed = 0xcbf29ce484222325ULL;
 constexpr uint64_t kSigKindToMtx = 0x1ULL;
 constexpr uint64_t kSigKindSprite = 0x2ULL;
 constexpr uint64_t kSigKindAnimVtx = 0x3ULL;
+constexpr uint64_t kSigKindProjRot = 0x4ULL;
 constexpr float kAnimVtxSnapRatio = 0.5f;
 constexpr float kSpriteSnapDistSq = 300.0f * 300.0f;
 constexpr int kRingSlots = 4;
@@ -60,6 +61,8 @@ struct CameraProjRotData {
     float rollDeg;
     float pitchDeg;
     float yawDeg;
+    uint64_t pathSig;
+    bool ambiguousSig;
 };
 
 struct ScopeFrame {
@@ -67,6 +70,7 @@ struct ScopeFrame {
     uint32_t toMtxIdx;
     uint32_t spriteIdx;
     uint32_t animVtxIdx;
+    uint32_t projRotIdx;
     const char* key;
     uintptr_t id;
 };
@@ -79,6 +83,7 @@ struct FrameTree {
     std::unordered_map<uint64_t, uint32_t> sigToToMtx;
     std::unordered_map<uint64_t, uint32_t> sigToSprite;
     std::unordered_map<uint64_t, uint32_t> sigToAnimVtx;
+    std::unordered_map<uint64_t, uint32_t> sigToProjRot;
     std::vector<ScopeFrame> scopeStack;
     float cameraPos[3] = { 0.0f, 0.0f, 0.0f };
     bool hasCameraPos = false;
@@ -95,6 +100,7 @@ struct FrameTree {
         sigToToMtx.clear();
         sigToSprite.clear();
         sigToAnimVtx.clear();
+        sigToProjRot.clear();
         scopeStack.clear();
         cameraPos[0] = cameraPos[1] = cameraPos[2] = 0.0f;
         hasCameraPos = false;
@@ -121,12 +127,18 @@ struct PairedAnimVtx {
     bool snap;
 };
 
+struct PairedProjRot {
+    uint32_t currIdx;
+    uint32_t prevIdx;
+};
+
 struct InterpolationCache {
     bool built = false;
     bool valid = false;
     std::vector<PairedToMtx> pairedToMtxs;
     std::vector<PairedSprite> pairedSprites;
     std::vector<PairedAnimVtx> pairedAnimVtxs;
+    std::vector<PairedProjRot> pairedProjRots;
     std::vector<uint32_t> camRelFixups;
     float cameraDelta[3] = { 0.0f, 0.0f, 0.0f };
     bool hasCameraDelta = false;
@@ -139,6 +151,7 @@ struct InterpolationCache {
         pairedToMtxs.clear();
         pairedSprites.clear();
         pairedAnimVtxs.clear();
+        pairedProjRots.clear();
         camRelFixups.clear();
         hasCameraDelta = false;
         prevHasCameraPos = false;
@@ -227,11 +240,12 @@ void FrameInterpolation_StartRecord(void) {
     gCollidedParentId = 0;
     gRecord->reset();
     gRecord->toMtxs.reserve(512);
-    gRecord->projRots.reserve(4);
+    gRecord->projRots.reserve(16);
     gRecord->sprites.reserve(256);
     gRecord->sigToToMtx.reserve(512);
     gRecord->sigToSprite.reserve(64);
-    gRecord->scopeStack.push_back({ kFnvSeed, 0, 0, 0, "root", 0 });
+    gRecord->sigToProjRot.reserve(16);
+    gRecord->scopeStack.push_back({ kFnvSeed, 0, 0, 0, 0, "root", 0 });
     gShouldInterpolate = true;
     gNoInterpolateDepth = 0;
     gCameraRelativeDepth = 0;
@@ -317,7 +331,7 @@ void FrameInterpolation_RecordOpenChild(const void* key, uintptr_t id) {
     uint64_t h = gRecord->scopeStack.back().pathHash;
     h = fnvMix(h, reinterpret_cast<uintptr_t>(key));
     h = fnvMix(h, static_cast<uint64_t>(id));
-    gRecord->scopeStack.push_back({ h, 0, 0, 0, static_cast<const char*>(key), id });
+    gRecord->scopeStack.push_back({ h, 0, 0, 0, 0, static_cast<const char*>(key), id });
 }
 
 void FrameInterpolation_RecordCloseChild(void) {
@@ -365,6 +379,12 @@ void FrameInterpolation_RecordCameraProjectionRotation(void* rollMtx, float roll
     if (!gRecording) {
         return;
     }
+
+    ScopeFrame& scope = gRecord->scopeStack.back();
+    uint64_t sig = fnvMix(fnvMix(scope.pathHash, kSigKindProjRot), scope.projRotIdx);
+    scope.projRotIdx++;
+
+    uint32_t idx = static_cast<uint32_t>(gRecord->projRots.size());
     gRecord->projRots.emplace_back();
     CameraProjRotData& d = gRecord->projRots.back();
     d.rollMtx = rollMtx;
@@ -373,6 +393,9 @@ void FrameInterpolation_RecordCameraProjectionRotation(void* rollMtx, float roll
     d.rollDeg = rollDeg;
     d.pitchDeg = pitchDeg;
     d.yawDeg = yawDeg;
+    d.pathSig = sig;
+    d.ambiguousSig = false;
+    recordSigCollision(gRecord->sigToProjRot, gRecord->projRots, sig, idx, gRecord->sigCollisions, gRecord->scopeStack);
 }
 
 void FrameInterpolation_RecordCameraPosition(const float pos[3]) {
@@ -550,6 +573,27 @@ void BuildInterpolationCache() {
 
     gCache.pairedToMtxs.reserve(currToMtxs.size());
     gCache.pairedSprites.reserve(currSprites.size());
+
+    // Camera/viewport projection rotations, matched by path signature. Anything
+    // without a partner this tick keeps the matrix the game already wrote, which
+    // is this tick's own end state.
+    const std::vector<CameraProjRotData>& currProjRots = gRenderCurr->projRots;
+    const std::vector<CameraProjRotData>& prevProjRots = gRenderPrev->projRots;
+    gCache.pairedProjRots.reserve(currProjRots.size());
+    for (uint32_t i = 0; i < currProjRots.size(); i++) {
+        const CameraProjRotData& c = currProjRots[i];
+        if (c.ambiguousSig) {
+            continue;
+        }
+        auto it = gRenderPrev->sigToProjRot.find(c.pathSig);
+        if (it == gRenderPrev->sigToProjRot.end() || it->second >= prevProjRots.size()) {
+            continue;
+        }
+        if (prevProjRots[it->second].ambiguousSig) {
+            continue;
+        }
+        gCache.pairedProjRots.push_back({ i, it->second });
+    }
 
     // Whatever stays out of the cache falls back to the interpreter decoding
     // the Mtx bytes the game itself wrote, which already hold the correct
@@ -860,21 +904,19 @@ void FrameInterpolation_Interpolate(float t, std::unordered_map<Mtx*, MtxF>& rep
 
     const std::vector<CameraProjRotData>& prevProj = gRenderPrev->projRots;
     const std::vector<CameraProjRotData>& currProj = gRenderCurr->projRots;
-    if (prevProj.size() == currProj.size()) {
-        for (size_t i = 0; i < currProj.size(); i++) {
-            const CameraProjRotData& p = prevProj[i];
-            const CameraProjRotData& c = currProj[i];
-            auto emitProj = [&](void* dst, float deg, float ax, float ay, float az) {
-                if (dst == nullptr) {
-                    return;
-                }
-                MtxF& out = replacements[reinterpret_cast<Mtx*>(dst)];
-                guRotateF(out.mf, deg, ax, ay, az);
-            };
-            // Axis conventions per viewport.c: roll about -Z, pitch +X, yaw +Y.
-            emitProj(c.rollMtx, lerpAngleDegSP(p.rollDeg, c.rollDeg, t), 0.0f, 0.0f, -1.0f);
-            emitProj(c.pitchMtx, lerpAngleDegSP(p.pitchDeg, c.pitchDeg, t), 1.0f, 0.0f, 0.0f);
-            emitProj(c.yawMtx, lerpAngleDegSP(p.yawDeg, c.yawDeg, t), 0.0f, 1.0f, 0.0f);
-        }
+    for (const PairedProjRot& pair : gCache.pairedProjRots) {
+        const CameraProjRotData& c = currProj[pair.currIdx];
+        const CameraProjRotData& p = prevProj[pair.prevIdx];
+        auto emitProj = [&](void* dst, float deg, float ax, float ay, float az) {
+            if (dst == nullptr) {
+                return;
+            }
+            MtxF& out = replacements[reinterpret_cast<Mtx*>(dst)];
+            guRotateF(out.mf, deg, ax, ay, az);
+        };
+        // Axis conventions per viewport.c: roll about -Z, pitch +X, yaw +Y.
+        emitProj(c.rollMtx, lerpAngleDegSP(p.rollDeg, c.rollDeg, t), 0.0f, 0.0f, -1.0f);
+        emitProj(c.pitchMtx, lerpAngleDegSP(p.pitchDeg, c.pitchDeg, t), 1.0f, 0.0f, 0.0f);
+        emitProj(c.yawMtx, lerpAngleDegSP(p.yawDeg, c.yawDeg, t), 0.0f, 1.0f, 0.0f);
     }
 }

--- a/src/port/Patches/FramePacingPatches.cpp
+++ b/src/port/Patches/FramePacingPatches.cpp
@@ -62,6 +62,7 @@ static int sLairDingpotDurations[] = { 6, 5, 5, 5, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4,
 static int sCutsceneCounter = 0;
 static int sCutsceneNextStutter = 0;
 static int sCutsceneLagIndex = 0;
+static int sCutsceneExtraVis = 0;
 
 static bool shouldLagCutscene(int* startFrames, int* durations, int count) {
     if (sCutsceneNextStutter == -1) {
@@ -93,47 +94,40 @@ static void resetCutsceneTimings(void) {
     sCutsceneCounter = 0;
     sCutsceneNextStutter = 0;
     sCutsceneLagIndex = 0;
+    sCutsceneExtraVis = 0;
 }
 
-int port_getCutsceneExtraVis(void) {
-    if (!CVarGetInteger(CVAR_CUTSCENE_SYNC, 1))
-        return 0;
+// Advances the stutter tables by one cutscene frame. Called from func_802E4384,
+// the single point where a tick commits its time delta, so every consumer of
+// port_getCutsceneExtraVis() sees the same answer for that tick.
+void port_tickCutsceneStutter(void) {
+    sCutsceneExtraVis = 0;
 
-    int extra = 0;
+    if (!CVarGetInteger(CVAR_CUTSCENE_SYNC, 1))
+        return;
 
     switch (gsworld_getMap()) {
         case MAP_1E_CS_START_NINTENDO:
             if (shouldLagCutscene(sConcertStartFrames, sConcertDurations,
                                   (int)(sizeof(sConcertStartFrames) / sizeof(sConcertStartFrames[0])))) {
-                extra = 1;
+                sCutsceneExtraVis = 1;
             }
             sCutsceneCounter++;
             break;
         case MAP_7B_CS_INTRO_GL_DINGPOT_1:
             if (shouldLagCutscene(sLairDingpotStartFrames, sLairDingpotDurations,
                                   (int)(sizeof(sLairDingpotStartFrames) / sizeof(sLairDingpotStartFrames[0])))) {
-                extra = 1;
+                sCutsceneExtraVis = 1;
             }
             sCutsceneCounter++;
             break;
         default:
             break;
     }
-
-    return extra;
 }
 
-int port_getInterpolationFpsCap(void) {
-    if (!CVarGetInteger(CVAR_CUTSCENE_SYNC, 1))
-        return 0;
-
-    switch (gsworld_getMap()) {
-        // [port] Cap concert to 30 fps
-        case MAP_1E_CS_START_NINTENDO:
-            return 30;
-        default:
-            return 0;
-    }
+int port_getCutsceneExtraVis(void) {
+    return sCutsceneExtraVis;
 }
 
 } // extern "C"

--- a/src/port/Patches/Patches.h
+++ b/src/port/Patches/Patches.h
@@ -21,8 +21,8 @@ void port_pipelineSyncPoint(void);
 int port_getDemoViCount(void);
 void port_setDemoViCount(int viCount);
 int port_getDemoDisplayViCount(int rawViCount);
+void port_tickCutsceneStutter(void);
 int port_getCutsceneExtraVis(void);
-int port_getInterpolationFpsCap(void);
 
 // Localization (Localization.cpp)
 


### PR DESCRIPTION
Before the thread5 revival in #280 every game system, including rendering and game logic, was collapsed into a single thread. This led to prerecorded demos and some cutscenes needing to have artificial fps caps to maintain their sync. With multithreading, the render thread is now decoupled from game logic and audio, and interpolation can once again be uncapped.

Resolves #303