### PR TITLE
GV: fix Gobi and Trunker reverting after a death reload

### DIFF
--- a/src/port/Rando/MiscBehavior/WorldState.cpp
+++ b/src/port/Rando/MiscBehavior/WorldState.cpp
@@ -211,7 +211,7 @@ void Rando::MiscBehavior::InitWorldStateBehavior() {
                 ev->result = RANDO_SAVE_FLAGS[RANDO_INF_MINIGAME_RINGS_COMPLETED].flagState ||
                              CustomObject::CheckSpawnedIdList(randoCheckId);
             } else {
-                ev->result = CustomObject::CheckSpawnedIdList(randoCheckId);
+                ev->result = CustomObject::CheckSpawnedIdList(randoCheckId) || RANDO_SAVE_CHECKS[randoCheckId].obtained;
             }
         }
     })


### PR DESCRIPTION
Resolve #378. Rando's `OnIsJiggyScoreSpawned` hook answered only from the per-map-session spawned-object list, which is also cleared as soon as the reward is picked up. Vanilla's `jiggyscore_isSpawned` ORs in `isCollected`, so the bit means "this spawn happened" for the rest of the file.

Gobi2, Gobi3 and Trunker all read that bit as world state, so reloading GV after collecting the Trunker jiggy check hid Gobi from the ancient tomb, re-armed Gobi2's Trunker dialog and shrank the tree back down. Fall back to the check's obtained flag when the object is no longer spawned.
