### PR TITLE
Add BK_LOG_DEBUG, demote spawnqueue logs, null-guard bundle spawns

### DIFF
--- a/src/core2/actor_array.c
+++ b/src/core2/actor_array.c
@@ -2365,7 +2365,9 @@ void func_8032B5C0(ActorMarker *arg0, ActorMarker *arg1, CollisionParams *arg2) 
 
     this = marker_getActor(arg0);
     sp70 = collision_getDropBundleNum(arg2);
-    sp6C = collision_getUnkBit7(arg2);
+// [port] unkBit7 is 3 bits wide, but each bundle group holds only 5 spread variants
+//  sp6C = collision_getUnkBit7(arg2);
+    sp6C = MIN(collision_getUnkBit7(arg2), 5);
     sp68 = collision_getHitsToTrigger(arg2);
     sp64 = collision_getNextState(arg2);
     if (((baiFrame_getState() != 3) && func_8028F1E0()) || (collision_getDamageToPlayer(arg2) == 0)) {

--- a/src/core2/bundle.c
+++ b/src/core2/bundle.c
@@ -1,5 +1,6 @@
 // BanjoDecomp: core2/code_41FB0.c
 #include "functions.h"
+#include "port/ShipUtils.h"
 #include "variables.h"
 #include <ultra64.h>
 
@@ -148,6 +149,12 @@ Actor *__bundle_spawnWithFirstActor(enum bundle_e bundle_id, f32 position[3], Ac
         if (!EventSystem_Should(VB_OVERRIDE_BUNDLE_SPAWN, false, bundle_id, bundle_info, i, position, &actor)) {
             actor = (i == 0 && firstActor) ? firstActor : actor_spawnWithYaw_f32(bundle_info->actor_id, position, 0);
             //}
+            // [port] Suppressed spawn: a cancelled OnActorSpawn returns the listener's actor,
+            // which is NULL when the rando replaced this check with an object that already exists.
+            if (actor == NULL) {
+                BK_LOG_WARN("bundle %d: spawn of actor 0x%X suppressed", bundle_id, bundle_info->actor_id);
+                continue;
+            }
             actor->is_bundle = true;
 
             bundle = (Bundle*)&actor->unkBC;

--- a/src/core2/ch/icecube.c
+++ b/src/core2/ch/icecube.c
@@ -201,8 +201,11 @@ void __chicecube_spawnHalfCubes(ActorMarker *marker){
     for(i = 0; i < 2; i++){//L8035A7FC
         bundle_setYaw((i & 1)? actor->yaw : actor->yaw + 180.0f);
         other = bundle_spawn_f32(BUNDLE_21__ICECUBE_B, sp54);
-        other->actorTypeSpecificField = 1; //don't spawn more
-        other->scale = randf2(0.5f, 0.6f)*actor->scale;
+        // [port] Suppressed spawn: bundle_spawn_f32 is nullable
+        if (other != NULL) {
+            other->actorTypeSpecificField = 1; //don't spawn more
+            other->scale = randf2(0.5f, 0.6f)*actor->scale;
+        }
         actor->yaw = randi2(0, 359);
     }
     if(marker);

--- a/src/core2/spawnqueue.c
+++ b/src/core2/spawnqueue.c
@@ -522,7 +522,7 @@ void __spawnQueue_add_0(GenFunction_0 arg0){
         spawnQueue[spawnQueueLength].arg_cnt = 0;
         spawnQueueLength++;
     } else {
-        BK_LOG_WARN("spawnQueue FULL (%d entries) — dropped add_0 entry", tmp);
+        BK_LOG_DEBUG("spawnQueue FULL (%d entries): dropped add_0 entry", tmp);
     }
 }
 
@@ -534,7 +534,7 @@ void __spawnQueue_add_1(GenFunction_1 arg0, uintptr_t arg1){
         spawnQueue[spawnQueueLength].arg_cnt = 1;
         spawnQueueLength++;
     } else {
-        BK_LOG_WARN("spawnQueue FULL (%d entries) — dropped add_1 entry", tmp);
+        BK_LOG_DEBUG("spawnQueue FULL (%d entries): dropped add_1 entry", tmp);
     }
 }
 
@@ -547,7 +547,7 @@ void __spawnQueue_add_2(GenFunction_2 arg0, uintptr_t arg1, uintptr_t arg2){
         spawnQueue[spawnQueueLength].arg_cnt = 2;
         spawnQueueLength++;
     } else {
-        BK_LOG_WARN("spawnQueue FULL (%d entries) — dropped add_2 entry", tmp);
+        BK_LOG_DEBUG("spawnQueue FULL (%d entries): dropped add_2 entry", tmp);
     }
 }
 
@@ -561,7 +561,7 @@ void __spawnQueue_add_3(GenFunction_3 arg0, uintptr_t arg1, uintptr_t arg2, uint
         spawnQueue[spawnQueueLength].arg_cnt = 3;
         spawnQueueLength++;
     } else {
-        BK_LOG_WARN("spawnQueue FULL (%d entries) — dropped add_3 entry", tmp);
+        BK_LOG_DEBUG("spawnQueue FULL (%d entries): dropped add_3 entry", tmp);
     }
 }
 
@@ -576,7 +576,7 @@ void __spawnQueue_add_4(GenFunction_4 arg0, uintptr_t arg1, uintptr_t arg2, uint
         spawnQueue[spawnQueueLength].arg_cnt = 4;
         spawnQueueLength++;
     } else {
-        BK_LOG_WARN("spawnQueue FULL (%d entries) — dropped add_4 entry", tmp);
+        BK_LOG_DEBUG("spawnQueue FULL (%d entries): dropped add_4 entry", tmp);
     }
 }
 
@@ -592,7 +592,7 @@ void __spawnQueue_add_5(GenFunction_5 arg0, uintptr_t arg1, uintptr_t arg2, uint
         spawnQueue[spawnQueueLength].arg_cnt = 5;
         spawnQueueLength++;
     } else {
-        BK_LOG_WARN("spawnQueue FULL (%d entries) — dropped add_5 entry", tmp);
+        BK_LOG_DEBUG("spawnQueue FULL (%d entries): dropped add_5 entry", tmp);
     }
 }
 

--- a/src/port/ShipUtils.cpp
+++ b/src/port/ShipUtils.cpp
@@ -106,6 +106,13 @@ int port_checkHeap(const char* label) {
 }
 
 // Wrappers to use SPDLOG from C code
+void BK_LOG_DEBUG(const char* fmt, ...) {
+    va_list args;
+    va_start(args, fmt);
+    bk_log_vfmt(spdlog::level::debug, fmt, args);
+    va_end(args);
+}
+
 void BK_LOG_INFO(const char* fmt, ...) {
     va_list args;
     va_start(args, fmt);

--- a/src/port/ShipUtils.h
+++ b/src/port/ShipUtils.h
@@ -35,6 +35,7 @@ u32 port_jiggyscore_isCollectedRaw(enum jiggy_e jiggy_id);
 bool port_honeycombscore_getRaw(enum honeycomb_e indx);
 
 // SPDLOG level wrappers callable from C
+void BK_LOG_DEBUG(const char* fmt, ...);
 void BK_LOG_INFO(const char* fmt, ...);
 void BK_LOG_WARN(const char* fmt, ...);
 void BK_LOG_ERROR(const char* fmt, ...);


### PR DESCRIPTION
Resolves the #486 crash point, but may be done differently in Rando v2. Tagging @aMannus for approval or refitting.