### PR TITLE
Repair Banjo-Dreamie

### DIFF
--- a/src/core2/map/cutscene_skip.c
+++ b/src/core2/map/cutscene_skip.c
@@ -1522,9 +1522,15 @@ void func_8031FAB4(NodeProp *arg0, ActorMarker *arg1) {
 void warp_lairEnterLairFromSMLevel(NodeProp *arg0, ActorMarker *arg1) {
     if (fileProgressFlag_get(FILEPROG_BD_ENTER_LAIR_CUTSCENE) != 0) {
         // MM Lobby
-        // [port] BB romhacks can override this warp destination
-        s32 override = port_getRomhackWarpEnterLair();
-        func_8031CC8C(arg0, override >= 0 ? override : 0x6912);
+        // [port] BB romhacks can override this warp destination via BKCF; port
+        // listeners can refine further by responding to OnWarpResolveDest.
+        s32 dest = 0x6912;
+        s32 bkcf = port_getRomhackWarpEnterLair();
+        if (bkcf >= 0) {
+            dest = bkcf;
+        }
+        CALL_EVENT(OnWarpResolveDest, WARP_ID_LAIR_ENTER_LAIR_FROM_SM_LEVEL, 0x6912, bkcf, &dest);
+        func_8031CC8C(arg0, dest);
     } else {
         fileProgressFlag_set(FILEPROG_BD_ENTER_LAIR_CUTSCENE, 1);
         // Enter Lair Cutscene

--- a/src/port/Enhancements/Events/Hooks/List/GameEvent.h
+++ b/src/port/Enhancements/Events/Hooks/List/GameEvent.h
@@ -28,6 +28,9 @@ DEFINE_EVENT(OnSaveFileSave, void* saveBuffer; int32_t fileNum; int32_t * result
 typedef enum WarpId {
     WARP_ID_SM_EXIT_BANJOS_HOUSE = 1,
     WARP_ID_LAIR_ENTER_MM_LOBBY_FROM_SM_LEVEL = 2,
+    // Also lands in the MM Lobby, but from the post-cutscene branch of a different
+    // dispatcher. Listeners that treat both lair entrances alike should match on 2 || 3.
+    WARP_ID_LAIR_ENTER_LAIR_FROM_SM_LEVEL = 3,
 } WarpId;
 
 DEFINE_EVENT(OnWarpResolveDest, int32_t warpId; int32_t defaultDest; int32_t bkcfOverride; int32_t * dest;)

--- a/src/port/Romhack/RomhackConfig.cpp
+++ b/src/port/Romhack/RomhackConfig.cpp
@@ -769,3 +769,8 @@ extern "C" int port_getRomhackWarpDest(int warp_index) {
     auto it = sWarpDests.find(warp_index);
     return (it != sWarpDests.end()) ? it->second : -1;
 }
+
+extern "C" void port_clearRomhackWarpDest(int warp_index) {
+    LoadGameConfig();
+    sWarpDests.erase(warp_index);
+}

--- a/src/port/Romhack/RomhackConfig.h
+++ b/src/port/Romhack/RomhackConfig.h
@@ -42,6 +42,7 @@ int port_getRomhackJiggyPuzzleSize(int puzzle_index);
 int port_getRomhackJiggyPuzzleFlag(int puzzle_index);
 const char* port_getRomhackLevelName(int level_index);
 int port_getRomhackWarpDest(int warp_index);
+void port_clearRomhackWarpDest(int warp_index);
 bool port_getRomhackCustomCodeHash(char out_hex[41]);
 int port_getRomhackCustomCodeKind(void);
 bool port_getRomhackRomHash(char out_hex[41]);

--- a/src/port/Romhack/RomhackRegistration.cpp
+++ b/src/port/Romhack/RomhackRegistration.cpp
@@ -16,6 +16,7 @@
 #include "port/ShipInit.hpp"
 
 #define ROMHACK_PORT_LIST(PORT) \
+    PORT(Dreamie)               \
     PORT(JiggiesOfTime)         \
     PORT(NewHorizons)           \
     PORT(Nostalgia64)           \

--- a/src/port/Romhack/RomhackTable.h
+++ b/src/port/Romhack/RomhackTable.h
@@ -48,6 +48,9 @@ static constexpr RomhackTableEntry kRomhackTable[] = {
     // rebinds, though Nostalgia 64 also fills spare overlay space with its own
     // functions and repoints update funcs at them.
 
+    // Banjo-Dreamie
+    { "3972b2a3aca230dde1cbf66ffa6f052327b7d3fa", "Dreamie", true },
+
     // Jiggies of Time
     { "ad7ef5ba9051c6a360c1d60546d5ca8cf61f0d92", "JiggiesOfTime", true },
 

--- a/src/port/Romhack/Specific/Dreamie.cpp
+++ b/src/port/Romhack/Specific/Dreamie.cpp
@@ -1,0 +1,38 @@
+/*
+ * Banjo-Dreamie
+ *
+ * Dreamie ships no custom code at all - it rewires the world purely through BB
+ * globalized-overlay data, so the BKCF carries everything. Spiral Mountain becomes
+ * the hub, and two of the ~86 warp edits retarget the Spiral Mountain transitions:
+ *
+ *   warp_smExitBanjosHouse         0x0112 -> 0x0105
+ *   warp_lairEnterLairFromSMLevel  0x6912 -> 0x0112
+ *
+ * Both resolve to map 0x01, which is also Dreamie's new-game map (START_MAP = 1,
+ * START_LEVEL_2 = 1, down from vanilla 0x69). Honoring them verbatim drops every hub
+ * transition back into the starting room instead of moving between areas.
+ *
+ * On every OnWarpResolveDest fire, restore the dispatcher's vanilla default for these
+ * two warps, ignoring what the BKCF claims. The other BKCF warp remaps are genuine and
+ * pass through untouched.
+ *
+ */
+
+#include <libultraship/bridge.h>
+
+#include "port/Enhancements/Events/Hooks/Events.h"
+#include "port/Romhack/RomhackConfig.h"
+
+static constexpr int kWarpIdxSmExitBanjosHouse = 281;
+
+void RegisterDreamiePatches() {
+    port_clearRomhackWarpDest(kWarpIdxSmExitBanjosHouse);
+
+    REGISTER_LISTENER(OnWarpResolveDest, EVENT_PRIORITY_NORMAL, [](IEvent* event) {
+        auto* ev = reinterpret_cast<OnWarpResolveDest*>(event);
+        if (ev->warpId == WARP_ID_SM_EXIT_BANJOS_HOUSE || ev->warpId == WARP_ID_LAIR_ENTER_MM_LOBBY_FROM_SM_LEVEL ||
+            ev->warpId == WARP_ID_LAIR_ENTER_LAIR_FROM_SM_LEVEL) {
+            *ev->dest = ev->defaultDest;
+        }
+    });
+}


### PR DESCRIPTION
The romhack refactor leading up to release accidentally removed the existing patch for Banjo-Dreamie. Restore it.