### PR TITLE
Correct a typo in the Sequences menu and add additional cutscenes

### DIFF
--- a/src/port/DevTools/DevSequences.cpp
+++ b/src/port/DevTools/DevSequences.cpp
@@ -15,6 +15,7 @@ void gcparade_beginFFParade(void);
 void gcparade_beginFinalParade(void);
 void func_8034BA7C(enum map_e map_id, int exit_id); // warp (B&K demo uses MAP_1, exit 93)
 void transitionToMap(enum map_e map, int exit, int transition);
+void func_802E412C(int arg0, int arg1);
 void func_8034B968(void);          // start the attract demo selected by D_80386110 (sets transition + D_80386114)
 extern int D_80386110;             // attract-demo cycle index
 void func_8025A55C(int, int, int); // fade the active music track
@@ -31,9 +32,15 @@ namespace Lighthouse {
 namespace DevTools {
 
 static int sPending = SEQ_NONE;
+static int sPendingMap = -1;
 
 void RequestSequence(int seq) {
     sPending = seq;
+}
+
+void RequestCutsceneMap(int mapId) {
+    sPendingMap = mapId;
+    sPending = SEQ_CUTSCENE_MAP;
 }
 
 void RegisterDevSequences_Init() {
@@ -75,6 +82,13 @@ void RegisterDevSequences_Init() {
                 break;
             case SEQ_ENDING_ALL_100:
                 transitionToMap(MAP_95_CS_END_ALL_100, 0, 1);
+                break;
+            case SEQ_GAME_OVER:
+                func_802E412C(1, 0);
+                transitionToMap(MAP_83_CS_GAME_OVER_MACHINE_ROOM, 0, 1);
+                break;
+            case SEQ_CUTSCENE_MAP:
+                transitionToMap((enum map_e)sPendingMap, 0, 1);
                 break;
             default:
                 D_80386110 = seq - SEQ_ATTRACT_BASE;

--- a/src/port/DevTools/DevSequences.h
+++ b/src/port/DevTools/DevSequences.h
@@ -10,11 +10,14 @@ enum DevSequenceId {
     SEQ_MODE9_BK,
     SEQ_MODE9_DIALOG,
     SEQ_ENDING_ALL_100,
+    SEQ_GAME_OVER,
+    SEQ_CUTSCENE_MAP,
     SEQ_ATTRACT_BASE,
 };
 
 constexpr int ATTRACT_DEMO_COUNT = 10;
 void RequestSequence(int seq);
+void RequestCutsceneMap(int mapId);
 
 } // namespace DevTools
 } // namespace Lighthouse

--- a/src/port/UI/LighthouseMenuDevTools.cpp
+++ b/src/port/UI/LighthouseMenuDevTools.cpp
@@ -11,6 +11,7 @@
 #include <spdlog/fmt/fmt.h>
 
 #include "variables.h"
+#include "enums.h"
 
 namespace LighthouseGui {
 
@@ -84,7 +85,7 @@ void LighthouseMenu::AddMenuDevTools() {
         .CVar(CVAR_DEVELOPER_TOOLS("DebugMode"))
         .Options(CheckboxOptions().Tooltip("Various debug features, including a level selector from the main menu."));*/
 
-    // Sequences (dev: jump straight to a parade or demo)
+    // Sequences
     using namespace Lighthouse::DevTools;
     path.sidebarName = "Sequences";
     AddSidebarEntry("Dev Tools", "Sequences", 1);
@@ -97,19 +98,51 @@ void LighthouseMenu::AddMenuDevTools() {
         .Callback([](WidgetInfo&) { RequestSequence(SEQ_PARADE_FINAL); })
         .Options(ButtonOptions().Size(Sizes::Inline).Tooltip("Jump to the post-Grunty end-credits parade."));
 
-    AddWidget(path, "Demos", WIDGET_SEPARATOR_TEXT);
+    AddWidget(path, "Cutscenes", WIDGET_SEPARATOR_TEXT);
     AddWidget(path, "Spiral Mountain Ending Sequence", WIDGET_BUTTON)
         .Callback([](WidgetInfo&) { RequestSequence(SEQ_MODE9_BK); })
+        .PreFunc([](WidgetInfo& info) {
+            if (mLighthouseMenu->disabledMap.at(DISABLE_FOR_ROMHACK).active) {
+                info.activeDisables.push_back(DISABLE_FOR_ROMHACK);
+            }
+        })
         .Options(ButtonOptions().Size(Sizes::Inline).Tooltip("Jump to the post-parade demo."));
+    AddWidget(path, "Under 100 Ending Scene", WIDGET_BUTTON)
+        .Callback([](WidgetInfo&) { RequestCutsceneMap(MAP_20_CS_END_NOT_100); })
+        .PreFunc([](WidgetInfo& info) {
+            if (mLighthouseMenu->disabledMap.at(DISABLE_FOR_ROMHACK).active) {
+                info.activeDisables.push_back(DISABLE_FOR_ROMHACK);
+            }
+        })
+        .Options(ButtonOptions().Size(Sizes::Inline).Tooltip("Jump to the not-100 jiggy ending cutscene."));
     AddWidget(path, "All 100 Ending Scene", WIDGET_BUTTON)
         .Callback([](WidgetInfo&) { RequestSequence(SEQ_ENDING_ALL_100); })
-        .Options(ButtonOptions()
-                     .Size(Sizes::Inline)
-                     .Tooltip("Jump to the 100-jiggy ending cutscene (normally shown after the final parade)."));
+        .PreFunc([](WidgetInfo& info) {
+            if (mLighthouseMenu->disabledMap.at(DISABLE_FOR_ROMHACK).active) {
+                info.activeDisables.push_back(DISABLE_FOR_ROMHACK);
+            }
+        })
+        .Options(ButtonOptions().Size(Sizes::Inline).Tooltip("Jump to the 100-jiggy ending cutscene."));
+    AddWidget(path, "Game Over Cutscene", WIDGET_BUTTON)
+        .Callback([](WidgetInfo&) { RequestSequence(SEQ_GAME_OVER); })
+        .PreFunc([](WidgetInfo& info) {
+            if (mLighthouseMenu->disabledMap.at(DISABLE_FOR_ROMHACK).active) {
+                info.activeDisables.push_back(DISABLE_FOR_ROMHACK);
+            }
+        })
+        .Options(
+            ButtonOptions().Size(Sizes::Inline).Tooltip("Jump to the Game Over cutscene in Grunty's machine room."));
+    AddWidget(path, "Klungo's Machine Room (Unused)", WIDGET_BUTTON)
+        .Callback([](WidgetInfo&) { RequestCutsceneMap(MAP_84_CS_UNUSED_MACHINE_ROOM); })
+        .PreFunc([](WidgetInfo& info) {
+            if (mLighthouseMenu->disabledMap.at(DISABLE_FOR_ROMHACK).active) {
+                info.activeDisables.push_back(DISABLE_FOR_ROMHACK);
+            }
+        })
+        .Options(
+            ButtonOptions().Size(Sizes::Inline).Tooltip("Unused and incomplete cutscene. It has no exit trigger."));
 
     AddWidget(path, "Attract Demos", WIDGET_SEPARATOR_TEXT);
-    // Demo index = slot in the decomp attract table (D_80371F00); 4 and 9 are the
-    // Rareware-logo cutscenes, intentionally skipped.
     static const struct {
         const char* name;
         int demo;


### PR DESCRIPTION
Adds a couple cutscenes to the Sequences devtools menu and disabled them for romhacks, since romhacks can recycle cutscene maps. Also corrects a typo (Demos -> Cutscenes).

<!--- section:artifacts:start -->
### Build Artifacts
  - [Lighthouse-windows.zip](https://nightly.link/HarbourMasters/Lighthouse/actions/artifacts/9184447425.zip)
  - [Lighthouse-linux.zip](https://nightly.link/HarbourMasters/Lighthouse/actions/artifacts/9183861203.zip)
  - [Lighthouse-mac.zip](https://nightly.link/HarbourMasters/Lighthouse/actions/artifacts/9183536039.zip)
<!--- section:artifacts:end -->