### PR TITLE
Real Fast Transform

### DIFF
--- a/src/core2/ba/batimer.c
+++ b/src/core2/ba/batimer.c
@@ -21,7 +21,9 @@ bool batimer_decrement(s32 id){
     if(0.0f == s_batimer.value[id]){
         return false;
     }
-    s_batimer.value[id] = ml_max_f(0.0f, s_batimer.value[id] - time_getDelta());
+    int mult = 1;
+    CALL_EVENT(SetAnimSpeedMult, &mult, id);
+    s_batimer.value[id] = ml_max_f(0.0f, s_batimer.value[id] - (time_getDelta() * mult));
     return s_batimer.value[id] == 0.0f;
 }
 

--- a/src/core2/mumbo.c
+++ b/src/core2/mumbo.c
@@ -220,6 +220,7 @@ void chMumbo_func_802D1B8C(Actor *this, enum transformation_e transform_id) {
 }
 
 void chMumbo_update(Actor *this) {
+    CALL_EVENT(OnActorUpdate, this);
     s32 face_buttons[6];
     f32 sp4C[3];
     bool sp48;
@@ -280,9 +281,9 @@ void chMumbo_update(Actor *this) {
 
         case 2: //L802D1F90
             if (actor_animationIsAt(this, 0.25f) != 0) {
-            sfxsource_playHighPriority(0x41);
-        }
-        actor_playAnimationOnce(this);
+                sfxsource_playHighPriority(0x41);
+            }
+            actor_playAnimationOnce(this);
             if (actor_animationIsAt(this, 0.999f)) {
                 if( !fileProgressFlag_get(FILEPROG_11_HAS_MET_MUMBO) 
                     && !volatileFlag_get(VOLATILE_FLAG_1) 
@@ -375,10 +376,6 @@ void chMumbo_update(Actor *this) {
             break;
 
         case 5: //L802D2488
-            // [port] Fast Transformation drives this state from Cheats.cpp instead.
-            if (!EventSystem_Should(VB_MUMBO_HUT_TRANSFORM_CUTSCENE, true, this)) {
-                break;
-            }
             actor_playAnimationOnce(this);
             if (actor_animationIsAt(this, 0.35f)){
                 sfxSource_func_8030E2C4(this->unk44_31);

--- a/src/port/Enhancements/Cheats/Cheats.cpp
+++ b/src/port/Enhancements/Cheats/Cheats.cpp
@@ -247,82 +247,26 @@ void RegisterCycleTransform_Init() {
     });
 }
 
-// Copies of chMumbo_update state 5's 0.01 and 0.999 beats minus the audio; keep in step with it.
-extern "C" {
-void chMumbo_func_802D1B8C(Actor* actor, enum transformation_e transform_id);
-extern u8 D_8037DDF0; // the transformation this hut offers
-}
-
-static bool sMumboFastXformStarted = false;
-
-static bool FastTransform_startHutTransform(Actor* actor) {
-    if (actor->has_met_before || (actor->unk10_12 == 0 && (s32)player_getTransformation() != TRANSFORM_1_BANJO &&
-                                  (s32)player_getTransformation() != romhack_mumboWishwashyId())) {
-        return romhack_mumboTransform(TRANSFORM_1_BANJO);
-    }
-    if (romhack_mumboTransform(D_8037DDF0)) {
-        if (D_8037DDF0 != romhack_mumboWishwashyId()) {
-            enum file_progress_e paidFlag =
-                (enum file_progress_e)((D_8037DDF0 - TRANSFORM_2_TERMITE) + FILEPROG_90_PAID_TERMITE_COST);
-            if (fileProgressFlag_getAndSet(paidFlag, true)) {
-                actor->velocity[0] = 1.0f;
-            }
-            actor->unk38_31 = 0;
-        }
-        if (actor->unk10_12 == 1) {
-            actor->unk10_12 = 0;
-        }
-        return true;
-    }
-    return false;
-}
-
-// No has_met_before branch: those sequences are left to vanilla below.
-static void FastTransform_endHutTransform(Actor* actor) {
-    func_8028F918(0); // pops the look-at lock state 4 pushed
-    if ((s32)player_getTransformation() != TRANSFORM_1_BANJO) {
-        subaddie_set_state(actor, 3);
-        chMumbo_func_802D1B8C(actor, (enum transformation_e)D_8037DDF0);
-        return;
-    }
-    gcpausemenu_80314AC8(1);
-    subaddie_set_state(actor, 4);
-}
-
-// Fast Transformation — speeds up Mumbo transformation animation by 3x
 void RegisterFastTransform_Init() {
-    COND_HOOK(GameFrameUpdate, EVENT_PRIORITY_NORMAL, CVarGetInteger(CVAR_FAST_TRANSFORM, 0), [](IEvent* event) {
-        // Check if currently transforming
+    COND_HOOK(SetAnimSpeedMult, EVENT_PRIORITY_NORMAL, CVarGetInteger(CVAR_FAST_TRANSFORM, 0), [](IEvent* event) {
         if (baflag_isTrue(BA_FLAG_1B_TRANSFORMING)) {
-            // Speed up the transformation timer (timer 0 controls animation progress)
-            f32 remaining = batimer_get(0);
-            if (remaining > 0.0f) {
-                // Reduce timer by 2x remaining time per frame (3x total speed)
-                batimer_incrementBy(0, -remaining * 2.0f);
+            SetAnimSpeedMult* ev = reinterpret_cast<SetAnimSpeedMult*>(event);
+            if (ev->id == 0) {
+                *ev->mult *= 8;
             }
         }
     });
 
-    // Hut transforms ignore that timer; Mumbo's state 5 paces off his own 7.5s animation instead.
-    COND_VB_SHOULD(VB_MUMBO_HUT_TRANSFORM_CUTSCENE, EVENT_PRIORITY_NORMAL, CVarGetInteger(CVAR_FAST_TRANSFORM, 0), {
-        Actor* actor = va_arg(args, Actor*);
-        // T-Rex/mistake gags end in a dialog wired to a callback private to mumbo.c.
-        if (actor != nullptr && !actor->has_met_before) {
-            // Only latch once the spell has been accepted. Gags don't count as valid.
-            if (!sMumboFastXformStarted) {
-                sMumboFastXformStarted = FastTransform_startHutTransform(actor);
-            } else if (!baflag_isTrue(BA_FLAG_1B_TRANSFORMING)) {
-                // Safe to read as "the transformation ended" only because of the latch above.
-                sMumboFastXformStarted = false;
-                FastTransform_endHutTransform(actor);
-            }
-            *should = false;
+    COND_HOOK(OnActorUpdate, EVENT_PRIORITY_NORMAL, CVarGetInteger(CVAR_FAST_TRANSFORM, 0), [](IEvent* event) {
+        OnActorUpdate* ev = reinterpret_cast<OnActorUpdate*>(event);
+        if (ev->actor->actor_info->actorId != ACTOR_7_MUMBO) {
+            return;
+        }
+
+        if (ev->actor->state == 4 || ev->actor->state == 5) {
+            anctrl_setDuration(ev->actor->anctrl, 7.5f / 8.0f);
         }
     });
-
-    // A map torn down mid-transform would leave the next one thinking it had already run.
-    COND_HOOK(OnMapLoad, EVENT_PRIORITY_NORMAL, CVarGetInteger(CVAR_FAST_TRANSFORM, 0),
-              [](IEvent* event) { sMumboFastXformStarted = false; });
 }
 
 // ============================================================================

--- a/src/port/Enhancements/Events/Hooks/Events.h
+++ b/src/port/Enhancements/Events/Hooks/Events.h
@@ -47,7 +47,6 @@ typedef enum VBehaviorID {
     // Gameplay options and cheats
     VB_DISABLE_SNACKER,
     VB_SAVE_AND_EXIT,
-    VB_MUMBO_HUT_TRANSFORM_CUTSCENE,
     VB_MUMBO_DETRANSFORM,
 
     // Rando object behavior

--- a/src/port/Enhancements/Events/Hooks/List/GameEvent.h
+++ b/src/port/Enhancements/Events/Hooks/List/GameEvent.h
@@ -2,6 +2,8 @@
 
 #include <libultraship/bridge/eventsbridge.h>
 
+DEFINE_EVENT(SetAnimSpeedMult, int32_t* mult; int32_t id;)
+DEFINE_EVENT(OnActorUpdate, Actor* actor;)
 DEFINE_EVENT(OnActorDestroy, Actor* actor;)
 DEFINE_EVENT(OnPlayerDeath)
 DEFINE_EVENT(OnGameFileErase, int32_t gamenum;)

--- a/src/port/Enhancements/Events/PortEnhancements.cpp
+++ b/src/port/Enhancements/Events/PortEnhancements.cpp
@@ -99,8 +99,9 @@ void PortEnhancements_Register() {
     REGISTER_EVENT(EggHeadSpawn);
     REGISTER_EVENT(OnActorDestroy);
     REGISTER_EVENT(OnCheckSpiralMountainAbilities);
-
     REGISTER_EVENT(OnReset);
+    REGISTER_EVENT(SetAnimSpeedMult);
+    REGISTER_EVENT(OnActorUpdate);
 
     // Register rando events
     REGISTER_EVENT(InitRandoEvents);


### PR DESCRIPTION
The previous fast transform was intended to be a 3x speed increase, but what it was actually doing was instantly finishing the animation. This fixes that by properly multiplying `timeDelta()` in the animation update rather than trying to manually decrement the timer.

The attempt to make Mumbo account for this speed failed because it always assumed a transformation was successful, and while WishyWashy was a *completed* transformation, successful meant the intended transformation for that level. The attempted fix was not complete. Thanks to @garrettjoecox I was able to find out that setting the animation timer in Mumbo's update speeds up his transformation animation without bypassing any of the animation step code, so this also applies that same speed increase (which is now 8x) to Mumbo's transformation animation duration, speeding it up without skipping it, and allowing all vanilla paths to process, thus eliminating the previous implementation's double charge for WishyWashy failures.