### PR TITLE
Fix Gruntys Lair Gate not rising after collection

### DIFF
--- a/src/port/Rando/MiscBehavior/WorldState.cpp
+++ b/src/port/Rando/MiscBehavior/WorldState.cpp
@@ -173,6 +173,13 @@ void Rando::MiscBehavior::InitWorldStateBehavior() {
                         break;
                     }
                 }
+                if (ev->jiggyId == JIGGY_37_LAIR_BGS_WITCH_SWITCH) {
+                    if (currenLevel == LEVEL_6_LAIR) {
+                        event->Cancelled = true;
+                        ev->result = RANDO_SAVE_CHECKS[RC_GL_JIGGY_WITCH_SWITCH_BUBBLEGLOOP_SWAMP].obtained;
+                        break;
+                    }
+                }
 
                 event->Cancelled = true;
                 ev->result = randoSaveCheck.obtained;


### PR DESCRIPTION
This adds back the JiggyScore_Collected check for the Gate.