### PR TITLE
Fix the audio cushion never refilling after a stall and pole filter

### DIFF
--- a/src/core1/audio_manager.c
+++ b/src/core1/audio_manager.c
@@ -357,7 +357,11 @@ void audioManagerThread_entry(void *arg) {
     s32 skip_handle_done_mesg = 1;
 
     while (true) {
-        osRecvMesg(&audioManager.audioFrameMsgQ, NULL, OS_MESG_BLOCK);
+        // [port] False when the pump owes the playback cushion a catch-up frame, which it takes
+        // without waiting.
+        if (port_audioPumpShouldWait()) {
+            osRecvMesg(&audioManager.audioFrameMsgQ, NULL, OS_MESG_BLOCK);
+        }
         if (OS_ThreadShouldExit()) { // [port] cooperative shutdown
             return;
         }
@@ -375,14 +379,6 @@ void audioManagerThread_entry(void *arg) {
             } else {
                 skip_handle_done_mesg--;
             }
-        }
-        // [port] The N64 pacing is open-loop (pump cadence x frame size vs the
-        // DAC, same crystal), so a pump missed on PC drains the playback
-        // cushion for tens of seconds. Self-post one extra frame at a time,
-        // re-deciding on the fresh buffer level after each push, until the
-        // cushion is rebuilt.
-        if (port_audioCatchupFrames() > 0) {
-            osSendMesgPtr(&audioManager.audioFrameMsgQ, NULL, OS_MESG_NOBLOCK);
         }
     }
 }

--- a/src/port/Audio/mixer.c
+++ b/src/port/Audio/mixer.c
@@ -112,6 +112,16 @@ static inline int32_t clamp32(int64_t v) {
     return (int32_t)v;
 }
 
