### PR TITLE
Fix three asan triggers

### DIFF
--- a/src/port/Rando/Logic/GlitchlessLogic.cpp
+++ b/src/port/Rando/Logic/GlitchlessLogic.cpp
@@ -241,7 +241,9 @@ void PopulateJinjoCheckIds() {
 }
 
 void ResetSaveData() {
-    for (int s = 0; s < sizeof(SaveData); s++) {
+    // [port] `data` is the 112-byte vanilla payload, not the whole SaveData, which is
+    // ~43 KB once shipSaveData (rando checks, note/jinjo retention) is counted.
+    for (size_t s = 0; s < sizeof(gameFile_saveData[selectedFileNum].data); s++) {
         gameFile_saveData[selectedFileNum].data[s] = 0;
     }
 

--- a/src/port/Save/Types.h
+++ b/src/port/Save/Types.h
@@ -417,6 +417,9 @@ static constexpr int kSnsItemCount = sizeof(kSnsUnlocked) / sizeof(kSnsUnlocked[
 // so internal gamenum 0/1/2 corresponds to displayed Game 1/3/2.
 static int SlotToFileIndex(int gameNum) {
     static const int fileMap[3] = { 1, 3, 2 };
+    if (gameNum < 0 || gameNum >= 3) {
+        return 0;
+    }
     return fileMap[gameNum];
 }
 

--- a/src/port/UI/Notification.cpp
+++ b/src/port/UI/Notification.cpp
@@ -2,11 +2,15 @@
 #include "port/UI/cvar_prefixes.h"
 #include <libultraship/libultraship.h>
 #include <fast/Fast3dGui.h>
+#include <mutex>
+#include <vector>
 
 namespace Notification {
 
 static uint32_t nextId = 0;
 static std::vector<Options> notifications = {};
+// Emit() runs on the game thread; Draw()/UpdateElement() run on the render thread.
+static std::mutex notificationsMutex;
 
 #define ABS(x) ((x) >= 0 ? (x) : -(x))
 
@@ -46,9 +50,17 @@ void Window::Draw() {
     ImGui::PushStyleVar(ImGuiStyleVar_WindowPadding,
                         ImVec2(8.0f * CVarGetFloat(CVAR_SETTING("Notifications.Size"), 1.8f), 8.0f));
 
-    for (size_t index = 0; index < notifications.size(); ++index) {
-        auto& notification = notifications[index];
-        int inverseIndex = -ABS((int)index - (int)(notifications.size() - 1));
+    // Render from a snapshot rather than the live vector, so a concurrent Emit() can
+    // reallocate without invalidating anything this loop is reading.
+    std::vector<Options> snapshot;
+    {
+        std::lock_guard<std::mutex> lock(notificationsMutex);
+        snapshot = notifications;
+    }
+
+    for (size_t index = 0; index < snapshot.size(); ++index) {
+        auto& notification = snapshot[index];
+        int inverseIndex = -ABS((int)index - (int)(snapshot.size() - 1));
 
         ImGui::SetNextWindowViewport(vp->ID);
         if (notification.remainingTime < 4.0f) {
@@ -114,6 +126,7 @@ void Window::Draw() {
 }
 
 void Window::UpdateElement() {
+    std::lock_guard<std::mutex> lock(notificationsMutex);
     for (int index = 0; index < notifications.size(); ++index) {
         auto& notification = notifications[index];
 
@@ -129,11 +142,14 @@ void Window::UpdateElement() {
 }
 
 void Emit(Options notification) {
-    notification.id = nextId++;
     if (notification.remainingTime == 0.0f) {
         notification.remainingTime = CVarGetFloat(CVAR_SETTING("Notifications.Duration"), 10.0f);
     }
-    notifications.push_back(notification);
+    {
+        std::lock_guard<std::mutex> lock(notificationsMutex);
+        notification.id = nextId++;
+        notifications.push_back(notification);
+    }
     if (!notification.mute) {
         // TODO: play game notification sound
     }


### PR DESCRIPTION
1) `SlotToFileIndex` needs a guard for gameNum (no file0.json ever exists)
2) `ResetSaveData` needs to only zero the vanilla save payload, not the whole file where Ship data is
3) Notifications UI needs a lock to avoid race conditions between logic thread and draw thread

These heap corruptions may have been the real cause behind difficult-to-trace bugs like Conga's infinite oranges, Clanker's tooth crashes, and TTC Lobby's cannon jiggy. When the heap gets corrupted, all sorts of unexplained things can occur and stack traces are made to point the finger at unrelated code.

The decomp has been littered with heap corruptions time and time again. We should make it a policy to perform address sanitizer runs on new features (this time the thread5 revivals and how imgui interacts with it).