### PR TITLE
Fix unbalanced ImGui::EndPopup in the modal window

### DIFF
--- a/src/port/UI/LighthouseModals.cpp
+++ b/src/port/UI/LighthouseModals.cpp
@@ -74,8 +74,8 @@ void LighthouseModalWindow::DrawElement() {
                 }
                 UIWidgets::PopStyleButton();
             }
+            ImGui::EndPopup();
         }
-        ImGui::EndPopup();
     }
 }
 


### PR DESCRIPTION
ImGui::EndPopup() is only legal when the matching BeginPopupModal() call returned true. DrawElement() called it unconditionally, one level outside the "if (ImGui::BeginPopupModal(...))" block, so it also ran on frames where the popup was not open.

That state is trivially reachable. The closePopup branch above calls ImGui::CloseCurrentPopup() and erases the modal from the queue, so on the very next frame BeginPopupModal() returns false, and the old code still called EndPopup(). This pops a window that was never pushed, corrupting ImGui's internal window and ID stacks for the rest of the frame.

Debug builds of ImGui assert on this, and the path is reachable on every platform every single time a modal is dismissed. Moving EndPopup() inside the block keeps the Begin/End pair balanced.

---

AI assistance was used in preparing this change; the diff and its reasoning were
reviewed and verified by hand before submission.