+static uint16_t naudio_dmem_addr(uint8_t dmem_shift) {
+    static const uint16_t kNAudioBuffers[] = { 0, 368, 736, 1248, 1616, 1984, 2352 };
+    for (unsigned i = 0; i < sizeof(kNAudioBuffers) / sizeof(kNAudioBuffers[0]); i++) {
+        if ((kNAudioBuffers[i] >> 8) == dmem_shift) {
+            return kNAudioBuffers[i];
+        }
+    }
+    return (uint16_t)(dmem_shift << 8);
+}
+
 void aClearBufferImpl(uint16_t addr, int nbytes) {
     nbytes = ROUND_UP_16(nbytes);
     memset(BUF_U8(addr), 0, nbytes);
@@ -356,7 +366,9 @@ void aResampleImpl(uint8_t flags, uint16_t pitch, RESAMPLE_STATE state, uint16_t
     int16_t tmp[16];
     int16_t* in_initial = BUF_S16(inofs);
     int16_t* in = in_initial;
-    int16_t* out = BUF_S16(OFS_BASE + ((outflag & 3) != 0) * NUM_BYTES);
+    // [port] outflag is a packed buffer address, not a flag. Reading it as one was right only
+    // because the resampler is never pointed past N_AL_TEMP_1.
+    int16_t* out = BUF_S16(naudio_dmem_addr(outflag));
     int nbytes = ROUND_UP_16(NUM_BYTES);
     uint32_t pitch_accumulator;
     int i;
@@ -699,14 +711,9 @@ void aSetVolumeImpl(uint8_t flags, int16_t v, int16_t t, int16_t r) {
 
 // Lighthouse-custom
 void aPoleFilterImpl(uint8_t flags, uint16_t gain, uint8_t dmem_shift, void* state) {
-    // dmem_shift is the buffer address >> 8
-    uint16_t dmem_addr = dmem_shift << 8;
+    uint16_t dmem_addr = naudio_dmem_addr(dmem_shift);
     int16_t* buf = BUF_S16(dmem_addr);
     POLEF_STATE* filterState = (POLEF_STATE*)state;
-
-    // Single-pole IIR lowpass: y[n] = (gain * x[n] + coef[8] * y[n-1]) >> 14
-    // gain = fgain (SCALE - timeConstant), coef[8] = timeConstant
-    // SCALE = 16384 = 2^14, so gain + coef[8] = SCALE (unity DC gain)
     int16_t* coef = (int16_t*)rspa.adpcm_table;
 
     int32_t prev;

--- a/src/port/OS/OS_AI.cpp
+++ b/src/port/OS/OS_AI.cpp
@@ -10,6 +10,7 @@
 #include "port/UI/cvar_prefixes.h"
 
 extern "C" {
+#include "port/Patches/Patches.h"
 #include "libultraship/libultra/types.h"
 #include "libultraship/libultra/os.h"
 int32_t AudioPlayerBuffered(void);
@@ -25,17 +26,34 @@ extern "C" u32 osAiGetLength(void) {
     return excess > 0 ? (u32)excess * 4 : 0;
 }
 
-// How many extra synth frames the audio pump should queue this cycle to
-// rebuild the playback cushion.
-extern "C" int32_t port_audioCatchupFrames(void) {
+// Audio pacing
+namespace {
+
+int32_t sCatchupOwed = 0;
+bool sLastFrameWasCatchup = false;
+
+int32_t AudioCatchupFrames() {
     constexpr int32_t kFrameSamples = 736;
-    constexpr int32_t kMaxCatchup = 3;
-    int32_t deficit = AudioPlayerGetDesiredBuffered() - AudioPlayerBuffered();
-    if (deficit < kFrameSamples) {
+    if (sLastFrameWasCatchup) {
         return 0;
     }
-    int32_t frames = deficit / kFrameSamples;
-    return frames > kMaxCatchup ? kMaxCatchup : frames;
+    if (port_audioHeld() || port_audioStallHold()) {
+        return 0;
+    }
+    const int32_t deficit = AudioPlayerGetDesiredBuffered() - AudioPlayerBuffered();
+    return deficit >= kFrameSamples ? 1 : 0;
+}
+
+} // namespace
+
+extern "C" int32_t port_audioPumpShouldWait(void) {
+    if (sCatchupOwed > 0) {
+        sCatchupOwed--;
+        sLastFrameWasCatchup = true;
+        return 0;
+    }
+    sLastFrameWasCatchup = false;
+    return 1;
 }
 
 extern "C" s32 osAiSetNextBuffer(void* buff, size_t len) {
@@ -49,13 +67,16 @@ extern "C" s32 osAiSetNextBuffer(void* buff, size_t len) {
     float masterVol = CVarGetInteger(CVAR_SETTING("Volume.Master"), 40) / 100.0f;
     if (masterVol >= 1.0f) {
         AudioPlayerPlayFrame((const uint8_t*)buff, len);
+        sCatchupOwed = AudioCatchupFrames();
         return 0;
     }
-    std::vector<int16_t> scaled(len / 2);
+    static thread_local std::vector<int16_t> scaled;
+    scaled.resize(len / 2);
     const int16_t* src = (const int16_t*)buff;
     for (size_t i = 0; i < scaled.size(); i++) {
         scaled[i] = (int16_t)(src[i] * masterVol);
     }
     AudioPlayerPlayFrame((const uint8_t*)scaled.data(), len);
+    sCatchupOwed = AudioCatchupFrames();
     return 0;
 }

--- a/src/port/Patches/Patches.h
+++ b/src/port/Patches/Patches.h
@@ -130,7 +130,7 @@ void port_tickDemoAudioHold(void);
 int port_audioHeld(void);
 void port_noteMainLoopAlive(void);
 int port_audioStallHold(void);
-int32_t port_audioCatchupFrames(void);
+int32_t port_audioPumpShouldWait(void);
 
 // One-shot cues when a teammate's file-progress flag arrives
 void port_progressFlag_remoteCue(int32_t progressFlag);


### PR DESCRIPTION
I debugged and logged, but I still can't reproduce the static and stutter other people have reported. This is my *attempt* at fixing the reported issue, and it may or may not work, as it's based on numbers analysis. The artifacts produced with this pull request should be tested by the affected parties.