### PR TITLE
Fix imgui audio backends showing up when they shouldn't

### DIFF
--- a/src/port/UI/Menu.cpp
+++ b/src/port/UI/Menu.cpp
@@ -113,6 +113,13 @@ void Menu::UpdateWindowBackendObjects() {
     }
 }
 
+void Menu::UpdateAudioBackendObjects() {
+    availableAudioBackends = Ship::Context::GetRawInstance()->GetAudio()->GetAvailableAudioBackends();
+    for (auto& backend : *availableAudioBackends) {
+        availableAudioBackendsMap[backend] = audioBackendsMap.at(backend);
+    }
+}
+
 bool Menu::IsMenuPopped() {
     return popped;
 }
@@ -135,6 +142,7 @@ void Menu::InitElement() {
     menuThemeIndex = static_cast<UIWidgets::Colors>(CVarGetInteger(CVAR_SETTING("Menu.Theme"), defaultThemeIndex));
 
     UpdateWindowBackendObjects();
+    UpdateAudioBackendObjects();
 }
 
 void Menu::UpdateElement() {
@@ -342,10 +350,9 @@ void Menu::MenuDrawItem(WidgetInfo& widget, uint32_t width, UIWidgets::Colors me
                 UIWidgets::ComboboxOptions options = {};
                 options.color = menuThemeIndex;
                 options.tooltip = "Sets the audio API used by the game. Requires a relaunch to take effect.";
-                options.disabled =
-                    Ship::Context::GetRawInstance()->GetAudio()->GetAvailableAudioBackends()->size() <= 1;
+                options.disabled = availableAudioBackends->size() <= 1;
                 options.disabledTooltip = "Only one audio API is available on this platform.";
-                if (UIWidgets::Combobox("Audio API", &currentAudioBackend, audioBackendsMap, options)) {
+                if (UIWidgets::Combobox("Audio API", &currentAudioBackend, availableAudioBackendsMap, options)) {
                     Ship::Context::GetRawInstance()->GetAudio()->SetCurrentAudioBackend(currentAudioBackend);
                 }
             } break;

--- a/src/port/UI/Menu.h
+++ b/src/port/UI/Menu.h
@@ -20,6 +20,7 @@ public:
     void InsertSidebarSearch();
     void RemoveSidebarSearch();
     void UpdateWindowBackendObjects();
+    void UpdateAudioBackendObjects();
     bool IsMenuPopped();
     UIWidgets::Colors GetMenuThemeColor();
 
@@ -41,6 +42,8 @@ protected:
     std::shared_ptr<std::vector<int32_t>> availableWindowBackends;
     std::unordered_map<Fast::WindowBackend, const char*> availableWindowBackendsMap;
     Fast::WindowBackend configWindowBackend;
+    std::shared_ptr<std::vector<Ship::AudioBackend>> availableAudioBackends;
+    std::unordered_map<Ship::AudioBackend, const char*> availableAudioBackendsMap;
 
     std::unordered_map<uint32_t, disabledInfo> disabledMap;
     std::vector<disabledInfo> disabledVector;

--- a/src/port/UI/MenuTypes.h
+++ b/src/port/UI/MenuTypes.h
@@ -266,6 +266,7 @@ struct MainMenuEntry {
 
 static const std::unordered_map<Ship::AudioBackend, const char*> audioBackendsMap = {
     { Ship::AudioBackend::WASAPI, "Windows Audio Session API" },
+    { Ship::AudioBackend::COREAUDIO, "Core Audio" },
     { Ship::AudioBackend::SDL, "SDL" },
     { Ship::AudioBackend::NUL, "Null" },
 };


### PR DESCRIPTION
The combobox was drawing from the full static `audioBackendsMap` instead of `GetAvailableAudioBackends()`, so WASAPI showed everywhere. Resolves #297.