### PR TITLE
Restore rumble to proper state and restore screenshake

### DIFF
--- a/src/core1/bamotor.c
+++ b/src/core1/bamotor.c
@@ -155,9 +155,7 @@ void baMotor_80250D94(f32 arg0, f32 arg1, f32 arg2){
     if(arg2 != 0.0f && D_802823AC){
         if(func_802E4A08() == 0){
             if(!(0.1 < D_80282420 - D_80282424) || !(arg0 + arg1 < D_80282428 + D_8028242C)){
-                // [port] Scale intensity by ImGui rumble setting.
-                // Original N64 values are ~50% of max (duty cycling a binary motor).
-                f32 scale = port_getRumbleScale() * 2.0f;
+                f32 scale = port_getRumbleScale();
                 D_80282420 = arg2;
                 D_80282424 = 0.0f;
                 D_80282428 = MIN(arg0 * scale, 1.0f);

--- a/src/core2/nc/camera_nodemanager.c
+++ b/src/core2/nc/camera_nodemanager.c
@@ -307,7 +307,9 @@ void ncCamera_update(void){
     viewport_getPosition_vec3f(sp2C);
     viewport_getRotation_vec3f(sp20);
     func_802BB4D8(sp2C, sp20);
-    viewport_setPosition_vec3f(sp2C);
+    if (EventSystem_Should(VB_CAMERA_APPLY_SHAKE, true)) {
+        viewport_setPosition_vec3f(sp2C);
+    }
     viewport_update();
     func_802BEFB0();
     func_802BBA84();

--- a/src/core2/nc/camera_nodemanager.c
+++ b/src/core2/nc/camera_nodemanager.c
@@ -307,6 +307,7 @@ void ncCamera_update(void){
     viewport_getPosition_vec3f(sp2C);
     viewport_getRotation_vec3f(sp20);
     func_802BB4D8(sp2C, sp20);
+    viewport_setPosition_vec3f(sp2C);
     viewport_update();
     func_802BEFB0();
     func_802BBA84();

--- a/src/port/Enhancements/Events/Hooks/Events.h
+++ b/src/port/Enhancements/Events/Hooks/Events.h
@@ -20,6 +20,7 @@ typedef enum VBehaviorID {
     VB_STATIC_CAMERA_EXIT,
     VB_CAMERA_LIVE_ASPECT,
     VB_CAMERA_FOLLOW,
+    VB_CAMERA_APPLY_SHAKE,
 
     // Cutscene and celebration skips
     VB_PLAY_BOOT_LOGOS,

--- a/src/port/Patches/CameraPatches.cpp
+++ b/src/port/Patches/CameraPatches.cpp
@@ -92,6 +92,7 @@ static void updateCutsceneAspect(int32_t mapId) {
 // Widescreen yaw fix — per-frame yaw adjustment for certain static cameras in widescreen mode
 
 #define CVAR_WS_CAMERA_FIX CVAR_ENHANCEMENT("Fix.WidescreenCamera")
+#define CVAR_NO_SCREEN_SHAKE CVAR_SETTING("A11yDisableScreenShake")
 
 struct WsYawFix {
     int32_t map;
@@ -172,5 +173,11 @@ void RegisterCameraPatches_Init() {
     });
 }
 
+void RegisterScreenShake_Init() {
+    COND_VB_SHOULD(VB_CAMERA_APPLY_SHAKE, EVENT_PRIORITY_NORMAL, CVarGetInteger(CVAR_NO_SCREEN_SHAKE, 0),
+                   { *should = false; });
+}
+
 static RegisterShipInitFunc cutsceneAspectInitFunc(RegisterCutsceneAspect, { CVAR_CUTSCENE_ASPECT });
 static RegisterShipInitFunc staticCamInitFunc(RegisterCameraPatches_Init);
+static RegisterShipInitFunc screenShakeInitFunc(RegisterScreenShake_Init, { CVAR_NO_SCREEN_SHAKE });

--- a/src/port/UI/LighthouseMenuSettings.cpp
+++ b/src/port/UI/LighthouseMenuSettings.cpp
@@ -261,21 +261,17 @@ void LighthouseMenu::AddMenuSettings() {
         .Options(ButtonOptions()
                      .Size(Sizes::Inline)
                      .Tooltip("Pick a Banjo-Kazooie ROM and extract only its dialog into a slim language pack."));
+
+    // Accessibility Options
     AddWidget(path, "Accessibility", WIDGET_SEPARATOR_TEXT);
-#if defined(_WIN32) || defined(__APPLE__) || defined(ESPEAK)
-    AddWidget(path, "Text to Speech", WIDGET_CVAR_CHECKBOX)
-        .CVar(CVAR_SETTING("A11yTTS"))
+    AddWidget(path, "Disable Screen Shake", WIDGET_CVAR_CHECKBOX)
+        .CVar(CVAR_SETTING("A11yDisableScreenShake"))
         .RaceDisable(false)
-        .Options(CheckboxOptions().Tooltip("Enables text to speech for in game dialog"));
-#endif
-    AddWidget(path, "Disable Idle Camera Re-Centering", WIDGET_CVAR_CHECKBOX)
-        .CVar(CVAR_SETTING("A11yDisableIdleCam"))
-        .RaceDisable(false)
-        .Options(CheckboxOptions().Tooltip("Disables the automatic re-centering of the camera when idle."));
-    AddWidget(path, "Disable Screen Flash for Finishing Blow", WIDGET_CVAR_CHECKBOX)
-        .CVar(CVAR_SETTING("A11yNoScreenFlashForFinishingBlow"))
-        .RaceDisable(false)
-        .Options(CheckboxOptions().Tooltip("Disables the white screen flash on enemy kill."));
+        .Options(CheckboxOptions().Tooltip(
+            "Stops the camera shaking on impacts such as Beak Buster landings, boulders and boss attacks. "
+            "Controller rumble is unaffected."));
+
+    // Experimental Options
     AddWidget(path, "EXPERIMENTAL", WIDGET_SEPARATOR_TEXT).Options(TextOptions().Color(Colors::Orange));
     AddWidget(path, "ImGui Menu Scaling", WIDGET_CVAR_COMBOBOX)
         .CVar(CVAR_SETTING("ImGuiScale"))


### PR DESCRIPTION
c48ed153 regressed the beak buster screenshake (looong time ago), and since rumble now goes through the game's thread system it no longer needs the multiplier. Adds an accessibility toggle. Resolves #340