### PR TITLE
Fix Pedestal Sync

### DIFF
--- a/src/lair/jigsawpicture.c
+++ b/src/lair/jigsawpicture.c
@@ -451,6 +451,24 @@ static void revealCcwPuzzlePodium(Actor *this) {
     }
 }
 
+static s32 jigsawPicture_placedFromFlags(Actor *this) {
+    return fileProgressFlag_getN(_puzzleFlag(this->actorTypeSpecificField - 1), _puzzleSize(this->actorTypeSpecificField - 1));
+}
+
+static void jigsawPicture_resyncFromFlags(Actor *this) {
+    ActorLocal_lair_86F0 *local = (ActorLocal_lair_86F0*)&this->local;
+    s32 placed = jigsawPicture_placedFromFlags(this);
+    s32 i;
+
+    local->unk0 = 0;
+    local->unk4 = 0;
+    for(i = 0; i < placed; i++){
+        local->unk4++;
+        local->unk0 |= (1 << getPicturePiecePosition(this));
+    }
+    setInitialJigsawPictureOpacity(this);
+}
+
 void updateJigsawPictureActor(Actor *this) {
     ActorLocal_lair_86F0 *local;
     s32 sp7C[6]; //buttons
@@ -533,6 +551,9 @@ void updateJigsawPictureActor(Actor *this) {
     controller_copyFaceButtons(0, sp7C);
     controller_copySideButtons(0, sp6C);
     func_8038EDBC(this);
+    if (local->unk4 != jigsawPicture_placedFromFlags(this) && EventSystem_Should(VB_JIGSAW_PICTURE_RESYNC, false, this)) {
+        jigsawPicture_resyncFromFlags(this);
+    }
     if (this->state != JIGSAW_PICTURE_LEAVE_PODIUM && !port_jigsawPedestal_isSelf(this->actorTypeSpecificField)) {
         jigsawPicture_setState(this, JIGSAW_PICTURE_LEAVE_PODIUM);
         return;

--- a/src/port/Enhancements/Events/Hooks/Events.h
+++ b/src/port/Enhancements/Events/Hooks/Events.h
@@ -91,8 +91,9 @@ typedef enum VBehaviorID {
     VB_DOOR_OPEN_CAMERA,        // Suppresses door-open camera lock when the flag came from a teammate, not us.
     VB_CC_RINGS_SNAP_WATER,     // CC rings water snap on run teardown: suppressed when a teammate finished the rings.
     VB_LEVELDOOR_REMOTE_OPEN_DONE, // Lair door remote-open "already handled" test.
-    VB_CCW_PODIUM_DESPAWN, // Despawn the unrevealed CCW puzzle podium: suppressed so a teammate's switch press can
-                           // reveal it live.
+    VB_CCW_PODIUM_DESPAWN,    // Despawn the unrevealed CCW puzzle podium: suppressed so a teammate's switch press can
+                              // reveal it live.
+    VB_JIGSAW_PICTURE_RESYNC, // Rebuild a lair podium's cached piece state when the synced flags disagree with it.
 
     // Romhack port gates
     VB_JIGGYSCORE_LEVEL_TOTAL,

--- a/src/port/Network/Anchor/HookHandlers.cpp
+++ b/src/port/Network/Anchor/HookHandlers.cpp
@@ -331,6 +331,12 @@ void Anchor::RegisterHooks() {
         }
     });
 
+    COND_VB_SHOULD(VB_JIGSAW_PICTURE_RESYNC, EVENT_PRIORITY_NORMAL, isConnected, {
+        if (Anchor_WorldSyncActive()) {
+            *should = true;
+        }
+    });
+
     // Lair door remote-open: Door of Grunty's open flag (0xE2) is already set on arrival; key off
     // visual state (fully open == 0x1B) instead. Other lair doors stay flag-based.
     COND_VB_SHOULD(VB_LEVELDOOR_REMOTE_OPEN_DONE, EVENT_PRIORITY_NORMAL, isConnected, {

--- a/src/port/Network/Anchor/JigsawPedestal.cpp
+++ b/src/port/Network/Anchor/JigsawPedestal.cpp
@@ -1,5 +1,6 @@
 #include "port/Network/Anchor/JigsawPedestal.h"
 #include "port/Network/Anchor/Anchor.h"
+#include "functions.h"
 #include <unordered_map>
 #include <vector>
 
@@ -36,6 +37,11 @@ int32_t port_jigsawPedestal_isSelf(int32_t id) {
 void port_jigsawPedestal_release(int32_t id) {
     Anchor* anchor = Anchor::GetInstance();
     if (!JigsawPedestal_SyncActive()) {
+        return;
+    }
+    // Keep a finished picture's claim until we leave the map: vanilla already refuses to let anyone
+    // step back on it, and holding covers a teammate whose completion bits are still in flight.
+    if (jigsawPicture_isJigsawPictureComplete(id)) {
         return;
     }
     auto it = sPedestalOwner.find(id);


### PR DESCRIPTION
Remote clients weren't live reacting to puzzle completion packets, and so once a player on a pedestal completed them, they released authority immediately and anyone else in range of a puzzle lock would trigger it and could put more puzzle pieces into it. This sets it up so that authority is never released for completed puzzles, since they're not meaningfully interactable afterward, and sets up the live completion sync so that remote clients reflect a completed puzzle.