### PR TITLE
Fix event priority mismatch in LoadGlobalData.

### DIFF
--- a/src/port/Enhancements/Save/SaveEnhancements.cpp
+++ b/src/port/Enhancements/Save/SaveEnhancements.cpp
@@ -53,7 +53,7 @@ extern "C" void port_syncBottlesBonusIndex(void) {
 }
 
 void RegisterStopNSwop100_Init() {
-    COND_HOOK(OnGameLoad, EVENT_PRIORITY_NORMAL, CVAR_STOPNSWOP, [](IEvent* event) {
+    COND_HOOK(OnGameStart, EVENT_PRIORITY_NORMAL, CVAR_STOPNSWOP, [](IEvent* event) {
         if (jiggyscore_total() == 100 && fileProgressFlag_get(FILEPROG_FC_DEFEAT_GRUNTY)) {
             for (int i = 1; i < SNS_ITEM_length; i++) {
                 sns_set_item_state(i, SNS_UNLOCKED, true);

--- a/src/port/Save/SaveManager.cpp
+++ b/src/port/Save/SaveManager.cpp
@@ -926,7 +926,7 @@ void SaveManager_Init() {
     // Decomp clears global arrays (e.g. gCompletedBottlesBonusGames) just before
     // gameFile_load fires OnGameLoad. Restore them from global.json here before
     // other OnGameLoad listeners read them.
-    REGISTER_LISTENER(OnGameLoad, EVENT_PRIORITY_HIGH, [](IEvent* event) { LoadGlobalData(); });
+    REGISTER_LISTENER(OnGameLoad, EVENT_PRIORITY_LOW, [](IEvent* event) { LoadGlobalData(); });
 }
 
 static void RegisterPersistBottlesBonus_Init() {


### PR DESCRIPTION
Also fix SNS to use OnGameStart; the event priority mismatch had broken persistent bottles bonus.