### PR TITLE
Anchor fixes

### DIFF
--- a/src/GV/ch/ancientone.c
+++ b/src/GV/ch/ancientone.c
@@ -4,7 +4,7 @@
 #include "variables.h"
 
 extern void core1_7090_initSfxSource(s32, s32, s32, f32);
-extern s32 port_anchor_isConnected(void);
+extern s32 port_anchor_isWorldSyncActive(void);
 
 typedef struct {
     f32 unk0[3];
@@ -135,7 +135,7 @@ void chAncientOne_update(Actor *this){
         }
         // Anchor only. A statue that has not been drawn yet still has to run the
         // body below so it can catch up to flags another client set.
-        if(!port_anchor_isConnected()){
+        if(!port_anchor_isWorldSyncActive()){
             return;
         }
         {
@@ -152,7 +152,7 @@ void chAncientOne_update(Actor *this){
             return;
         }
         // Anchor: ring order is randomized per-client; advance by synced-flag count.
-        if(port_anchor_isConnected()){
+        if(port_anchor_isWorldSyncActive()){
             s32 fc = 0, fi;
             for(fi = 7; fi < 0xC && mapSpecificFlags_get(fi); fi++) fc++;
             if(this->state == 1 && this->actorTypeSpecificField <= fc){

--- a/src/core2/quiz/game.c
+++ b/src/core2/quiz/game.c
@@ -534,6 +534,10 @@ void port_breakable_despawnBrokenRestores(s32 map) {
     }
 }
 
+s32 port_cutsceneWarp_getReturnMap(void) {
+    return D_80367694;
+}
+
 void chMMMBreakableWooden_update(Actor *this){
     func_802D3CE8(this);
 }

--- a/src/port/Network/Anchor/Anchor.cpp
+++ b/src/port/Network/Anchor/Anchor.cpp
@@ -343,6 +343,12 @@ void Anchor::ClearDummies() {
     dummies.clear();
 }
 
+// Presence only: true in any room, including the global one. For dummy-player visuals.
+extern "C" s32 port_anchor_isConnected(void) {
+    Anchor* anchor = Anchor::GetInstance();
+    return (anchor != nullptr && anchor->isConnected) ? 1 : 0;
+}
+
 // Lets decomp gate Anchor-only catch-up paths so single player keeps vanilla behaviour.
 extern "C" s32 port_anchor_isWorldSyncActive(void) {
     Anchor* anchor = Anchor::GetInstance();
@@ -403,11 +409,20 @@ void Anchor::RemoveDummy(uint32_t clientId) {
     }
 }
 
+extern "C" s32 port_cutsceneWarp_getReturnMap(void);
 extern void port_breakable_clearForLevel(int32_t levelId);
 extern void port_hutSmash_clearForLevel(int32_t levelId);
 extern void port_eggToll_clearForLevel(int32_t levelId);
 extern void port_puzzleStep_clearForLevel(int32_t levelId);
 extern void port_carriedSync_clearForLevel(int32_t levelId);
+
+s32 Anchor_LevelOfMap(s32 map) {
+    if (map <= 0 || map >= MAP_NUM_MAPS) {
+        return 0;
+    }
+    s32 level = (s32)map_getLevel((enum map_e)map);
+    return (level > 0 && level < 0x20) ? level : 0;
+}
 
 void Anchor::SweepUnoccupiedLevelState(GameMap selfMap) {
     // Nothing is shared without world sync, so these stores hold only our own progress —
@@ -416,20 +431,24 @@ void Anchor::SweepUnoccupiedLevelState(GameMap selfMap) {
         return;
     }
 
+    s32 selfLevel = Anchor_LevelOfMap((s32)selfMap);
+    if (selfLevel == 0 || selfLevel == (s32)LEVEL_D_CUTSCENE || selfMap == MAP_91_FILE_SELECT) {
+        return;
+    }
+
     bool occupied[0x20] = { false }; // level_e ids are small; matches jinjo retention slot count
     auto markOccupied = [&occupied](s32 map) {
-        if (map <= 0 || map >= MAP_NUM_MAPS) {
-            return;
-        }
-        s32 level = (s32)map_getLevel((enum map_e)map);
-        if (level > 0 && level < 0x20) {
+        s32 level = Anchor_LevelOfMap(map);
+        if (level != 0) {
             occupied[level] = true;
         }
     };
     markOccupied((s32)selfMap);
+    markOccupied(port_cutsceneWarp_getReturnMap());
     for (auto& [clientId, client] : clients) {
         if (!client.self && client.online && client.isSaveLoaded) {
             markOccupied((s32)client.map);
+            markOccupied(client.cutsceneReturnMap);
         }
     }
     for (s32 level = 1; level < 0x20; level++) {

--- a/src/port/Network/Anchor/Anchor.cpp
+++ b/src/port/Network/Anchor/Anchor.cpp
@@ -1,5 +1,6 @@
 #include "Anchor.h"
 #include "Authority.h"
+#include <cstring>
 #include <nlohmann/json.hpp>
 #include <libultraship/libultraship.h>
 #include "port/Engine.h"
@@ -32,7 +33,11 @@ void Anchor::Enable() {
 }
 
 bool Anchor::IsGlobalRoom() {
-    return std::string("lh-global") == CVarGetString(CVAR_REMOTE_ANCHOR("RoomId"), "");
+    return strcmp(CVarGetString(CVAR_REMOTE_ANCHOR("RoomId"), ""), "lh-global") == 0;
+}
+
+bool Anchor::IsWorldSyncActive() {
+    return isConnected && !IsGlobalRoom() && roomState.syncItemsAndFlags != 0;
 }
 
 void Anchor::Disable() {
@@ -55,8 +60,8 @@ void Anchor::OnConnected() {
     SendPacket_Handshake();
     RegisterHooks();
 
-    port_noteRetention_setForced(1);
-    port_jinjoRetention_setForced(1);
+    port_noteRetention_setForced(IsGlobalRoom() ? 0 : 1);
+    port_jinjoRetention_setForced(IsGlobalRoom() ? 0 : 1);
 
     if (IsSaveLoaded()) {
         SendPacket_RequestTeamState();
@@ -339,9 +344,9 @@ void Anchor::ClearDummies() {
 }
 
 // Lets decomp gate Anchor-only catch-up paths so single player keeps vanilla behaviour.
-extern "C" s32 port_anchor_isConnected(void) {
+extern "C" s32 port_anchor_isWorldSyncActive(void) {
     Anchor* anchor = Anchor::GetInstance();
-    return (anchor != nullptr && anchor->isConnected) ? 1 : 0;
+    return (anchor != nullptr && anchor->IsWorldSyncActive()) ? 1 : 0;
 }
 
 // actorArray_free tears down actors/markers without firing OnActorDestroy; forget them all.
@@ -405,6 +410,12 @@ extern void port_puzzleStep_clearForLevel(int32_t levelId);
 extern void port_carriedSync_clearForLevel(int32_t levelId);
 
 void Anchor::SweepUnoccupiedLevelState(GameMap selfMap) {
+    // Nothing is shared without world sync, so these stores hold only our own progress —
+    // dropping them on a level change would undo single-player state.
+    if (!IsWorldSyncActive()) {
+        return;
+    }
+
     bool occupied[0x20] = { false }; // level_e ids are small; matches jinjo retention slot count
     auto markOccupied = [&occupied](s32 map) {
         if (map <= 0 || map >= MAP_NUM_MAPS) {

--- a/src/port/Network/Anchor/Anchor.h
+++ b/src/port/Network/Anchor/Anchor.h
@@ -31,6 +31,7 @@ typedef struct {
     bool isGameComplete;
     GameMap map, prevMap;
     s32 exit, prevExit;
+    s32 cutsceneReturnMap;
 
     DummyPlayer* dummy;
 } AnchorClient;

--- a/src/port/Network/Anchor/Anchor.h
+++ b/src/port/Network/Anchor/Anchor.h
@@ -210,6 +210,11 @@ public:
 
     bool IsGlobalRoom();
 
+    // The single gate for every Anchor behaviour that touches the world. A presence-only
+    // room (the global room, or a private room with "Sync Items & Flags" off) has to play
+    // exactly like single player, so only dummy players are allowed past this.
+    bool IsWorldSyncActive();
+
     // Presence/position/plumbing packets, the only ones allowed through when the room
     // is not syncing game state. Anything absent is treated as world state and dropped
     // at the send and receive choke points, so a new packet type is unsynced by default.

--- a/src/port/Network/Anchor/Authority.cpp
+++ b/src/port/Network/Anchor/Authority.cpp
@@ -48,9 +48,14 @@ static void Authority_ClearClaim(NetworkActivityId activity) {
     }
 }
 
+static bool Authority_SyncActive() {
+    Anchor* anchor = Anchor::GetInstance();
+    return anchor != nullptr && anchor->IsWorldSyncActive();
+}
+
 bool NetAuthority_IsSelf(NetworkActivityId activity) {
     Anchor* anchor = Anchor::GetInstance();
-    if (anchor == nullptr || !anchor->isConnected || !Authority_IsValidActivity(activity)) {
+    if (!Authority_SyncActive() || !Authority_IsValidActivity(activity)) {
         return true;
     }
     const ActivityState& state = sActivities[activity];
@@ -58,7 +63,7 @@ bool NetAuthority_IsSelf(NetworkActivityId activity) {
 }
 
 bool NetAuthority_IsClaimed(NetworkActivityId activity) {
-    return Authority_IsValidActivity(activity) && sActivities[activity].claimed;
+    return Authority_SyncActive() && Authority_IsValidActivity(activity) && sActivities[activity].claimed;
 }
 
 uint32_t NetAuthority_GetOwner(NetworkActivityId activity) {
@@ -70,7 +75,7 @@ uint32_t NetAuthority_GetOwner(NetworkActivityId activity) {
 
 void NetAuthority_Claim(NetworkActivityId activity) {
     Anchor* anchor = Anchor::GetInstance();
-    if (anchor == nullptr || !anchor->isConnected || !Authority_IsValidActivity(activity)) {
+    if (!Authority_SyncActive() || !Authority_IsValidActivity(activity)) {
         return;
     }
     ActivityState& state = sActivities[activity];
@@ -87,7 +92,7 @@ void NetAuthority_Claim(NetworkActivityId activity) {
 
 void NetAuthority_Release(NetworkActivityId activity) {
     Anchor* anchor = Anchor::GetInstance();
-    if (anchor == nullptr || !anchor->isConnected || !Authority_IsValidActivity(activity)) {
+    if (!Authority_SyncActive() || !Authority_IsValidActivity(activity)) {
         return;
     }
     ActivityState& state = sActivities[activity];

--- a/src/port/Network/Anchor/HookHandlers.cpp
+++ b/src/port/Network/Anchor/HookHandlers.cpp
@@ -25,6 +25,13 @@ extern "C" void port_fpTwinkly_release(void) {
     NetAuthority_Release(NET_ACTIVITY_FP_TWINKLY);
 }
 
+// Every listener below that alters vanilla behaviour is wrapped in this. Presence-only rooms
+// (the global room, or sync turned off) must play exactly like single player.
+static bool Anchor_WorldSyncActive() {
+    Anchor* anchor = Anchor::GetInstance();
+    return anchor != nullptr && anchor->IsWorldSyncActive();
+}
+
 // True when a remote client owns the Mr. Vile minigame (our local logic must follow).
 static bool Anchor_IsVileFollower() {
     return !NetAuthority_IsSelf(NET_ACTIVITY_VILE_MINIGAME);
@@ -32,8 +39,7 @@ static bool Anchor_IsVileFollower() {
 
 // True when we are the live, connected authority for the Mr. Vile minigame.
 static bool Anchor_IsVileAuthority() {
-    return Anchor::GetInstance()->isConnected && NetAuthority_IsClaimed(NET_ACTIVITY_VILE_MINIGAME) &&
-           NetAuthority_IsSelf(NET_ACTIVITY_VILE_MINIGAME);
+    return NetAuthority_IsClaimed(NET_ACTIVITY_VILE_MINIGAME) && NetAuthority_IsSelf(NET_ACTIVITY_VILE_MINIGAME);
 }
 
 // Authority-side per-frame work: stream Mr. Vile's transform and broadcast the periodic
@@ -60,7 +66,7 @@ static void Anchor_UpdateVileSync() {
 
 static void Anchor_UpdateFightSync() {
     auto* anchor = Anchor::GetInstance();
-    if (!anchor->isConnected || !anchor->IsSaveLoaded() || gsworld_getMap() != MAP_90_GL_BATTLEMENTS) {
+    if (!Anchor_WorldSyncActive() || !anchor->IsSaveLoaded() || gsworld_getMap() != MAP_90_GL_BATTLEMENTS) {
         return;
     }
 
@@ -181,7 +187,7 @@ void Anchor::RegisterHooks() {
         // Anchor::GetInstance()->SendPacket_PlayerUpdate(true);
 
         auto* anchor = Anchor::GetInstance();
-        if (anchor->isConnected && anchor->roomState.syncItemsAndFlags && ev->nextMap != MAP_91_FILE_SELECT &&
+        if (Anchor_WorldSyncActive() && ev->nextMap != MAP_91_FILE_SELECT &&
             ev->nextMap != MAP_1E_CS_START_NINTENDO && ev->nextMap != MAP_1F_CS_START_RAREWARE) {
             anchor->SendPacket_RequestScopedState((GameMap)ev->nextMap);
 
@@ -248,7 +254,7 @@ void Anchor::RegisterHooks() {
         Anchor_UpdateVileSync();
         Anchor_UpdateFightSync();
 
-        if (anchor->isConnected && anchor->IsSaveLoaded()) {
+        if (Anchor_WorldSyncActive() && anchor->IsSaveLoaded()) {
             anchor->FlushPendingJiggySpawns();
             if (!anchor->hasCheckedRandoCompat) {
                 anchor->CheckRandoRoomCompatibility();
@@ -268,7 +274,7 @@ void Anchor::RegisterHooks() {
     // returning to idle (or the player declining) releases it.
     COND_HOOK(OnVileGameStateChange, EVENT_PRIORITY_NORMAL, true, [](IEvent* event) {
         auto ev = reinterpret_cast<OnVileGameStateChange*>(event);
-        if (!Anchor::GetInstance()->isConnected || gsworld_getMap() != MAP_10_BGS_MR_VILE) {
+        if (!Anchor_WorldSyncActive() || gsworld_getMap() != MAP_10_BGS_MR_VILE) {
             return;
         }
         if (ev->state >= 2) {
@@ -300,23 +306,35 @@ void Anchor::RegisterHooks() {
 
     // Followers: suppress local random logic; network state drives these instead.
     COND_VB_SHOULD(VB_CCW_FLOWER_REMOTE_GROW, EVENT_PRIORITY_NORMAL, isConnected, {
-        s32 stageFlag = va_arg(args, s32);
-        *should = fileProgressFlag_get((enum file_progress_e)stageFlag) != 0;
+        if (Anchor_WorldSyncActive()) {
+            s32 stageFlag = va_arg(args, s32);
+            *should = fileProgressFlag_get((enum file_progress_e)stageFlag) != 0;
+        }
     });
 
-    COND_VB_SHOULD(VB_CC_RINGS_SNAP_WATER, EVENT_PRIORITY_NORMAL, isConnected, { *should = false; });
+    COND_VB_SHOULD(VB_CC_RINGS_SNAP_WATER, EVENT_PRIORITY_NORMAL, isConnected, {
+        if (Anchor_WorldSyncActive()) {
+            *should = false;
+        }
+    });
 
     // Vanilla despawns the CCW podium until its switch is pressed, and only rebuilds it when the cube
     // re-streams. Keep the actor alive (hidden) instead, so a teammate's press reveals it in place.
-    COND_VB_SHOULD(VB_CCW_PODIUM_DESPAWN, EVENT_PRIORITY_NORMAL, isConnected, { *should = false; });
+    COND_VB_SHOULD(VB_CCW_PODIUM_DESPAWN, EVENT_PRIORITY_NORMAL, isConnected, {
+        if (Anchor_WorldSyncActive()) {
+            *should = false;
+        }
+    });
 
     // Lair door remote-open: Door of Grunty's open flag (0xE2) is already set on arrival; key off
     // visual state (fully open == 0x1B) instead. Other lair doors stay flag-based.
     COND_VB_SHOULD(VB_LEVELDOOR_REMOTE_OPEN_DONE, EVENT_PRIORITY_NORMAL, isConnected, {
-        s32 doorActorId = va_arg(args, s32);
-        s32 doorState = va_arg(args, s32);
-        if (doorActorId == ACTOR_2E5_LARGE_DOOR_TO_FINAL_BATTLE) {
-            *should = (doorState == 0x1B);
+        if (Anchor_WorldSyncActive()) {
+            s32 doorActorId = va_arg(args, s32);
+            s32 doorState = va_arg(args, s32);
+            if (doorActorId == ACTOR_2E5_LARGE_DOOR_TO_FINAL_BATTLE) {
+                *should = (doorState == 0x1B);
+            }
         }
     });
 
@@ -329,25 +347,27 @@ void Anchor::RegisterHooks() {
     });
 
     COND_VB_SHOULD(VB_DOOR_OPEN_CAMERA, EVENT_PRIORITY_NORMAL, isConnected, {
-        s32 doorId = va_arg(args, s32);
-        switch (doorId) {
-            case GV_DOOR_CAM_SUN:
-                *should = !port_mapFlag_wasSetRemotely(3);
-                break;
-            case GV_DOOR_CAM_STAR:
-                *should = !port_mapFlag_wasSetRemotely(5);
-                break;
-            case GV_DOOR_CAM_KAZOOIE:
-                *should = !port_mapFlag_wasSetRemotely(6);
-                break;
-            case GV_DOOR_CAM_JINXY:
-                *should = !(port_mapFlag_wasSetRemotely(0) && port_mapFlag_wasSetRemotely(1));
-                break;
-            case MMM_DOOR_CAM_CHURCH:
-                *should = !port_mapFlag_wasSetRemotely(0); // MMM_SPECIFIC_FLAG_0_UNKNOWN
-                break;
-            default:
-                break;
+        if (Anchor_WorldSyncActive()) {
+            s32 doorId = va_arg(args, s32);
+            switch (doorId) {
+                case GV_DOOR_CAM_SUN:
+                    *should = !port_mapFlag_wasSetRemotely(3);
+                    break;
+                case GV_DOOR_CAM_STAR:
+                    *should = !port_mapFlag_wasSetRemotely(5);
+                    break;
+                case GV_DOOR_CAM_KAZOOIE:
+                    *should = !port_mapFlag_wasSetRemotely(6);
+                    break;
+                case GV_DOOR_CAM_JINXY:
+                    *should = !(port_mapFlag_wasSetRemotely(0) && port_mapFlag_wasSetRemotely(1));
+                    break;
+                case MMM_DOOR_CAM_CHURCH:
+                    *should = !port_mapFlag_wasSetRemotely(0); // MMM_SPECIFIC_FLAG_0_UNKNOWN
+                    break;
+                default:
+                    break;
+            }
         }
     });
 
@@ -520,26 +540,32 @@ void Anchor::RegisterHooks() {
 
     // SM intro Bottles: the tutorial offer is first-answer-wins for the team.
     COND_VB_SHOULD(VB_SM_TUTORIAL_CHOICE_OPEN, EVENT_PRIORITY_NORMAL, isConnected, {
-        if (__chSmBottles_isAnySpiralMountainAbilityLearned() ||
-            (port_puzzleStep_getForMap(MAP_1_SM_SPIRAL_MOUNTAIN, ANCHOR_PUZZLE_SM_TUTORIAL) & 1)) {
-            *should = false;
-        } else if (NetAuthority_IsClaimed(NET_ACTIVITY_SM_TUTORIAL) && !NetAuthority_IsSelf(NET_ACTIVITY_SM_TUTORIAL)) {
-            *should = false;
-        } else {
-            NetAuthority_Claim(NET_ACTIVITY_SM_TUTORIAL);
+        if (Anchor_WorldSyncActive()) {
+            if (__chSmBottles_isAnySpiralMountainAbilityLearned() ||
+                (port_puzzleStep_getForMap(MAP_1_SM_SPIRAL_MOUNTAIN, ANCHOR_PUZZLE_SM_TUTORIAL) & 1)) {
+                *should = false;
+            } else if (NetAuthority_IsClaimed(NET_ACTIVITY_SM_TUTORIAL) &&
+                       !NetAuthority_IsSelf(NET_ACTIVITY_SM_TUTORIAL)) {
+                *should = false;
+            } else {
+                NetAuthority_Claim(NET_ACTIVITY_SM_TUTORIAL);
+            }
         }
     });
 
     // Ability molehills wake up only after the tutorial choice exists: the offer was
     // answered (synced bit) or a move is already known (covers skip-tutorial saves).
     COND_VB_SHOULD(VB_SM_MOLEHILL_ACTIVE, EVENT_PRIORITY_NORMAL, isConnected, {
-        if (!__chSmBottles_isAnySpiralMountainAbilityLearned() &&
+        if (Anchor_WorldSyncActive() && !__chSmBottles_isAnySpiralMountainAbilityLearned() &&
             !(port_puzzleStep_getForMap(MAP_1_SM_SPIRAL_MOUNTAIN, ANCHOR_PUZZLE_SM_TUTORIAL) & 1)) {
             *should = false;
         }
     });
 
     COND_HOOK(OnTimedJiggyExpired, EVENT_PRIORITY_NORMAL, isConnected, [](IEvent* event) {
+        if (!Anchor_WorldSyncActive()) {
+            return;
+        }
         auto ev = reinterpret_cast<OnTimedJiggyExpired*>(event);
         port_jiggySpawn_remove(ev->jiggyId);
     });

--- a/src/port/Network/Anchor/HookHandlers.cpp
+++ b/src/port/Network/Anchor/HookHandlers.cpp
@@ -25,6 +25,8 @@ extern "C" void port_fpTwinkly_release(void) {
     NetAuthority_Release(NET_ACTIVITY_FP_TWINKLY);
 }
 
+s32 Anchor_LevelOfMap(s32 map);
+
 // Every listener below that alters vanilla behaviour is wrapped in this. Presence-only rooms
 // (the global room, or sync turned off) must play exactly like single player.
 static bool Anchor_WorldSyncActive() {
@@ -182,13 +184,16 @@ void Anchor::RegisterHooks() {
         Anchor::GetInstance()->ClearDummies();
         Anchor::GetInstance()->PopulateDummies((GameMap)ev->nextMap);
         Authority_OnSelfMapChanged(ev->nextMap);
-        Anchor::GetInstance()->SweepUnoccupiedLevelState((GameMap)ev->nextMap);
+        s32 prevLevel = Anchor_LevelOfMap((s32)ev->prevMap);
+        if (prevLevel == 0 || prevLevel != Anchor_LevelOfMap((s32)ev->nextMap)) {
+            Anchor::GetInstance()->SweepUnoccupiedLevelState((GameMap)ev->nextMap);
+        }
         Anchor::GetInstance()->SendPacket_MapLoad((GameMap)ev->nextMap, ev->exit);
         // Anchor::GetInstance()->SendPacket_PlayerUpdate(true);
 
         auto* anchor = Anchor::GetInstance();
-        if (Anchor_WorldSyncActive() && ev->nextMap != MAP_91_FILE_SELECT &&
-            ev->nextMap != MAP_1E_CS_START_NINTENDO && ev->nextMap != MAP_1F_CS_START_RAREWARE) {
+        if (Anchor_WorldSyncActive() && ev->nextMap != MAP_91_FILE_SELECT && ev->nextMap != MAP_1E_CS_START_NINTENDO &&
+            ev->nextMap != MAP_1F_CS_START_RAREWARE) {
             anchor->SendPacket_RequestScopedState((GameMap)ev->nextMap);
 
             s32 enteredFlag = -1;

--- a/src/port/Network/Anchor/JigsawPedestal.cpp
+++ b/src/port/Network/Anchor/JigsawPedestal.cpp
@@ -5,9 +5,14 @@
 
 static std::unordered_map<int32_t, uint32_t> sPedestalOwner;
 
+static bool JigsawPedestal_SyncActive() {
+    Anchor* anchor = Anchor::GetInstance();
+    return anchor != nullptr && anchor->IsWorldSyncActive();
+}
+
 int32_t port_jigsawPedestal_tryClaim(int32_t id) {
     Anchor* anchor = Anchor::GetInstance();
-    if (anchor == nullptr || !anchor->isConnected) {
+    if (!JigsawPedestal_SyncActive()) {
         return 1;
     }
     auto it = sPedestalOwner.find(id);
@@ -21,7 +26,7 @@ int32_t port_jigsawPedestal_tryClaim(int32_t id) {
 
 int32_t port_jigsawPedestal_isSelf(int32_t id) {
     Anchor* anchor = Anchor::GetInstance();
-    if (anchor == nullptr || !anchor->isConnected) {
+    if (!JigsawPedestal_SyncActive()) {
         return 1;
     }
     auto it = sPedestalOwner.find(id);
@@ -30,7 +35,7 @@ int32_t port_jigsawPedestal_isSelf(int32_t id) {
 
 void port_jigsawPedestal_release(int32_t id) {
     Anchor* anchor = Anchor::GetInstance();
-    if (anchor == nullptr || !anchor->isConnected) {
+    if (!JigsawPedestal_SyncActive()) {
         return;
     }
     auto it = sPedestalOwner.find(id);

--- a/src/port/Network/Anchor/JsonConversions.hpp
+++ b/src/port/Network/Anchor/JsonConversions.hpp
@@ -67,6 +67,7 @@ inline void from_json(const json& j, AnchorClient& client) {
     client.map = j.value("map", MAP_0_UNKNOWN);
     client.exit = j.value("exit", (s32)0);
     client.self = j.value("self", false);
+    client.cutsceneReturnMap = 0;
 }
 
 #endif // __cplusplus

--- a/src/port/Network/Anchor/Packets/MapLoad.cpp
+++ b/src/port/Network/Anchor/Packets/MapLoad.cpp
@@ -5,6 +5,7 @@
 
 #include "variables.h"
 #include "functions.h"
+#include "port/Patches/Patches.h"
 
 /**
  * MAP_LOAD
@@ -18,6 +19,7 @@ void Anchor::SendPacket_MapLoad(GameMap map, s32 exit) {
     payload["type"] = MAP_LOAD;
     payload["map"] = map;
     payload["exit"] = exit;
+    payload["returnMap"] = port_cutsceneWarp_getReturnMap();
     SendJsonToRemote(payload);
 }
 
@@ -28,6 +30,7 @@ void Anchor::HandlePacket_MapLoad(nlohmann::json& payload) {
 
     clients[clientId].map = payload.at("map").get<GameMap>();
     clients[clientId].exit = payload.at("exit").get<s32>();
+    clients[clientId].cutsceneReturnMap = payload.value("returnMap", (s32)0);
     clients[clientId].isSaveLoaded = clients[clientId].map != MAP_1E_CS_START_NINTENDO &&
                                      clients[clientId].map != MAP_1F_CS_START_RAREWARE &&
                                      clients[clientId].map != MAP_91_FILE_SELECT;

--- a/src/port/Patches/Patches.h
+++ b/src/port/Patches/Patches.h
@@ -142,6 +142,8 @@ void port_breakable_recordBreak(int32_t markerId, int32_t x, int32_t y, int32_t 
 
 int32_t port_breakable_isBroken(int32_t map, int32_t markerId, int32_t x, int32_t y, int32_t z);
 
+int32_t port_cutsceneWarp_getReturnMap(void);
+
 void port_eggToll_onAdvance(int32_t map, int32_t secondaryId, int32_t stage);
 int32_t port_eggToll_getStage(int32_t map, int32_t secondaryId);
 void port_eggToll_remoteApply(int32_t map, int32_t secondaryId, int32_t stage);

--- a/src/port/UI/LighthouseMenu.cpp
+++ b/src/port/UI/LighthouseMenu.cpp
@@ -217,7 +217,7 @@ void LighthouseMenu::InitElement() {
         { FORCED_ON_FOR_ANCHOR_CONNECTED,
           { [](disabledInfo& info) -> bool {
                Anchor* anchor = Anchor::GetInstance();
-               return anchor != nullptr && anchor->isConnected;
+               return anchor != nullptr && anchor->isConnected && !anchor->IsGlobalRoom();
            },
             "Forced on while connected to Anchor" } },
     };

--- a/src/port/UI/LighthouseMenuEnhancements.cpp
+++ b/src/port/UI/LighthouseMenuEnhancements.cpp
@@ -43,7 +43,7 @@ static const char* kBottlesBonusLockedTooltip =
 
 static bool IsBottlesBonusUnlocked(int i) {
     Anchor* anchor = Anchor::GetInstance();
-    if (anchor != nullptr && anchor->isConnected) {
+    if (anchor != nullptr && anchor->isConnected && !anchor->IsGlobalRoom()) {
         return true;
     }
     return gCompletedBottlesBonusGames[i] != 0;


### PR DESCRIPTION
Fixes map transitions (witch switch cutscenes, sub areas) clearing some transient persistence structures.
Gates all Anchor-specific code (hook handlers, vanilla code modifiers) behind a check for world sync to prevent operation in the global room.