### PR TITLE
Fix Presents not using the correct Level Flag.

### DIFF
--- a/src/port/Rando/ObjectBehavior/Present.cpp
+++ b/src/port/Rando/ObjectBehavior/Present.cpp
@@ -10,12 +10,25 @@ s32 levelSpecificFlags_get(s32 i);
 
 #define OPTION_ENABLED RANDO_SAVE_OPTIONS[RO_SHUFFLE_JIGGIES].optionValue
 
+std::map<actor_e, level_flags_e> presentLevelFlagMap = {
+    { ACTOR_1ED_BLUE_PRESENT_COLLECTIBLE, LEVEL_FLAG_11_FP_UNKNOWN },
+    { ACTOR_1EF_GREEN_PRESENT_COLLECTIBLE, LEVEL_FLAG_12_FP_UNKNOWN },
+    { ACTOR_1F1_RED_PRESENT_COLLECTIBLE, LEVEL_FLAG_13_FP_UNKNOWN },
+};
+
+void GetPresentLevelFlag(Actor* actor, level_flags_e levelFlag) {
+    if (levelSpecificFlags_get(levelFlag)) {
+        marker_despawn(actor->marker);
+    }
+}
+
 void Rando::ObjectBehavior::ModifyPresentBehavior(void* presentActor) {
     if (!IS_RANDO && !OPTION_ENABLED) {
         return;
     }
 
     Actor* actor = (Actor*)presentActor;
+    int32_t actorAdjustment = 0;
     int32_t levelFlag = 0;
 
     switch (actor->actor_info->actorId) {
@@ -30,10 +43,7 @@ void Rando::ObjectBehavior::ModifyPresentBehavior(void* presentActor) {
         case ACTOR_1ED_BLUE_PRESENT_COLLECTIBLE:
         case ACTOR_1EF_GREEN_PRESENT_COLLECTIBLE:
         case ACTOR_1F1_RED_PRESENT_COLLECTIBLE:
-            levelFlag = (LEVEL_FLAG_11_FP_UNKNOWN + (actor->actor_info->actorId - ACTOR_1ED_BLUE_PRESENT_COLLECTIBLE));
-            if (levelSpecificFlags_get(levelFlag)) {
-                marker_despawn(actor->marker);
-            }
+            GetPresentLevelFlag(actor, presentLevelFlagMap.at((actor_e)actor->actor_info->actorId));
             break;
         default:
             break;


### PR DESCRIPTION
Presents were using the wrong Level Flag to determine if they had been placed in the Igloo already. This fixes the flag ID so their state is correct.