### PR TITLE
Align actor array and marker pool

### DIFF
--- a/include/actor.h
+++ b/include/actor.h
@@ -5,6 +5,10 @@
 
 struct actorMarker_s;
 
+// [port] actor_new is the only allocator of ActorMarkers, one per actor, so the
+// marker pool and the actor array have to be sized off the same number.
+#define ACTOR_POOL_SIZE 0x200
+
 #define ACTOR_FLAG_NONE     (0)
 #define ACTOR_FLAG_UNKNOWN_0 (1 << 0)   // 0x1
 #define ACTOR_FLAG_UNKNOWN_1 (1 << 1)   // 0x2

--- a/src/core2/actor_array.c
+++ b/src/core2/actor_array.c
@@ -56,7 +56,9 @@ typedef struct {
 }Actorlocal_Core2_9E370;
 
 // [port] Sized ahead of demand so actor_new never bk_reallocs (relocates) the array mid-map.
-#define ACTOR_ARRAY_INITIAL_CAP 512
+// The marker pool is the binding limit (see ACTOR_POOL_SIZE); the grow chunk only exists so
+// the array stays large enough to hold whatever the pool handed out, never the other way round.
+#define ACTOR_ARRAY_INITIAL_CAP ACTOR_POOL_SIZE
 #define ACTOR_ARRAY_GROW_CHUNK  128
 
 /* .data */

--- a/src/core2/actor_cubepropsystem.c
+++ b/src/core2/actor_cubepropsystem.c
@@ -4,6 +4,7 @@
 #include "functions.h"
 #include "variables.h"
 #include "enums.h"
+#include "actor.h"
 
 #include <core2/file.h>
 #include "port/Patches/Patches.h"
@@ -13,8 +14,8 @@ extern int ResourceMgr_IsModelAsset(uint32_t assetId);
 
 #define AssetCacheSize 0x3D5
 
-// Port Expand Marker Pool for Rando Allocation
-#define MARKER_POOL_SIZE 0x1C0
+// [port] Expand Marker Pool for Rando Allocation
+#define MARKER_POOL_SIZE ACTOR_POOL_SIZE
 #define MARKER_BITMAP_BYTES (MARKER_POOL_SIZE / 8)
 
 extern bool func_802E74A0(f32[3], f32, f32[3], f32[3]);


### PR DESCRIPTION
The marker pool was fixed at 448 while the actor array started at 512 and grew unbounded, so past 448 live actors `actor_new` deterministically dereferenced a NULL marker from an exhausted pool, which was a crash in `marker_init` seen under Anchor, where every remote player costs an actor plus a shadow actor on top of a full level. Both now derive from one shared `ACTOR_POOL_SIZE` (`0x200`) in `include/actor.h`; no NULL guard was added, since exhaustion should still crash loudly as a signal that something is leaking actors.
