### PR TITLE
Rework widescreen camera and actor handling

### DIFF
--- a/include/functions.h
+++ b/include/functions.h
@@ -1821,6 +1821,7 @@ bool code33310_func_802BA4F0(ZoomCameraNode *self);
 s32 code33250_func_802BA234(RandomCameraNode *self);
 
 // --- core2/nc/cameranodelist.c ---
+s32 __ncCameraNodeList_capacity();
 s32 ncCameraNodeList_getNodeType(int camera_node_index);
 s32 ncCameraNodeList_nodeIsValid(int camera_node_index);
 void ncCameraNodeList_defrag();

--- a/src/core1/viewport.c
+++ b/src/core1/viewport.c
@@ -194,8 +194,6 @@ void viewport_setPosition_f3(f32 x, f32 y, f32 z) {
 
 void viewport_setRotation_vec3f(f32 src[3]) {
     ml_vec3f_copy(sViewportRotation, src);
-    // [port] Nudge static-camera yaw on configured maps when in widescreen.
-    port_camera_applyWsYawFix(sViewportRotation);
 }
 
 void viewport_setRotation_f3(f32 pitch, f32 yaw, f32 roll) {

--- a/src/core2/fx/cutscene_actors.c
+++ b/src/core2/fx/cutscene_actors.c
@@ -91,6 +91,9 @@ Actor *func_802E0738(ActorMarker *marker, Gfx **gfx, Mtx **mtx, Vtx **vtx){
     Actor *this;
 
     this = marker_getActorAndRotation(marker, rotation);
+    if (!EventSystem_Should(VB_CUTSCENE_ACTOR_DRAW, true, this)) {
+        return this;
+    }
     modelRender_setPreDrawCallback( (model_render_pre_draw_callback_f)func_802E0710, (void *)this);
     modelRender_setPostDrawCallback((model_render_post_draw_callback_f)actor_postdrawMethod, (void *)marker);
     modelRender_draw(gfx, mtx, this->position, rotation, this->scale, NULL, marker_loadModelBin(marker));

--- a/src/core2/gc/transition.c
+++ b/src/core2/gc/transition.c
@@ -294,7 +294,8 @@ void gctransition_draw(Gfx **gfx, Mtx **mtx, Vtx **vtx) {
 
     //complex animation (from animation bin file)
     if(s_current_transition.state == 1 || s_current_transition.state == 6){
-        modelRender_draw(gfx, mtx, sp58, vp_rotation, 1.0f, 0, s_current_transition.model_ptr);
+//      modelRender_draw(gfx, mtx, sp58, vp_rotation, 1.0f, 0, s_current_transition.model_ptr);
+        modelRender_draw(gfx, mtx, sp58, vp_rotation, transitionScale, 0, s_current_transition.model_ptr);
         if(s_current_transition.anctrl != NULL){
             gDPSetTextureFilter((*gfx)++, G_TF_BILERP);
             gDPSetColorDither((*gfx)++, G_CD_MAGICSQ);
@@ -314,7 +315,8 @@ void gctransition_draw(Gfx **gfx, Mtx **mtx, Vtx **vtx) {
             vp_rotation[2] = s_current_transition.rotation - 90.0f*percentage;
             scale = percentage*s_current_transition.transistion_info->scale + 0.1;
         }
-        modelRender_draw(gfx, mtx, sp58, vp_rotation, scale, 0, s_current_transition.model_ptr);
+//      modelRender_draw(gfx, mtx, sp58, vp_rotation, scale, 0, s_current_transition.model_ptr);
+        modelRender_draw(gfx, mtx, sp58, vp_rotation, scale * transitionScale, 0, s_current_transition.model_ptr);
     }
     else if(s_current_transition.state == TRANSITION_STATE_5_FADE_OUT){//L8030B9EC
         switch (s_current_transition.transistion_info->uid)
@@ -335,7 +337,8 @@ void gctransition_draw(Gfx **gfx, Mtx **mtx, Vtx **vtx) {
                 break;
         }
         if(!(s_current_transition.substate < 3) || s_current_transition.transistion_info->uid != 0x11){
-            modelRender_draw(gfx, mtx, sp58, vp_rotation, scale, 0, s_current_transition.model_ptr);
+//          modelRender_draw(gfx, mtx, sp58, vp_rotation, scale, 0, s_current_transition.model_ptr);
+            modelRender_draw(gfx, mtx, sp58, vp_rotation, scale * transitionScale, 0, s_current_transition.model_ptr);
         }
         else{
             modelRender_reset();

--- a/src/core2/map/mapModel.c
+++ b/src/core2/map/mapModel.c
@@ -374,6 +374,7 @@ void mapModel_opa_draw(Gfx **gfx, Mtx **mtx, Vtx **vtx) {
 
 void mapModel_xlu_draw(Gfx **gfx, Mtx **mtx, Vtx **vtx) {
     s32 temp_a0;
+    f32 scale; // [port]
 
     if (mapModel.model_bin_xlu != NULL) {
         if (gsworld_getMap() == MAP_1D_MMM_CELLAR) {
@@ -385,7 +386,10 @@ void mapModel_xlu_draw(Gfx **gfx, Mtx **mtx, Vtx **vtx) {
             modelRender_setAnimatedTexturesCacheId(temp_a0);
         }
         modelRender_setEnvColor(mapModel.env_red, mapModel.env_green, mapModel.env_blue, 0xFF);
-        modelRender_draw(gfx, mtx, NULL, NULL, mapModel.description->scale, NULL, mapModel.model_bin_xlu);
+//      modelRender_draw(gfx, mtx, NULL, NULL, mapModel.description->scale, NULL, mapModel.model_bin_xlu);
+        scale = mapModel.description->scale;
+        CALL_EVENT(MapModelXluScale, gsworld_getMap(), &scale);
+        modelRender_draw(gfx, mtx, NULL, NULL, scale, NULL, mapModel.model_bin_xlu);
         func_802F7BC0(gfx, mtx, vtx);
     }
 }

--- a/src/core2/nc/staticCamera.c
+++ b/src/core2/nc/staticCamera.c
@@ -44,19 +44,16 @@ void __ncStaticCamera_setToNode(s32 camera_node_index){
     sp1C = ncCameraNodeList_getStaticCameraNode(camera_node_index);
     cameraNodeType2_getPosition(sp1C, ncStaticCameraPosition);
     cameraNodeType2_getPitchYawRoll(sp1C, ncStaticCameraRotation);
+    CALL_EVENT(CameraRotationAuthored, CAMERA_TYPE_3_STATIC, camera_node_index, ncStaticCameraPosition, ncStaticCameraRotation);
 }
 
 void ncStaticCamera_setToNode(s32 camera_node_index){
-    if (EventSystem_Should(VB_STATIC_CAMERA_SET, true, &camera_node_index)) {
-        camera_setType(CAMERA_TYPE_3_STATIC);
-        __ncStaticCamera_setToNode(camera_node_index);
-    }
+    camera_setType(CAMERA_TYPE_3_STATIC);
+    __ncStaticCamera_setToNode(camera_node_index);
 }
 
 void ncStaticCamera_exit(void){
-    if (EventSystem_Should(VB_STATIC_CAMERA_EXIT, true)) {
-        camera_setType(CAMERA_TYPE_2_DYNAMIC);
-    }
+    camera_setType(CAMERA_TYPE_2_DYNAMIC);
 }
 
 void ncStaticCamera_setPositionAndRotation(f32 arg0[3], f32 arg1[3]){

--- a/src/cutscenes/cutscene_trigger.c
+++ b/src/cutscenes/cutscene_trigger.c
@@ -94,6 +94,7 @@ void func_802CDAC4(Actor *this){
     sp1C[0] = this->pitch;
     sp1C[1] = this->yaw;
     sp1C[2] = 0.0f;
+    CALL_EVENT(CameraRotationAuthored, CAMERA_TYPE_1_UNKNOWN, this->actorTypeSpecificField, this->position, sp1C);
     viewport_setRotation_vec3f(sp1C);
 }
 

--- a/src/port/Enhancements/Events/Hooks/Events.h
+++ b/src/port/Enhancements/Events/Hooks/Events.h
@@ -16,8 +16,7 @@ typedef enum VBehaviorID {
     VB_ZOOMBOX_TEXT_ADJUST, // text scale (shrink pause text) + X nudge (JP kana clearance)
 
     // Camera behavior
-    VB_STATIC_CAMERA_SET,
-    VB_STATIC_CAMERA_EXIT,
+    VB_CUTSCENE_ACTOR_DRAW,
     VB_CAMERA_LIVE_ASPECT,
     VB_CAMERA_FOLLOW,
     VB_CAMERA_APPLY_SHAKE,

--- a/src/port/Enhancements/Events/Hooks/List/EngineEvent.h
+++ b/src/port/Enhancements/Events/Hooks/List/EngineEvent.h
@@ -31,6 +31,8 @@ typedef struct {
 DEFINE_EVENT(OnModelDisplayListLoad, const char* path; u32 * dlWords; u32 dlWordCount; const ModelTexSize* texSizes;
              u16 texCount;);
 DEFINE_EVENT(ViewportFrustumUpdate, float* frustumX; float* frustumY;);
+DEFINE_EVENT(CameraRotationAuthored, s32 source; s32 id; const f32* position; f32 * rotation;);
+DEFINE_EVENT(MapModelXluScale, s32 map; f32 * scale;);
 DEFINE_EVENT(OnTransitionModelScale, Gfx** gfx; Mtx * *mtx; s32 uid; f32 * scale;);
 DEFINE_EVENT(OnTransitionStateUpdate, s32 modelId; s32 uid; s32 substate;);
 DEFINE_EVENT(DrawDistanceCubeWidth, int32_t mapWidth; int32_t * width;);

--- a/src/port/Enhancements/Events/PortEnhancements.cpp
+++ b/src/port/Enhancements/Events/PortEnhancements.cpp
@@ -26,6 +26,8 @@ void PortEnhancements_Register() {
     REGISTER_EVENT(OnModelLoad);
     REGISTER_EVENT(OnModelDisplayListLoad);
     REGISTER_EVENT(ViewportFrustumUpdate);
+    REGISTER_EVENT(CameraRotationAuthored);
+    REGISTER_EVENT(MapModelXluScale);
     REGISTER_EVENT(OnTransitionModelScale);
     REGISTER_EVENT(OnTransitionStateUpdate);
     REGISTER_EVENT(DrawDistanceCubeWidth);

--- a/src/port/Patches/ActorSpecificPatches.cpp
+++ b/src/port/Patches/ActorSpecificPatches.cpp
@@ -1,0 +1,123 @@
+#include <libultraship/libultraship.h>
+#include <libultraship/bridge/consolevariablebridge.h>
+
+#include "port/Engine.h"
+#include "port/Patches/Patches.h"
+#include "port/UI/cvar_prefixes.h"
+#include "port/Enhancements/Events/Hooks/Events.h"
+#include "port/ShipInit.hpp"
+#include "port/ShipUtils.h"
+
+#include <map>
+
+#include "enums.h"
+#include "functions.h"
+#include "variables.h"
+#include "actor.h"
+
+#define CVAR_WS_CAMERA_FIX CVAR_ENHANCEMENT("Fix.WidescreenCamera")
+
+struct WsXluScaleFix {
+    int32_t map;
+    float scale;
+};
+
+struct HiddenCutsceneActor {
+    int32_t map;
+    int32_t modelId;
+    float delay = 0.0f;
+};
+
+struct SpawnAnchor {
+    float position[3];
+    float elapsed;
+    bool moved;
+};
+
+static const WsXluScaleFix sWsXluScaleFixes[] = {
+    { .map = MAP_1F_CS_START_RAREWARE, .scale = 1.1f },
+};
+static const HiddenCutsceneActor sHiddenCutsceneActors[] = {
+    { .map = MAP_1F_CS_START_RAREWARE, .modelId = ASSET_3ED_MODEL_BUZZBOMB },
+    { .map = MAP_1E_CS_START_NINTENDO, .modelId = ASSET_353_MODEL_BIGBUTT, .delay = 0.2f },
+    { .map = MAP_1E_CS_START_NINTENDO, .modelId = ASSET_354_MODEL_SMALL_BULL, .delay = 0.7f },
+    { .map = MAP_1E_CS_START_NINTENDO, .modelId = ASSET_369_MODEL_CONCERT_FROG, .delay = 0.2f },
+};
+static constexpr int HIDDEN_CUTSCENE_ACTOR_COUNT =
+    sizeof(sHiddenCutsceneActors) / sizeof(sHiddenCutsceneActors[0]);
+static constexpr float kHiddenMoveThreshold = 1.0f;
+static std::map<ActorMarker*, SpawnAnchor> sSpawnAnchors;
+static constexpr int WS_XLU_SCALE_FIX_COUNT = sizeof(sWsXluScaleFixes) / sizeof(sWsXluScaleFixes[0]);
+
+void RegisterWidescreenXluScale() {
+    COND_HOOK(MapModelXluScale, EVENT_PRIORITY_NORMAL, CVarGetInteger(CVAR_WS_CAMERA_FIX, 1), [](IEvent* event) {
+        float aspectScale = port_wsCameraYawScale();
+        if (aspectScale <= 0.0f) {
+            return;
+        }
+        auto* ev = (MapModelXluScale*)event;
+        for (int i = 0; i < WS_XLU_SCALE_FIX_COUNT; i++) {
+            if (ev->map == sWsXluScaleFixes[i].map) {
+                *ev->scale *= 1.0f + (sWsXluScaleFixes[i].scale - 1.0f) * aspectScale;
+                break;
+            }
+        }
+    });
+}
+
+static const HiddenCutsceneActor* findHiddenCutsceneActor(int32_t map, int32_t modelId) {
+    for (int i = 0; i < HIDDEN_CUTSCENE_ACTOR_COUNT; i++) {
+        if (map == sHiddenCutsceneActors[i].map && modelId == sHiddenCutsceneActors[i].modelId) {
+            return &sHiddenCutsceneActors[i];
+        }
+    }
+    return nullptr;
+}
+
+void RegisterHiddenCutsceneActors() {
+    COND_VB_SHOULD(VB_CUTSCENE_ACTOR_DRAW, EVENT_PRIORITY_NORMAL, CVarGetInteger(CVAR_WS_CAMERA_FIX, 1), {
+        Actor* actor = va_arg(args, Actor*);
+        if (actor == nullptr || actor->marker == nullptr) {
+            return;
+        }
+        const HiddenCutsceneActor* hidden = findHiddenCutsceneActor((int32_t)gsworld_getMap(), actor->marker->modelId);
+        if (hidden == nullptr) {
+            return;
+        }
+
+        auto entry = sSpawnAnchors.find(actor->marker);
+        if (entry == sSpawnAnchors.end()) {
+            SpawnAnchor anchor;
+            for (int i = 0; i < 3; i++) {
+                anchor.position[i] = actor->position[i];
+            }
+            anchor.elapsed = 0.0f;
+            anchor.moved = false;
+            entry = sSpawnAnchors.emplace(actor->marker, anchor).first;
+        }
+        SpawnAnchor& anchor = entry->second;
+
+        if (!anchor.moved) {
+            float dx = actor->position[0] - anchor.position[0];
+            float dy = actor->position[1] - anchor.position[1];
+            float dz = actor->position[2] - anchor.position[2];
+            if ((dx * dx + dy * dy + dz * dz) > (kHiddenMoveThreshold * kHiddenMoveThreshold)) {
+                anchor.moved = true;
+            } else {
+                *should = false;
+                return;
+            }
+        }
+
+        if (anchor.elapsed < hidden->delay) {
+            anchor.elapsed += time_getDelta();
+            *should = false;
+        }
+    });
+
+    COND_HOOK(OnMapLoad, EVENT_PRIORITY_NORMAL, CVarGetInteger(CVAR_WS_CAMERA_FIX, 1),
+              [](IEvent* event) { sSpawnAnchors.clear(); });
+}
+
+static RegisterShipInitFunc widescreenXluScaleInitFunc(RegisterWidescreenXluScale, { CVAR_WS_CAMERA_FIX });
+static RegisterShipInitFunc hiddenCutsceneActorsInitFunc(RegisterHiddenCutsceneActors, { CVAR_WS_CAMERA_FIX });

--- a/src/port/Patches/ActorSpecificPatches.cpp
+++ b/src/port/Patches/ActorSpecificPatches.cpp
@@ -43,8 +43,7 @@ static const HiddenCutsceneActor sHiddenCutsceneActors[] = {
     { .map = MAP_1E_CS_START_NINTENDO, .modelId = ASSET_354_MODEL_SMALL_BULL, .delay = 0.7f },
     { .map = MAP_1E_CS_START_NINTENDO, .modelId = ASSET_369_MODEL_CONCERT_FROG, .delay = 0.2f },
 };
-static constexpr int HIDDEN_CUTSCENE_ACTOR_COUNT =
-    sizeof(sHiddenCutsceneActors) / sizeof(sHiddenCutsceneActors[0]);
+static constexpr int HIDDEN_CUTSCENE_ACTOR_COUNT = sizeof(sHiddenCutsceneActors) / sizeof(sHiddenCutsceneActors[0]);
 static constexpr float kHiddenMoveThreshold = 1.0f;
 static std::map<ActorMarker*, SpawnAnchor> sSpawnAnchors;
 static constexpr int WS_XLU_SCALE_FIX_COUNT = sizeof(sWsXluScaleFixes) / sizeof(sWsXluScaleFixes[0]);

--- a/src/port/Patches/AnimVertexPatches.cpp
+++ b/src/port/Patches/AnimVertexPatches.cpp
@@ -14,8 +14,7 @@ extern "C" {
 namespace {
 
 // A single anim-vertex model runs 500-750 vertices. This covers roughly 20-25
-// of them on screen at once; past that a draw falls back to the shared buffer,
-// which is exactly the behaviour that existed before this file.
+// of them on screen at once; past that a draw falls back to the shared buffer.
 constexpr size_t kVerticesPerSlot = 16384;
 constexpr int kSlots = 2;
 

--- a/src/port/Patches/CameraPatches.cpp
+++ b/src/port/Patches/CameraPatches.cpp
@@ -82,9 +82,9 @@ struct WsCameraFix {
     int32_t source;
     int32_t id = -1;
     bool matchTransform = false;
-    float position[3] = { 0.0f, 0.0f, 0.0f };   // x, y, z
-    float rotation[3] = { 0.0f, 0.0f, 0.0f };   // pitch, yaw, roll
-    float adjust[3] = { 0.0f, 0.0f, 0.0f };     // pitch, yaw, roll
+    float position[3] = { 0.0f, 0.0f, 0.0f }; // x, y, z
+    float rotation[3] = { 0.0f, 0.0f, 0.0f }; // pitch, yaw, roll
+    float adjust[3] = { 0.0f, 0.0f, 0.0f };   // pitch, yaw, roll
 };
 
 // If adding a camera adjustment here, you need the following:
@@ -102,15 +102,9 @@ static const WsCameraFix sWsCameraFixes[] = {
       .rotation = { 0.0f, 83.0f, 0.0f },
       .adjust = { 0.0f, -5.0f, 0.0f } },
     // Eggs molehill
-    { .map = MAP_2_MM_MUMBOS_MOUNTAIN,
-      .source = CAMERA_TYPE_3_STATIC,
-      .id = 0x16,
-      .adjust = { 5.9f, -6.0f, 0.0f } },
+    { .map = MAP_2_MM_MUMBOS_MOUNTAIN, .source = CAMERA_TYPE_3_STATIC, .id = 0x16, .adjust = { 5.9f, -6.0f, 0.0f } },
     // Beak Buster molehill
-    { .map = MAP_2_MM_MUMBOS_MOUNTAIN,
-      .source = CAMERA_TYPE_3_STATIC,
-      .id = 0x17,
-      .adjust = { 0.0f, -6.0f, 0.0f } },
+    { .map = MAP_2_MM_MUMBOS_MOUNTAIN, .source = CAMERA_TYPE_3_STATIC, .id = 0x17, .adjust = { 0.0f, -6.0f, 0.0f } },
 };
 
 static constexpr int WS_CAMERA_FIX_COUNT = sizeof(sWsCameraFixes) / sizeof(sWsCameraFixes[0]);
@@ -209,25 +203,24 @@ void RegisterCutsceneAspect() {
 }
 
 void RegisterWidescreenCamera() {
-    COND_HOOK(CameraRotationAuthored, EVENT_PRIORITY_NORMAL, CVarGetInteger(CVAR_WS_CAMERA_FIX, 1),
-              [](IEvent* event) {
-                  float scale[3];
-                  wsCameraScales(scale);
-                  if (scale[1] <= 0.0f) {
-                      return;
-                  }
-                  auto* ev = (CameraRotationAuthored*)event;
-                  int32_t curMap = (int32_t)gsworld_getMap();
-                  for (int i = 0; i < WS_CAMERA_FIX_COUNT; i++) {
-                      if (wsCameraFixMatches(sWsCameraFixes[i], ev, curMap)) {
-                          for (int axis = 0; axis < 3; axis++) {
-                              ev->rotation[axis] =
-                                  mlNormalizeAngle(ev->rotation[axis] + sWsCameraFixes[i].adjust[axis] * scale[axis]);
-                          }
-                          break;
-                      }
-                  }
-              });
+    COND_HOOK(CameraRotationAuthored, EVENT_PRIORITY_NORMAL, CVarGetInteger(CVAR_WS_CAMERA_FIX, 1), [](IEvent* event) {
+        float scale[3];
+        wsCameraScales(scale);
+        if (scale[1] <= 0.0f) {
+            return;
+        }
+        auto* ev = (CameraRotationAuthored*)event;
+        int32_t curMap = (int32_t)gsworld_getMap();
+        for (int i = 0; i < WS_CAMERA_FIX_COUNT; i++) {
+            if (wsCameraFixMatches(sWsCameraFixes[i], ev, curMap)) {
+                for (int axis = 0; axis < 3; axis++) {
+                    ev->rotation[axis] =
+                        mlNormalizeAngle(ev->rotation[axis] + sWsCameraFixes[i].adjust[axis] * scale[axis]);
+                }
+                break;
+            }
+        }
+    });
 
     COND_HOOK(CameraRotationAuthored, EVENT_PRIORITY_LOW, CVarGetInteger(CVAR_WS_CAMERA_FIX, 1), [](IEvent* event) {
         auto* ev = (CameraRotationAuthored*)event;

--- a/src/port/Patches/CameraPatches.cpp
+++ b/src/port/Patches/CameraPatches.cpp
@@ -1,9 +1,3 @@
-// Camera Patches
-//
-// Cutscene aspect lock and widescreen yaw fixes. The cutscene lock and
-// static camera tracking use the event system; the per-frame yaw fix
-// is as a direct port_* call from viewport_update().
-
 #include <libultraship/libultraship.h>
 #include <libultraship/bridge/consolevariablebridge.h>
 
@@ -28,23 +22,24 @@ extern float sViewportFOVy;
 extern float sViewportAspect;
 }
 
-// Cutscene aspect lock — force 4:3 during cutscene maps
-
 #define CVAR_AR_ENABLED CVAR_PREFIX_ADVANCED_RESOLUTION ".Enabled"
 #define CVAR_AR_COMBO CVAR_PREFIX_ADVANCED_RESOLUTION ".UIComboItem.AspectRatio"
 #define CVAR_AR_X CVAR_PREFIX_ADVANCED_RESOLUTION ".AspectRatioX"
 #define CVAR_AR_Y CVAR_PREFIX_ADVANCED_RESOLUTION ".AspectRatioY"
 #define CVAR_CUTSCENE_ASPECT CVAR_ENHANCEMENT("Graphics.CutsceneAspect")
-
 #define CVAR_CSA_BAK_ACTIVE CVAR_ENHANCEMENT("Graphics.CutsceneAspectBackup.Active")
 #define CVAR_CSA_BAK_ENABLED CVAR_ENHANCEMENT("Graphics.CutsceneAspectBackup.Enabled")
 #define CVAR_CSA_BAK_COMBO CVAR_ENHANCEMENT("Graphics.CutsceneAspectBackup.Combo")
 #define CVAR_CSA_BAK_X CVAR_ENHANCEMENT("Graphics.CutsceneAspectBackup.X")
 #define CVAR_CSA_BAK_Y CVAR_ENHANCEMENT("Graphics.CutsceneAspectBackup.Y")
+#define CVAR_WS_CAMERA_FIX CVAR_ENHANCEMENT("Fix.WidescreenCamera")
+#define CVAR_NO_SCREEN_SHAKE CVAR_SETTING("A11yDisableScreenShake")
 
 static int32_t sCutsceneAspectActive = 0;
+static constexpr float kWsPositionTolerance = 2.0f;
+static constexpr float kWsRotationTolerance = 1.0f;
+static constexpr float kWsReferenceAspect = 16.0f / 9.0f;
 
-// Restore the user's Advanced Resolution settings from the persisted backup and clear the flag.
 static void restoreCutsceneAspectBackup() {
     CVarSetInteger(CVAR_AR_ENABLED, CVarGetInteger(CVAR_CSA_BAK_ENABLED, 0));
     CVarSetInteger(CVAR_AR_COMBO, CVarGetInteger(CVAR_CSA_BAK_COMBO, 3));
@@ -52,13 +47,6 @@ static void restoreCutsceneAspectBackup() {
     CVarSetFloat(CVAR_AR_Y, CVarGetFloat(CVAR_CSA_BAK_Y, 9.0f));
     CVarClear(CVAR_CSA_BAK_ACTIVE);
     sCutsceneAspectActive = 0;
-}
-
-static void ResetCutsceneAspect() {
-    if (!sCutsceneAspectActive) {
-        return;
-    }
-    restoreCutsceneAspectBackup();
 }
 
 static void updateCutsceneAspect(int32_t mapId) {
@@ -85,53 +73,132 @@ static void updateCutsceneAspect(int32_t mapId) {
             sCutsceneAspectActive = 1;
         }
     } else if (!isCutscene && sCutsceneAspectActive) {
-        ResetCutsceneAspect();
+        restoreCutsceneAspectBackup();
     }
 }
 
-// Widescreen yaw fix — per-frame yaw adjustment for certain static cameras in widescreen mode
-
-#define CVAR_WS_CAMERA_FIX CVAR_ENHANCEMENT("Fix.WidescreenCamera")
-#define CVAR_NO_SCREEN_SHAKE CVAR_SETTING("A11yDisableScreenShake")
-
-struct WsYawFix {
+struct WsCameraFix {
     int32_t map;
-    int32_t node;
-    float adjust;
+    int32_t source;
+    int32_t id = -1;
+    bool matchTransform = false;
+    float position[3] = { 0.0f, 0.0f, 0.0f };   // x, y, z
+    float rotation[3] = { 0.0f, 0.0f, 0.0f };   // pitch, yaw, roll
+    float adjust[3] = { 0.0f, 0.0f, 0.0f };     // pitch, yaw, roll
 };
 
-static const WsYawFix sWsYawFixes[] = {
-    { MAP_2_MM_MUMBOS_MOUNTAIN, 0x17, -5.0f },
+// If adding a camera adjustment here, you need the following:
+//   - map: the map the camera is in
+//   - source: the camera type
+//   - matchTransform: true if the camera moves and you need conditional adjustment
+//   - position, rotation: keys for matchTransform
+//   - adjust: self explanatory
+static const WsCameraFix sWsCameraFixes[] = {
+    // Concert, when Banjo looks at Tooty
+    { .map = MAP_1E_CS_START_NINTENDO,
+      .source = CAMERA_TYPE_1_UNKNOWN,
+      .matchTransform = true,
+      .position = { 464.32f, 382.75f, 258.68f },
+      .rotation = { 0.0f, 83.0f, 0.0f },
+      .adjust = { 0.0f, -5.0f, 0.0f } },
+    // Eggs molehill
+    { .map = MAP_2_MM_MUMBOS_MOUNTAIN,
+      .source = CAMERA_TYPE_3_STATIC,
+      .id = 0x16,
+      .adjust = { 5.9f, -6.0f, 0.0f } },
+    // Beak Buster molehill
+    { .map = MAP_2_MM_MUMBOS_MOUNTAIN,
+      .source = CAMERA_TYPE_3_STATIC,
+      .id = 0x17,
+      .adjust = { 0.0f, -6.0f, 0.0f } },
 };
-static constexpr int WS_YAW_FIX_COUNT = sizeof(sWsYawFixes) / sizeof(sWsYawFixes[0]);
 
-static int32_t sLastStaticCameraNode = -1;
+static constexpr int WS_CAMERA_FIX_COUNT = sizeof(sWsCameraFixes) / sizeof(sWsCameraFixes[0]);
 
-extern "C" void port_camera_applyWsYawFix(float rotation[3]) {
-    if (!CVarGetInteger(CVAR_WS_CAMERA_FIX, 1))
-        return;
-    if (WS_YAW_FIX_COUNT == 0 || sLastStaticCameraNode < 0) {
-        return;
+struct WsAuthoredCamera {
+    bool valid;
+    int32_t map;
+    int32_t source;
+    int32_t id;
+    float position[3];
+    float rotation[3];
+};
+
+static WsAuthoredCamera sWsAuthored;
+static float sWsLastAspect;
+
+extern "C" float port_wsCameraYawScale(void) {
+    float fovY = sViewportFOVy > 0.0f ? sViewportFOVy : 40.0f;
+    float tanHalfFovY = std::tan((fovY * 0.5f) * (float)(M_PI / 180.0));
+    float base = std::atan(tanHalfFovY * sViewportAspect);
+    float reference = std::atan(tanHalfFovY * kWsReferenceAspect) - base;
+    if (reference <= 0.0f) {
+        return 1.0f;
     }
-    if (GameEngine_GetAspectRatio() <= 1.34f) {
-        return;
+    float extra = std::atan(tanHalfFovY * GameEngine_GetAspectRatio()) - base;
+    return extra > 0.0f ? extra / reference : 0.0f;
+}
+
+extern "C" float port_wsCameraPitchScale(void) {
+    return std::sqrt(port_wsCameraYawScale());
+}
+
+static void wsCameraScales(float scale[3]) {
+    scale[1] = port_wsCameraYawScale();
+    scale[0] = std::sqrt(scale[1]);
+    scale[2] = 1.0f;
+}
+
+static float wsAngleDifference(float a, float b) {
+    float delta = a - b;
+    while (delta > 180.0f) {
+        delta -= 360.0f;
     }
-    int32_t curMap = (int32_t)gsworld_getMap();
-    for (int i = 0; i < WS_YAW_FIX_COUNT; i++) {
-        if (curMap == sWsYawFixes[i].map &&
-            (sWsYawFixes[i].node == -1 || sLastStaticCameraNode == sWsYawFixes[i].node)) {
-            rotation[1] += sWsYawFixes[i].adjust;
-            break;
+    while (delta < -180.0f) {
+        delta += 360.0f;
+    }
+    return delta;
+}
+
+static bool wsCameraFixMatches(const WsCameraFix& fix, const CameraRotationAuthored* ev, int32_t curMap) {
+    if (curMap != fix.map || ev->source != fix.source) {
+        return false;
+    }
+    if (fix.id != -1 && ev->id != fix.id) {
+        return false;
+    }
+    if (!fix.matchTransform) {
+        return true;
+    }
+    if (ev->position == nullptr) {
+        return false;
+    }
+    for (int i = 0; i < 3; i++) {
+        if (std::fabs(ev->position[i] - fix.position[i]) > kWsPositionTolerance) {
+            return false;
+        }
+        if (std::fabs(wsAngleDifference(ev->rotation[i], fix.rotation[i])) > kWsRotationTolerance) {
+            return false;
         }
     }
+    return true;
+}
+
+static void wsReauthorStaticCamera() {
+    float rotation[3];
+    for (int i = 0; i < 3; i++) {
+        rotation[i] = sWsAuthored.rotation[i];
+    }
+    CALL_EVENT(CameraRotationAuthored, sWsAuthored.source, sWsAuthored.id, sWsAuthored.position, rotation);
+
+    float position[3];
+    ncStaticCamera_getPosition(position);
+    ncStaticCamera_setPositionAndRotation(position, rotation);
 }
 
 // Event listeners
 
 void RegisterCutsceneAspect() {
-    // Boot-time self-heal: if a previous session crashed or quit during a cutscene, the persisted
-    // gAdvancedResolution cvars may still hold the forced 4:3. Restore the user's real settings from
-    // the backup before anything reads them. This runs from the init process, not a per-frame listener.
     if (CVarGetInteger(CVAR_CSA_BAK_ACTIVE, 0)) {
         restoreCutsceneAspectBackup();
     }
@@ -141,27 +208,67 @@ void RegisterCutsceneAspect() {
     });
 }
 
+void RegisterWidescreenCamera() {
+    COND_HOOK(CameraRotationAuthored, EVENT_PRIORITY_NORMAL, CVarGetInteger(CVAR_WS_CAMERA_FIX, 1),
+              [](IEvent* event) {
+                  float scale[3];
+                  wsCameraScales(scale);
+                  if (scale[1] <= 0.0f) {
+                      return;
+                  }
+                  auto* ev = (CameraRotationAuthored*)event;
+                  int32_t curMap = (int32_t)gsworld_getMap();
+                  for (int i = 0; i < WS_CAMERA_FIX_COUNT; i++) {
+                      if (wsCameraFixMatches(sWsCameraFixes[i], ev, curMap)) {
+                          for (int axis = 0; axis < 3; axis++) {
+                              ev->rotation[axis] =
+                                  mlNormalizeAngle(ev->rotation[axis] + sWsCameraFixes[i].adjust[axis] * scale[axis]);
+                          }
+                          break;
+                      }
+                  }
+              });
+
+    COND_HOOK(CameraRotationAuthored, EVENT_PRIORITY_LOW, CVarGetInteger(CVAR_WS_CAMERA_FIX, 1), [](IEvent* event) {
+        auto* ev = (CameraRotationAuthored*)event;
+        sWsAuthored.valid = true;
+        sWsAuthored.map = (int32_t)gsworld_getMap();
+        sWsAuthored.source = ev->source;
+        sWsAuthored.id = ev->id;
+        for (int i = 0; i < 3; i++) {
+            sWsAuthored.rotation[i] = ev->rotation[i];
+            sWsAuthored.position[i] = ev->position != nullptr ? ev->position[i] : 0.0f;
+        }
+    });
+
+    COND_HOOK(GameFrameUpdate, EVENT_PRIORITY_NORMAL, CVarGetInteger(CVAR_WS_CAMERA_FIX, 1), [](IEvent* event) {
+        float aspect = GameEngine_GetAspectRatio();
+        if (std::fabs(aspect - sWsLastAspect) < 0.0005f) {
+            return;
+        }
+        sWsLastAspect = aspect;
+        if (!sWsAuthored.valid || sWsAuthored.source != CAMERA_TYPE_3_STATIC) {
+            return;
+        }
+        if (sWsAuthored.map != (int32_t)gsworld_getMap() || ncCamera_getType() != CAMERA_TYPE_3_STATIC) {
+            return;
+        }
+        wsReauthorStaticCamera();
+    });
+}
+
 void RegisterCameraPatches_Init() {
 
-    COND_VB_SHOULD(VB_STATIC_CAMERA_SET, EVENT_PRIORITY_NORMAL, true,
-                   { sLastStaticCameraNode = *va_arg(args, int32_t*); });
-    COND_VB_SHOULD(VB_STATIC_CAMERA_EXIT, EVENT_PRIORITY_NORMAL, true, { sLastStaticCameraNode = -1; });
     COND_VB_SHOULD(VB_CAMERA_LIVE_ASPECT, EVENT_PRIORITY_NORMAL, true, { *should = false; });
 
-    // Bigger frustum — widen the side planes from the actual FOV and aspect
-    // ratio, and pad the top/bottom planes to mask vertical cam pop-in.
-    // Bail in replayed-input modes (attract demo, Bottles bonus, SnS picture):
-    // those recordings are deterministic against the vanilla cull set, and any
-    // frustum change shifts which actors tick and desyncs the playback.
+    // Bigger frustum for wider aspect ratios, no-op for deterministic scenes
     REGISTER_LISTENER(ViewportFrustumUpdate, EVENT_PRIORITY_NORMAL, [](IEvent* event) {
         if (IsDemoMode()) {
             return;
         }
         auto* ev = (ViewportFrustumUpdate*)event;
-        // Widen the side planes to the actual render aspect, floored at 4:3 so we never
-        // cull tighter than vanilla.
-        const float kFrustumZ = 45.168514251708984f; // must match the literal in viewport.c
-        const float kMargin = 1.10f;                 // ~10% wider than the exact FOV
+        const float kFrustumZ = 45.168514251708984f;
+        const float kMargin = 1.10f;
         float aspect = GameEngine_GetAspectRatio();
         if (aspect < sViewportAspect) {
             aspect = sViewportAspect;
@@ -179,5 +286,6 @@ void RegisterScreenShake_Init() {
 }
 
 static RegisterShipInitFunc cutsceneAspectInitFunc(RegisterCutsceneAspect, { CVAR_CUTSCENE_ASPECT });
+static RegisterShipInitFunc widescreenCameraInitFunc(RegisterWidescreenCamera, { CVAR_WS_CAMERA_FIX });
 static RegisterShipInitFunc staticCamInitFunc(RegisterCameraPatches_Init);
 static RegisterShipInitFunc screenShakeInitFunc(RegisterScreenShake_Init, { CVAR_NO_SCREEN_SHAKE });

--- a/src/port/Patches/Patches.h
+++ b/src/port/Patches/Patches.h
@@ -62,7 +62,8 @@ void port_syncBottlesBonusIndex(void);
 
 // Camera (CameraPatches.cpp)
 
-void port_camera_applyWsYawFix(float rotation[3]);
+float port_wsCameraYawScale(void);
+float port_wsCameraPitchScale(void);
 
 // Input
 

--- a/src/port/UI/DeveloperTools/CameraTools.cpp
+++ b/src/port/UI/DeveloperTools/CameraTools.cpp
@@ -1,0 +1,332 @@
+#include "CameraTools.h"
+
+#include "port/Enhancements/Events/Hooks/Events.h"
+#include "port/Patches/Patches.h"
+#include "port/ShipInit.hpp"
+#include "port/ShipUtils.h"
+#include "port/UI/LighthouseGui.hpp"
+#include "port/UI/UIWidgets.hpp"
+
+#include <cstdio>
+#include <map>
+#include <utility>
+#include <imgui.h>
+#include <libultraship/libultraship.h>
+
+#include "enums.h"
+#include "functions.h"
+#include "variables.h"
+
+static constexpr s32 kPivotCameraNodeType = 1;
+static constexpr s32 kStaticCameraNodeType = 2;
+static constexpr s32 kZoomCameraNodeType = 3;
+static const char* kCameraNodeTypeNames[] = { "Unknown", "Pivot", "Static", "Zoom", "Random" };
+
+struct CameraNodeInfo {
+    s32 type = 0;
+    bool hasTransform = false;
+    f32 position[3] = { 0.0f, 0.0f, 0.0f };
+    f32 rotation[3] = { 0.0f, 0.0f, 0.0f };
+};
+
+struct ActiveCamera {
+    bool valid = false;
+    s32 source = CAMERA_TYPE_3_STATIC;
+    s32 id = -1;
+    f32 position[3] = { 0.0f, 0.0f, 0.0f };
+    f32 authored[3] = { 0.0f, 0.0f, 0.0f };
+    f32 fixed[3] = { 0.0f, 0.0f, 0.0f };
+    f32 applied[3] = { 0.0f, 0.0f, 0.0f };
+};
+
+struct CameraNudge {
+    f32 rotation[3] = { 0.0f, 0.0f, 0.0f };
+};
+
+static ActiveCamera sActiveCamera;
+static std::map<std::pair<s32, s32>, CameraNudge> sCameraNudges;
+
+static f32 CameraYawDelta(f32 applied, f32 authored) {
+    f32 delta = applied - authored;
+    while (delta > 180.0f) {
+        delta -= 360.0f;
+    }
+    while (delta < -180.0f) {
+        delta += 360.0f;
+    }
+    return delta;
+}
+
+static const char* CameraSourceName(s32 source) {
+    return source == CAMERA_TYPE_1_UNKNOWN ? "Cutscene" : "Static node";
+}
+
+static const char* CameraSourceEnumName(s32 source) {
+    return source == CAMERA_TYPE_1_UNKNOWN ? "CAMERA_TYPE_1_UNKNOWN" : "CAMERA_TYPE_3_STATIC";
+}
+
+static const char* CameraNodeTypeName(s32 type) {
+    return (type >= 0 && type <= 4) ? kCameraNodeTypeNames[type] : "?";
+}
+
+static const char* CameraTypeName(s32 type) {
+    switch (type) {
+        case CAMERA_TYPE_1_UNKNOWN:
+            return "Unknown(1)";
+        case CAMERA_TYPE_2_DYNAMIC:
+            return "Dynamic";
+        case CAMERA_TYPE_3_STATIC:
+            return "Static";
+        case CAMERA_TYPE_4_RANDOM:
+            return "Random";
+        default:
+            return "None";
+    }
+}
+
+static bool ReadCameraNode(s32 node, CameraNodeInfo& out) {
+    if (!ncCameraNodeList_nodeIsValid(node)) {
+        return false;
+    }
+    out = CameraNodeInfo{};
+    out.type = ncCameraNodeList_getNodeType(node);
+
+    const f32* position = nullptr;
+    const f32* rotation = nullptr;
+    switch (out.type) {
+        case kPivotCameraNodeType:
+            if (PivotCameraNode* data = ncCameraNodeList_getPivotCameraNode(node)) {
+                position = data->position;
+                rotation = data->pitchYawRoll;
+            }
+            break;
+        case kStaticCameraNodeType:
+            if (StaticCameraNode* data = ncCameraNodeList_getStaticCameraNode(node)) {
+                position = data->position;
+                rotation = data->pitchYawRoll;
+            }
+            break;
+        case kZoomCameraNodeType:
+            if (ZoomCameraNode* data = ncCameraNodeList_getZoomCameraNode(node)) {
+                position = data->position;
+                rotation = data->pitchYawRoll;
+            }
+            break;
+        default:
+            break;
+    }
+
+    if (position != nullptr && rotation != nullptr) {
+        for (int i = 0; i < 3; i++) {
+            out.position[i] = position[i];
+            out.rotation[i] = rotation[i];
+        }
+        out.hasTransform = true;
+    }
+    return true;
+}
+
+static void FormatWsCameraFixRow(char* out, size_t size, s32 map, const ActiveCamera& cam, const f32 adjust[3]) {
+    if (cam.source == CAMERA_TYPE_1_UNKNOWN) {
+        snprintf(out, size,
+                 "{ .map = 0x%X, .source = %s, .matchTransform = true, .position = { %.2ff, %.2ff, %.2ff }, "
+                 ".rotation = { %.2ff, %.2ff, %.2ff }, .adjust = { %.1ff, %.1ff, %.1ff } },",
+                 map, CameraSourceEnumName(cam.source), cam.position[0], cam.position[1], cam.position[2],
+                 cam.authored[0], cam.authored[1], cam.authored[2], adjust[0], adjust[1], adjust[2]);
+    } else {
+        snprintf(out, size, "{ .map = 0x%X, .source = %s, .id = 0x%02X, .adjust = { %.1ff, %.1ff, %.1ff } },", map,
+                 CameraSourceEnumName(cam.source), cam.id, adjust[0], adjust[1], adjust[2]);
+    }
+}
+
+void CameraTools_Register() {
+    REGISTER_LISTENER(CameraRotationAuthored, EVENT_PRIORITY_LOW, [](IEvent* event) {
+        auto* ev = (CameraRotationAuthored*)event;
+        sActiveCamera.valid = true;
+        sActiveCamera.source = ev->source;
+        sActiveCamera.id = ev->id;
+        for (int i = 0; i < 3; i++) {
+            sActiveCamera.authored[i] = ev->rotation[i];
+            if (ev->position != nullptr) {
+                sActiveCamera.position[i] = ev->position[i];
+            }
+        }
+    });
+    REGISTER_LISTENER(CameraRotationAuthored, EVENT_PRIORITY_HIGH, [](IEvent* event) {
+        auto* ev = (CameraRotationAuthored*)event;
+        auto nudge = sCameraNudges.find({ ev->source, ev->id });
+        for (int i = 0; i < 3; i++) {
+            sActiveCamera.fixed[i] = ev->rotation[i];
+            if (nudge != sCameraNudges.end()) {
+                ev->rotation[i] = mlNormalizeAngle(ev->rotation[i] + nudge->second.rotation[i]);
+            }
+            sActiveCamera.applied[i] = ev->rotation[i];
+        }
+    });
+    REGISTER_LISTENER(OnMapLoad, EVENT_PRIORITY_NORMAL, [](IEvent* event) {
+        sActiveCamera = ActiveCamera{};
+        sCameraNudges.clear();
+    });
+}
+
+void DrawCameraTools() {
+    s32 map = gsworld_getMap();
+    s32 cameraType = ncCamera_getType();
+    bool staticCameraLive = (cameraType == CAMERA_TYPE_3_STATIC);
+    f32 livePosition[3];
+    f32 liveRotation[3];
+    viewport_getPosition_vec3f(livePosition);
+    viewport_getRotation_vec3f(liveRotation);
+    const f32 scale[3] = { port_wsCameraPitchScale(), port_wsCameraYawScale(), 1.0f };
+    f32 delta[3];
+    f32 tableAdjust[3];
+    for (int i = 0; i < 3; i++) {
+        delta[i] = CameraYawDelta(sActiveCamera.applied[i], sActiveCamera.authored[i]);
+        tableAdjust[i] = scale[i] > 0.0f ? delta[i] / scale[i] : delta[i];
+    }
+    char fixRow[320] = "";
+    if (sActiveCamera.valid) {
+        FormatWsCameraFixRow(fixRow, sizeof(fixRow), map, sActiveCamera, tableAdjust);
+    }
+
+    ImGui::SeparatorText("Live Camera");
+    ImGui::Text("Map: %s (%d / 0x%X)   Camera: %s", port_mapName(map), map, map, CameraTypeName(cameraType));
+    ImGui::Text("Pos %9.2f %9.2f %9.2f   Pitch/Yaw/Roll %7.2f %7.2f %7.2f", livePosition[0], livePosition[1],
+                livePosition[2], liveRotation[0], liveRotation[1], liveRotation[2]);
+
+    if (sActiveCamera.valid) {
+        ImGui::Text("Source: %s   Id: %d / 0x%02X", CameraSourceName(sActiveCamera.source), sActiveCamera.id,
+                    sActiveCamera.id);
+
+        auto key = std::make_pair(sActiveCamera.source, sActiveCamera.id);
+        auto stored = sCameraNudges.find(key);
+        CameraNudge nudge = stored != sCameraNudges.end() ? stored->second : CameraNudge{};
+
+        ImGui::SetNextItemWidth(240.0f);
+        bool edited = ImGui::SliderFloat("Yaw Nudge", &nudge.rotation[1], -45.0f, 45.0f, "%+.1f deg");
+        ImGui::SetNextItemWidth(240.0f);
+        edited |= ImGui::SliderFloat("Pitch Nudge", &nudge.rotation[0], -45.0f, 45.0f, "%+.1f deg");
+        ImGui::SetNextItemWidth(240.0f);
+        edited |= ImGui::SliderFloat("Roll Nudge", &nudge.rotation[2], -45.0f, 45.0f, "%+.1f deg");
+
+        if (edited) {
+            sCameraNudges[key] = nudge;
+            f32 rotation[3];
+            for (int i = 0; i < 3; i++) {
+                rotation[i] = mlNormalizeAngle(sActiveCamera.fixed[i] + nudge.rotation[i]);
+                sActiveCamera.applied[i] = rotation[i];
+            }
+            if (staticCameraLive) {
+                f32 position[3];
+                ncStaticCamera_getPosition(position);
+                ncStaticCamera_setPositionAndRotation(position, rotation);
+            } else {
+                viewport_setRotation_vec3f(rotation);
+            }
+        }
+
+        ImGui::Text("Delta pyr %+.1f %+.1f %+.1f   16:9 pyr %+.1f %+.1f %+.1f (scale %.2fx pitch, %.2fx yaw)", delta[0],
+                    delta[1], delta[2], tableAdjust[0], tableAdjust[1], tableAdjust[2], scale[0], scale[1]);
+        ImGui::TextDisabled("%s", fixRow);
+    } else {
+        ImGui::TextDisabled("No camera has authored a rotation yet on this map.");
+    }
+
+    ImGui::SeparatorText("Camera Nodes");
+
+    if (UIWidgets::Button("Dump To Log", { .color = THEME_COLOR })) {
+        BK_LOG_DEBUG("camera nodes for map %s (%d / 0x%X), camera type %s:", port_mapName(map), map, map,
+                     CameraTypeName(cameraType));
+        BK_LOG_DEBUG("  live viewport  pos %9.2f %9.2f %9.2f  pyr %7.2f %7.2f %7.2f", livePosition[0], livePosition[1],
+                     livePosition[2], liveRotation[0], liveRotation[1], liveRotation[2]);
+        if (sActiveCamera.valid) {
+            BK_LOG_DEBUG("  active camera  %s id %d (0x%02X)  pos %9.2f %9.2f %9.2f  authored pyr %7.2f %7.2f %7.2f  "
+                         "applied %7.2f %7.2f %7.2f  delta %+.2f %+.2f %+.2f",
+                         CameraSourceName(sActiveCamera.source), sActiveCamera.id, sActiveCamera.id,
+                         sActiveCamera.position[0], sActiveCamera.position[1], sActiveCamera.position[2],
+                         sActiveCamera.authored[0], sActiveCamera.authored[1], sActiveCamera.authored[2],
+                         sActiveCamera.applied[0], sActiveCamera.applied[1], sActiveCamera.applied[2], delta[0],
+                         delta[1], delta[2]);
+            if (delta[0] != 0.0f || delta[1] != 0.0f || delta[2] != 0.0f) {
+                BK_LOG_DEBUG("    %s", fixRow);
+            }
+        }
+        s32 dumped = 0;
+        for (s32 node = 0; node < __ncCameraNodeList_capacity(); node++) {
+            CameraNodeInfo info;
+            if (!ReadCameraNode(node, info)) {
+                continue;
+            }
+            dumped++;
+            if (info.hasTransform) {
+                BK_LOG_DEBUG("  node %2d (0x%02X)  %-7s  pos %9.2f %9.2f %9.2f  pyr %7.2f %7.2f %7.2f", node, node,
+                             CameraNodeTypeName(info.type), info.position[0], info.position[1], info.position[2],
+                             info.rotation[0], info.rotation[1], info.rotation[2]);
+            } else {
+                BK_LOG_DEBUG("  node %2d (0x%02X)  %-7s  (no transform)", node, node, CameraNodeTypeName(info.type));
+            }
+        }
+        if (dumped == 0) {
+            BK_LOG_DEBUG("No cameras found to dump.");
+        }
+    }
+
+    if (!ImGui::BeginTable("CameraNodeTable", 8,
+                           ImGuiTableFlags_SizingFixedFit | ImGuiTableFlags_RowBg | ImGuiTableFlags_ScrollY)) {
+        return;
+    }
+    ImGui::TableSetupColumn("Node");
+    ImGui::TableSetupColumn("Type");
+    ImGui::TableSetupColumn("X");
+    ImGui::TableSetupColumn("Y");
+    ImGui::TableSetupColumn("Z");
+    ImGui::TableSetupColumn("Pitch");
+    ImGui::TableSetupColumn("Yaw");
+    ImGui::TableSetupColumn("Roll");
+    ImGui::TableHeadersRow();
+
+    s32 found = 0;
+    for (s32 node = 0; node < __ncCameraNodeList_capacity(); node++) {
+        CameraNodeInfo info;
+        if (!ReadCameraNode(node, info)) {
+            continue;
+        }
+        found++;
+        bool active = staticCameraLive && info.type == kStaticCameraNodeType && sActiveCamera.valid &&
+                      sActiveCamera.source == CAMERA_TYPE_3_STATIC && node == sActiveCamera.id;
+
+        ImGui::TableNextRow();
+        if (active) {
+            ImGui::TableSetBgColor(ImGuiTableBgTarget_RowBg0, ImGui::GetColorU32(ImGuiCol_TextSelectedBg));
+        }
+        ImGui::TableNextColumn();
+        ImGui::Text("%d / 0x%02X", node, node);
+        ImGui::TableNextColumn();
+        ImGui::Text("%s", CameraNodeTypeName(info.type));
+
+        for (int i = 0; i < 3; i++) {
+            ImGui::TableNextColumn();
+            if (info.hasTransform) {
+                ImGui::Text("%.2f", info.position[i]);
+            } else {
+                ImGui::TextDisabled("-");
+            }
+        }
+        for (int i = 0; i < 3; i++) {
+            ImGui::TableNextColumn();
+            if (info.hasTransform) {
+                ImGui::Text("%.2f", info.rotation[i]);
+            } else {
+                ImGui::TextDisabled("-");
+            }
+        }
+    }
+    ImGui::EndTable();
+
+    if (found == 0) {
+        ImGui::TextDisabled("This map has no camera nodes. Use the Live Camera "
+                            "editor above.");
+    }
+}
+
+static RegisterShipInitFunc cameraToolsInitFunc(CameraTools_Register);

--- a/src/port/UI/DeveloperTools/CameraTools.h
+++ b/src/port/UI/DeveloperTools/CameraTools.h
@@ -1,0 +1,4 @@
+#pragma once
+
+void DrawCameraTools(void);
+void CameraTools_Register(void);

--- a/src/port/UI/DeveloperTools/GameplayTools.cpp
+++ b/src/port/UI/DeveloperTools/GameplayTools.cpp
@@ -1,4 +1,5 @@
 #include "GameplayTools.h"
+#include "CameraTools.h"
 #include "port/Rando/Rando.h"
 #include "port/Rando/Logic/Logic.h"
 #include "port/Rando/CustomObject/CustomObject.h"
@@ -6,8 +7,11 @@
 
 #include "port/UI/UIWidgets.hpp"
 #include "port/UI/Notification.h"
+#include "port/Patches/Patches.h"
+#include "port/ShipInit.hpp"
 #include "port/ShipUtils.h"
 
+#include <cstdio>
 #include <string>
 #include <imgui.h>
 #include <libultraship/libultraship.h>
@@ -515,6 +519,10 @@ void GameplayTools_DrawTabBar() {
         }
         if (ImGui::BeginTabItem("Monitoring")) {
             DrawMonitoringTools();
+            ImGui::EndTabItem();
+        }
+        if (ImGui::BeginTabItem("Cameras")) {
+            DrawCameraTools();
             ImGui::EndTabItem();
         }
         ImGui::EndTabBar();

--- a/src/port/UI/LighthouseMenuEnhancements.cpp
+++ b/src/port/UI/LighthouseMenuEnhancements.cpp
@@ -370,11 +370,13 @@ void LighthouseMenu::AddMenuEnhancements() {
     // Visual Section
     AddWidget(path, "Visual", WIDGET_SEPARATOR_TEXT);
 
-    AddWidget(path, "Fix Widescreen Camera", WIDGET_CVAR_CHECKBOX)
+    // Structural widescreen fix, always on.
+/*
+    AddWidget(path, "Fix widescreen oddities", WIDGET_CVAR_CHECKBOX)
         .CVar(CVAR_ENHANCEMENT("Fix.WidescreenCamera"))
         .RaceDisable(false)
-        .Options(CheckboxOptions().DefaultValue(true).Tooltip("Adjusts static camera angles in widescreen to prevent skybox "
-                                           "exposure at the edges of the screen."));
+        .Options(CheckboxOptions().DefaultValue(true).Tooltip("Adjusts camera angles and actors to accommodate wider aspect ratios."));
+*/
 
     AddWidget(path, "Fix Conga's Name", WIDGET_CVAR_CHECKBOX)
         .CVar(CVAR_ENHANCEMENT("Fixes.CongaText"))

--- a/src/port/UI/LighthouseMenuEnhancements.cpp
+++ b/src/port/UI/LighthouseMenuEnhancements.cpp
@@ -373,7 +373,7 @@ void LighthouseMenu::AddMenuEnhancements() {
     AddWidget(path, "Fix Widescreen Camera", WIDGET_CVAR_CHECKBOX)
         .CVar(CVAR_ENHANCEMENT("Fix.WidescreenCamera"))
         .RaceDisable(false)
-        .Options(CheckboxOptions().Tooltip("Adjusts static camera angles in widescreen to prevent skybox "
+        .Options(CheckboxOptions().DefaultValue(true).Tooltip("Adjusts static camera angles in widescreen to prevent skybox "
                                            "exposure at the edges of the screen."));
 
     AddWidget(path, "Fix Conga's Name", WIDGET_CVAR_CHECKBOX)

--- a/src/port/UI/LighthouseMenuEnhancements.cpp
+++ b/src/port/UI/LighthouseMenuEnhancements.cpp
@@ -371,12 +371,13 @@ void LighthouseMenu::AddMenuEnhancements() {
     AddWidget(path, "Visual", WIDGET_SEPARATOR_TEXT);
 
     // Structural widescreen fix, always on.
-/*
-    AddWidget(path, "Fix widescreen oddities", WIDGET_CVAR_CHECKBOX)
-        .CVar(CVAR_ENHANCEMENT("Fix.WidescreenCamera"))
-        .RaceDisable(false)
-        .Options(CheckboxOptions().DefaultValue(true).Tooltip("Adjusts camera angles and actors to accommodate wider aspect ratios."));
-*/
+    /*
+        AddWidget(path, "Fix widescreen oddities", WIDGET_CVAR_CHECKBOX)
+            .CVar(CVAR_ENHANCEMENT("Fix.WidescreenCamera"))
+            .RaceDisable(false)
+            .Options(CheckboxOptions().DefaultValue(true).Tooltip("Adjusts camera angles and actors to accommodate wider
+       aspect ratios."));
+    */
 
     AddWidget(path, "Fix Conga's Name", WIDGET_CVAR_CHECKBOX)
         .CVar(CVAR_ENHANCEMENT("Fixes.CongaText"))


### PR DESCRIPTION
This will resolve #471. The widescreen camera fix has been reworked entirely and should be easier to modify in the future if needed. A camera tools menu has been added to Dev Tools and assisted with finding the right scales to use. The camera angle adjustments scale cleanly among different aspect ratios on demand.

In addition, transitions now scale properly where previously on wider aspect ratios they did not, which caused them to appear to play slowly. Specific actors in the Rareware Intro and Concert maps are also handled to be hidden until needed. This affects the buzz bombs in the sky with the Rareware logo, and the two bulls and frog in the Concert cutscene.

Additionally, the toggle for it has been commented out since there is zero logical reason anyone would want to disable this feature.