### PR TITLE
Fix Vanilla Retention With CVar Off

### DIFF
--- a/src/port/Enhancements/Fixes/TransientLevelState.cpp
+++ b/src/port/Enhancements/Fixes/TransientLevelState.cpp
@@ -1,0 +1,62 @@
+// Transient Level State
+//
+// The per-level stores Anchor replicates (huts, breakables, egg tolls, puzzle steps, carried
+// collectibles) are written unconditionally by decomp, but only Anchor's sweep ever cleared
+// them — offline, a smashed hut survived a level exit that should have restored it.
+//
+// Per level, not per map, so sub-area hops keep their state like the actor savestate did.
+
+#include "port/ShipInit.hpp"
+#include "port/Enhancements/Events/PortEnhancements.h"
+#include "port/Enhancements/Events/Hooks/Events.h"
+
+#include "functions.h"
+extern "C" {
+#include "enums.h"
+s32 port_anchor_isWorldSyncActive(void);
+}
+
+void port_breakable_clearForLevel(int32_t levelId);
+void port_hutSmash_clearForLevel(int32_t levelId);
+void port_eggToll_clearForLevel(int32_t levelId);
+void port_puzzleStep_clearForLevel(int32_t levelId);
+void port_carriedSync_clearForLevel(int32_t levelId);
+
+namespace {
+
+int32_t sCurrentLevel = -1;
+
+// 0 for maps outside the section table; map_getLevel would deref null on those.
+int32_t levelOfMap(int32_t map) {
+    if (map <= 0 || map >= MAP_NUM_MAPS) {
+        return 0;
+    }
+    return (int32_t)map_getLevel((enum map_e)map);
+}
+
+} // namespace
+
+void RegisterTransientLevelState_Init() {
+    REGISTER_LISTENER(OnSaveLoad, EVENT_PRIORITY_NORMAL, [](IEvent*) { sCurrentLevel = -1; });
+
+    // HIGH so the stores are empty before this event's NORMAL listeners read them for the new
+    // map (port_breakable_despawnBrokenRestores).
+    REGISTER_LISTENER(OnMapLoad, EVENT_PRIORITY_HIGH, [](IEvent* event) {
+        OnMapLoad* ev = (OnMapLoad*)event;
+        int32_t nextLevel = levelOfMap((int32_t)ev->nextMap);
+        if (nextLevel == 0 || nextLevel == sCurrentLevel) {
+            return;
+        }
+        sCurrentLevel = nextLevel;
+        if (port_anchor_isWorldSyncActive()) {
+            return;
+        }
+        port_breakable_clearForLevel(nextLevel);
+        port_hutSmash_clearForLevel(nextLevel);
+        port_eggToll_clearForLevel(nextLevel);
+        port_puzzleStep_clearForLevel(nextLevel);
+        port_carriedSync_clearForLevel(nextLevel);
+    });
+}
+
+static RegisterShipInitFunc initTransientLevelState(RegisterTransientLevelState_Init, {});

