### PR TITLE
Don't let animCache_getNew index before the array

### DIFF
--- a/src/core2/anim/animcache.c
+++ b/src/core2/anim/animcache.c
@@ -81,13 +81,15 @@ void animCache_update(void){
 
 s16 animCache_getNextFree(void){
     int i;
-
-    for(i = 0; i<340; i++){
+// [port] Don't let animCache_getNew index before the array
+//  for(i = 0; i<340; i++){
+    for(i = 1; i<340; i++){
         if(!D_80379E20[i].alive){
             return i;
         }
     }
-    return -1;
+//  return -1;
+    return 0;
 }
 
 s16 animCache_getNew(void){


### PR DESCRIPTION
`animCache_getNextFree` returns `-1` when the 340-entry animation cache is exhausted, and `animCache_getNew` indexes the array with it unchecked. The `-1` is also stored in `animcache_index[]` and passed back to `animCache_release` and `animCache_getBoneTransformList`. `struct10E0s` is 16 bytes on x64, so those writes land 16 bytes before the array. Depending on build layout, the entry's .life/.alive fields end up overwriting `D_80379E20`'s low bytes. `AnimTextureListCache_update` then walks arbitrary memory, reads `frame_cnt` as 0, and its wrap loop never terminates, which is where the game-tick thread stall comes from.

Should resolve #405, I was unable to reproduce with numerous attempts, yet my local build is not the github runner.