### PR TITLE
Fix No Mumbo Detransform

### DIFF
--- a/src/core2/mumbo.c
+++ b/src/core2/mumbo.c
@@ -514,26 +514,30 @@ Actor *chMumbo_draw(ActorMarker *marker, Gfx **gfx, Mtx **mtx, Vtx **vtx) {
 }
 
 void chMumbo_detransformWarn(NodeProp *arg0, ActorMarker *arg1){
-    s32 xform;
-    xform = player_getTransformation();
-    if(xform == TRANSFORM_1_BANJO || xform  == TRANSFORM_7_WISHWASHY || sHasWarnedBanjoAboutDetransform)
-        return;
-    
-    sHasWarnedBanjoAboutDetransform++;
-    if(D_8037DDF3)
-        return;
-    
-    gcdialog_showDialog(fileProgressFlag_getAndSet(FILEPROG_83_MAGIC_GET_WEAK_TEXT, TRUE) ? VER_SELECT(ASSET_F5C_DIALOG_MUMBO_MAGIC_GET_WEAK_ABREV, 0xAC2, 0, 0) : VER_SELECT(ASSET_F5B_DIALOG_MUMBO_MAGIC_GET_WEAK_FULL, 0xAC1, 0, 0), 0xe, NULL, NULL, NULL, NULL);
+    if (EventSystem_Should(VB_MUMBO_DETRANSFORM, true)) {
+        s32 xform;
+        xform = player_getTransformation();
+        if (xform == TRANSFORM_1_BANJO || xform == TRANSFORM_7_WISHWASHY || sHasWarnedBanjoAboutDetransform)
+            return;
+
+        sHasWarnedBanjoAboutDetransform++;
+        if (D_8037DDF3)
+            return;
+
+        gcdialog_showDialog(fileProgressFlag_getAndSet(FILEPROG_83_MAGIC_GET_WEAK_TEXT, TRUE) ? VER_SELECT(ASSET_F5C_DIALOG_MUMBO_MAGIC_GET_WEAK_ABREV, 0xAC2, 0, 0) : VER_SELECT(ASSET_F5B_DIALOG_MUMBO_MAGIC_GET_WEAK_FULL, 0xAC1, 0, 0), 0xe, NULL, NULL, NULL, NULL);
+    }
 }
 
 void chMumbo_detransformTrigger(NodeProp *arg0, ActorMarker *arg1){
-    s32 xform;
-    xform = player_getTransformation();
-    if(xform == TRANSFORM_1_BANJO || xform  == TRANSFORM_7_WISHWASHY || D_8037DDF1)
-        return;
-    gcdialog_showDialog(fileProgressFlag_getAndSet(FILEPROG_84_MAGIC_ALL_GONE_TEXT, TRUE) ? VER_SELECT(ASSET_F5E_DIALOG_MUMBO_MAGIC_RUN_OUT_ABREV, 0xAC4, 0, 0): VER_SELECT(ASSET_F5D_DIALOG_MUMBO_MAGIC_RUN_OUT_FULL, 0xAC3, 0, 0), 0xe, NULL, NULL, NULL, NULL);
-    D_8037DDF1++;
-    player_transform(TRANSFORM_1_BANJO);
+    if (EventSystem_Should(VB_MUMBO_DETRANSFORM, true)) {
+        s32 xform;
+        xform = player_getTransformation();
+        if (xform == TRANSFORM_1_BANJO || xform == TRANSFORM_7_WISHWASHY || D_8037DDF1)
+            return;
+        gcdialog_showDialog(fileProgressFlag_getAndSet(FILEPROG_84_MAGIC_ALL_GONE_TEXT, TRUE) ? VER_SELECT(ASSET_F5E_DIALOG_MUMBO_MAGIC_RUN_OUT_ABREV, 0xAC4, 0, 0) : VER_SELECT(ASSET_F5D_DIALOG_MUMBO_MAGIC_RUN_OUT_FULL, 0xAC3, 0, 0), 0xe, NULL, NULL, NULL, NULL);
+        D_8037DDF1++;
+        player_transform(TRANSFORM_1_BANJO);
+    }
 }
 
 void func_802D2CB8(void){

--- a/src/port/Enhancements/Cheats/Cheats.cpp
+++ b/src/port/Enhancements/Cheats/Cheats.cpp
@@ -331,12 +331,8 @@ void RegisterFastTransform_Init() {
 
 // Disable Mumbo untransform when going too far
 void RegisterNoMumboUntransform_Init() {
-    COND_HOOK(GameFrameUpdate, EVENT_PRIORITY_NORMAL, CVarGetInteger(CVAR_NO_MUMBO_UNTRANSFORM, 0), [](IEvent* event) {
-        // Prevent Mumbo from triggering untransform dialog/warn
-        // These functions check game state and show dialog
-        // We disable them by setting a flag they check
-        volatileFlag_set((enum volatile_flags_e)207, 1); // Prevents detransform warning
-    });
+    COND_VB_SHOULD(VB_MUMBO_DETRANSFORM, EVENT_PRIORITY_NORMAL, CVarGetInteger(CVAR_NO_MUMBO_UNTRANSFORM, 0),
+                   { *should = false; });
 }
 
 // ============================================================================

--- a/src/port/Enhancements/Events/Hooks/Events.h
+++ b/src/port/Enhancements/Events/Hooks/Events.h
@@ -48,6 +48,7 @@ typedef enum VBehaviorID {
     VB_DISABLE_SNACKER,
     VB_SAVE_AND_EXIT,
     VB_MUMBO_HUT_TRANSFORM_CUTSCENE,
+    VB_MUMBO_DETRANSFORM,
 
     // Rando object behavior
     VB_OVERRIDE_BOTTLES_TEXT_CALLBACK,


### PR DESCRIPTION
Moves No Mumbo Detransform to a VB Hook. Tested that it fires off correctly and no longer uses an expensive OnGameFrameUpdate call.