--- a/src/port/Enhancements/Retention/JinjoRetention.cpp
+++ b/src/port/Enhancements/Retention/JinjoRetention.cpp
@@ -156,7 +156,7 @@ extern "C" void port_jinjoRetention_applyRemoteCollect(int32_t map, int32_t bit,
 
 // Called from the actual pickup (__chJinjo_802CDBA8), not broad-phase collision.
 extern "C" void port_jinjoRetention_onLocalJinjoCollected(int32_t markerId) {
-    if (!applyEnabled() || !systemActive()) {
+    if (!systemActive()) {
         return;
     }
     u8 bit = jinjoBitFromMarker(markerId);
@@ -232,16 +232,6 @@ void RegisterJinjoRetention_Init() {
         event->Cancelled = true;
     });
 
-    // bcopy's scratch-slot save buffer doesn't carry our bits; sync them in.
-    COND_HOOK(OnSaveFileSave, EVENT_PRIORITY_HIGH, CVAR_VALUE, [](IEvent* event) {
-        OnSaveFileSave* ev = (OnSaveFileSave*)event;
-        SaveData* buf = (SaveData*)ev->saveBuffer;
-        JinjoRetentionSaveData* live = store();
-        if (buf != nullptr && live != nullptr && &buf->shipSaveData.jinjoRetention != live) {
-            buf->shipSaveData.jinjoRetention = *live;
-        }
-    });
-
     COND_VB_SHOULD(VB_OVERRIDE_BUNDLE_SPAWN, EVENT_PRIORITY_NORMAL, CVAR_VALUE, {
         (void)va_arg(args, int);
         BundleInfo* bundleInfo = va_arg(args, BundleInfo*);
@@ -265,3 +255,17 @@ void RegisterJinjoRetention_Init() {
 }
 
 static RegisterShipInitFunc initJinjoRetention(RegisterJinjoRetention_Init, { CVAR_JINJO_RETENTION });
+
+static void RegisterRetentionSaving_Init() {
+    // bcopy's scratch-slot save buffer doesn't carry our bits; sync them in.
+    COND_HOOK(OnSaveFileSave, EVENT_PRIORITY_HIGH, true, [](IEvent* event) {
+        OnSaveFileSave* ev = (OnSaveFileSave*)event;
+        SaveData* buf = (SaveData*)ev->saveBuffer;
+        JinjoRetentionSaveData* live = store();
+        if (buf != nullptr && live != nullptr && &buf->shipSaveData.jinjoRetention != live) {
+            buf->shipSaveData.jinjoRetention = *live;
+        }
+    });
+}
+
+static RegisterShipInitFunc initRetentionSaving(RegisterRetentionSaving_Init);

--- a/src/port/Enhancements/Retention/NoteRetention.cpp
+++ b/src/port/Enhancements/Retention/NoteRetention.cpp
@@ -18,6 +18,7 @@
 
 #include <vector>
 #include <unordered_map>
+#include <unordered_set>
 
 #include "functions.h"
 extern "C" {
@@ -74,8 +75,20 @@ int32_t noteCounter = 0;
 std::vector<QueuedNote> noteActorQueue;
 std::unordered_map<int64_t, ActorMarker*> activeNoteSet;
 
+// Notes taken since entering this level: reproduces the prop "taken" bit they lost to actors.
+std::unordered_set<int64_t> collectedThisVisit;
+int32_t sVisitLevel = -1;
+
 int64_t noteKey(int32_t mapId, int32_t noteIndex) {
     return ((int64_t)mapId << 32) | (uint32_t)noteIndex;
+}
+
+// 0 for maps outside the section table; map_getLevel would deref null on those.
+int32_t levelOfMap(int32_t map) {
+    if (map <= 0 || map >= MAP_NUM_MAPS) {
+        return 0;
+    }
+    return (int32_t)map_getLevel((enum map_e)map);
 }
 
 using retention::activeSlot;
@@ -86,6 +99,12 @@ int32_t sPendingSeedLevel = -1;
 
 bool applyEnabled() {
     return CVAR_VALUE;
+}
+
+// Rando drives note props on this same VB when they're shuffled, writing *should for every one
+// of them — hand the class over rather than race it on listener order.
+bool randoOwnsNoteProps() {
+    return IS_RANDO && RANDO_SAVE_OPTIONS[RO_SHUFFLE_MUSIC_NOTES].optionValue;
 }
 
 NoteRetentionSaveData* store() {
@@ -154,7 +173,7 @@ extern "C" void port_noteRetention_getSizeAndPtr(int32_t* size, uint8_t** addr) 
 
 // Called from the actual pickup (MARKER_5F_MUSIC_NOTE), not broad-phase collision.
 extern "C" void port_noteRetention_onLocalNoteCollected(void* markerPtr) {
-    if (!applyEnabled() || !systemActive()) {
+    if (!systemActive()) {
         return;
     }
     ActorMarker* marker = (ActorMarker*)markerPtr;
@@ -177,6 +196,7 @@ extern "C" void port_noteRetention_onLocalNoteCollected(void* markerPtr) {
     }
     bool wasCollected = isCollected(mapId, noteIndex);
     setCollected(mapId, noteIndex);
+    collectedThisVisit.insert(noteKey(mapId, noteIndex));
     activeNoteSet.erase(noteKey(mapId, noteIndex));
     if (!wasCollected) {
         CALL_EVENT(OnCollectibleCollected, ANCHOR_COLLECTIBLE_NOTE, noteIndex);
@@ -212,9 +232,14 @@ extern "C" void port_noteRetention_applyRemoteCollect(int32_t mapId, int32_t not
 // Called from gsworld_load before cube parsing; fires on every re-parse (map load, intra-
 // level warps). Resets the index counter.
 extern "C" void port_noteRetention_beginMapLoad(int32_t mapId) {
-    (void)mapId;
     noteCounter = 0;
     noteActorQueue.clear();
+    // Sub-area hops stay within the visit; only a real level change lets notes come back.
+    int32_t level = levelOfMap(mapId);
+    if (level != sVisitLevel) {
+        sVisitLevel = level;
+        collectedThisVisit.clear();
+    }
 }
 
 extern "C" void port_noteRetention_onActorsFreed(void) {
@@ -242,68 +267,6 @@ extern "C" int32_t port_noteRetention_debugPickLive(int32_t mapId) {
 }
 
 void RegisterNoteRetention_Init() {
-    COND_VB_SHOULD(VB_OVERRIDE_PROP_SPAWN, EVENT_PRIORITY_NORMAL, CVAR_VALUE, {
-        s16* spawnPosition = va_arg(args, s16*);
-        s32 spriteAsset = va_arg(args, s32);
-
-        if (!systemActive() || spriteAsset != kNoteSpriteAsset) {
-            return;
-        }
-
-        int32_t mapId = (int32_t)gsworld_getMap();
-        int32_t noteIndex = noteCounter++;
-        if (!indexInRange(mapId, noteIndex)) {
-            return; // out of addressable range
-        }
-
-        // We own this note: suppress the static sprite prop.
-        *should = true;
-
-        if (activeNoteSet.count(noteKey(mapId, noteIndex))) {
-            return; // a live actor already exists (re-parse)
-        }
-
-        if (applyEnabled() && isCollected(mapId, noteIndex)) {
-            return; // already collected and retention on
-        }
-
-        QueuedNote queued;
-        queued.pos[0] = spawnPosition[0];
-        queued.pos[1] = spawnPosition[1];
-        queued.pos[2] = spawnPosition[2];
-        queued.mapId = mapId;
-        queued.noteIndex = noteIndex;
-        queued.spawned = false;
-        noteActorQueue.push_back(queued);
-    });
-
-    // Flush queued notes into actors. actor_new does not re-fire OnActorSpawn.
-    COND_HOOK(OnActorSpawn, EVENT_PRIORITY_NORMAL, CVAR_VALUE, [](IEvent* event) {
-        if (!systemActive() || noteActorQueue.empty()) {
-            return;
-        }
-        for (auto& q : noteActorQueue) {
-            if (q.spawned) {
-                continue;
-            }
-            int32_t pos[3];
-            pos[0] = q.pos[0];
-            pos[1] = q.pos[1];
-            pos[2] = q.pos[2];
-            Actor* note = actor_new(pos, 0, &sumusicNote, ACTOR_FLAG_UNKNOWN_21);
-            if (note != nullptr) {
-                note->unk124_6 = 0;
-            }
-            ActorMarker* marker = (note != nullptr) ? note->marker : nullptr;
-            if (marker != nullptr) {
-                // Key on the marker (stable across the actor's life).
-                ObjectExtension::GetInstance().Set<NoteRetentionData>(marker, NoteRetentionData(q.mapId, q.noteIndex));
-                activeNoteSet[noteKey(q.mapId, q.noteIndex)] = marker;
-            }
-            q.spawned = true;
-        }
-    });
-
     // Bundle notes continue the map's index counter; identity stored in actor->local.
     COND_VB_SHOULD(VB_OVERRIDE_BUNDLE_SPAWN, EVENT_PRIORITY_NORMAL, true, {
         bundle_e bundleId = (bundle_e)va_arg(args, int);
@@ -329,8 +292,8 @@ void RegisterNoteRetention_Init() {
         if (activeNoteSet.count(key)) {
             return; // a live actor already exists (re-trigger this load)
         }
-        if (applyEnabled() && isCollected(mapId, noteIndex)) {
-            return; // already collected and retention on
+        if ((applyEnabled() && isCollected(mapId, noteIndex)) || collectedThisVisit.count(key)) {
+            return;
         }
 
         int32_t pos[3];
@@ -350,20 +313,6 @@ void RegisterNoteRetention_Init() {
 
         activeNoteSet[key] = note->marker;
         *actorOut = note;
-    });
-
-    COND_HOOK(OnLoadActorSaveState, EVENT_PRIORITY_NORMAL, CVAR_VALUE, [](IEvent* event) {
-        OnLoadActorSaveState* ev = (OnLoadActorSaveState*)event;
-        if (!systemActive() || ev->actor == nullptr) {
-            return;
-        }
-        if ((int32_t)ev->actor->modelCacheIndex != ACTOR_51_MUSIC_NOTE) {
-            return;
-        }
-        if (ev->actor->is_bundle && bundleNoteLocal(ev->actor) != nullptr) {
-            return; // keep restored bundle notes alive
-        }
-        event->Cancelled = true;
     });
 
     // Seed the level's note counter from collected notes.
@@ -410,8 +359,102 @@ void RegisterNoteRetention_Init() {
                 break;
         }
     });
+}
 
-    COND_HOOK(OnActorDestroy, EVENT_PRIORITY_NORMAL, CVAR_VALUE, [](IEvent* event) {
+static RegisterShipInitFunc initNoteRetention(RegisterNoteRetention_Init, { CVAR_NOTE_RETENTION });
+
+// Always registered: the sprite-prop pickup path has no marker to record through, so notes must
+// be actors even when the enhancement isn't applying. Only the suppression below is gated.
+static void RegisterRetentionSaving_Init() {
+    REGISTER_LISTENER(OnSaveLoad, EVENT_PRIORITY_NORMAL, [](IEvent*) {
+        collectedThisVisit.clear();
+        sVisitLevel = -1;
+    });
+
+    // The cube parse rebuilds static notes every map load, so a restored copy would double them
+    // on a sub-area round trip. Bundle notes have no parse to come from and must survive.
+    REGISTER_LISTENER(OnLoadActorSaveState, EVENT_PRIORITY_NORMAL, [](IEvent* event) {
+        OnLoadActorSaveState* ev = (OnLoadActorSaveState*)event;
+        if (!systemActive() || ev->actor == nullptr) {
+            return;
+        }
+        if ((int32_t)ev->actor->modelCacheIndex != ACTOR_51_MUSIC_NOTE) {
+            return;
+        }
+        if (ev->actor->is_bundle && bundleNoteLocal(ev->actor) != nullptr) {
+            return; // keep restored bundle notes alive
+        }
+        event->Cancelled = true;
+    });
+
+    COND_VB_SHOULD(VB_OVERRIDE_PROP_SPAWN, EVENT_PRIORITY_NORMAL, true, {
+        s16* spawnPosition = va_arg(args, s16*);
+        s32 spriteAsset = va_arg(args, s32);
+
+        if (!systemActive() || spriteAsset != kNoteSpriteAsset) {
+            return;
+        }
+
+        int32_t mapId = (int32_t)gsworld_getMap();
+        int32_t noteIndex = noteCounter++;
+        if (!indexInRange(mapId, noteIndex)) {
+            return; // out of addressable range
+        }
+
+        // Counter already advanced, so indices stay aligned; rando spawns these itself.
+        if (randoOwnsNoteProps()) {
+            return;
+        }
+
+        // We own this note: suppress the static sprite prop.
+        *should = true;
+
+        if (activeNoteSet.count(noteKey(mapId, noteIndex))) {
+            return; // a live actor already exists (re-parse)
+        }
+
+        if ((applyEnabled() && isCollected(mapId, noteIndex)) || collectedThisVisit.count(noteKey(mapId, noteIndex))) {
+            return;
+        }
+
+        QueuedNote queued;
+        queued.pos[0] = spawnPosition[0];
+        queued.pos[1] = spawnPosition[1];
+        queued.pos[2] = spawnPosition[2];
+        queued.mapId = mapId;
+        queued.noteIndex = noteIndex;
+        queued.spawned = false;
+        noteActorQueue.push_back(queued);
+    });
+
+    // Flush queued notes into actors. actor_new does not re-fire OnActorSpawn.
+    COND_HOOK(OnActorSpawn, EVENT_PRIORITY_NORMAL, true, [](IEvent* event) {
+        if (!systemActive() || noteActorQueue.empty()) {
+            return;
+        }
+        for (auto& q : noteActorQueue) {
+            if (q.spawned) {
+                continue;
+            }
+            int32_t pos[3];
+            pos[0] = q.pos[0];
+            pos[1] = q.pos[1];
+            pos[2] = q.pos[2];
+            Actor* note = actor_new(pos, 0, &sumusicNote, ACTOR_FLAG_UNKNOWN_21);
+            if (note != nullptr) {
+                note->unk124_6 = 0;
+            }
+            ActorMarker* marker = (note != nullptr) ? note->marker : nullptr;
+            if (marker != nullptr) {
+                // Key on the marker (stable across the actor's life).
+                ObjectExtension::GetInstance().Set<NoteRetentionData>(marker, NoteRetentionData(q.mapId, q.noteIndex));
+                activeNoteSet[noteKey(q.mapId, q.noteIndex)] = marker;
+            }
+            q.spawned = true;
+        }
+    });
+
+    COND_HOOK(OnActorDestroy, EVENT_PRIORITY_NORMAL, true, [](IEvent* event) {
         OnActorDestroy* ev = (OnActorDestroy*)event;
         if (ev->actor == nullptr) {
             return;
@@ -430,7 +473,7 @@ void RegisterNoteRetention_Init() {
     });
 
     // bcopy's scratch-slot save buffer doesn't carry our bits; sync them in.
-    COND_HOOK(OnSaveFileSave, EVENT_PRIORITY_HIGH, CVAR_VALUE, [](IEvent* event) {
+    COND_HOOK(OnSaveFileSave, EVENT_PRIORITY_HIGH, true, [](IEvent* event) {
         OnSaveFileSave* ev = (OnSaveFileSave*)event;
         SaveData* buf = (SaveData*)ev->saveBuffer;
         NoteRetentionSaveData* live = store();
@@ -440,4 +483,4 @@ void RegisterNoteRetention_Init() {
     });
 }
 
-static RegisterShipInitFunc initNoteRetention(RegisterNoteRetention_Init, { CVAR_NOTE_RETENTION });
+static RegisterShipInitFunc initRetentionSaving(RegisterRetentionSaving_Init);


### PR DESCRIPTION
The intended behavior of vanilla retention saving in the background even if the CVar was off was broken a while back. This restores that.
Also fixes transient persistence clearing bleeding out of Anchor and incorrectly clearing pieces on subarea transitions.