### PR TITLE
Implement Anchor GIVE_ITEM so remote sources can grant randomizer items

### DIFF
--- a/src/port/Network/Anchor/Anchor.h
+++ b/src/port/Network/Anchor/Anchor.h
@@ -233,7 +233,7 @@ public:
     void SendPacket_DamagePlayer(u32 clientId, u8 damageEffect, u8 damage);
     void SendPacket_EntranceDiscovered(u16 entranceIndex);
     void SendPacket_GameComplete();
-    void SendPacket_GiveItem(u16 modId, s16 getItemId);
+    void SendPacket_GiveItem(s32 randoItemId);
     void SendPacket_Handshake();
     void SendPacket_MapLoad(GameMap map, s32 exit);
     void SendPacket_PlayerAnimChange(AssetID anim_id, f32 duration, AnimControl control, f32 start_position,

--- a/src/port/Network/Anchor/Packets/GiveItem.cpp
+++ b/src/port/Network/Anchor/Packets/GiveItem.cpp
@@ -1,103 +1,68 @@
 #include "port/Network/Anchor/Anchor.h"
 #include <nlohmann/json.hpp>
 #include <libultraship/libultraship.h>
-#include "port/UI/Notification.h"
-
-#include "functions.h"
-// extern PlayState* gPlayState;
+#include "port/Rando/Rando.h"
+#include "port/Rando/ItemQueue/ItemQueue.h"
 
 /**
  * GIVE_ITEM
  *
- * unimplemented
+ * Directed grant of a single randomizer item to this client.
+ *
+ * SET_CHECK_STATUS mirrors a check a teammate already obtained. GIVE_ITEM instead asserts "this
+ * item is yours now", which is what an external item source (a multiworld or remote randomizer
+ * client) needs in order to hand items to a running game.
+ *
+ * Payload:
+ *   randoItemId  s32  a RandoItemId satisfying RI_UNKNOWN < randoItemId < RI_MAX
+ *
+ * Safety:
+ *   - Only applied on a loaded rando save; a vanilla save has nowhere to put a RandoItemId.
+ *   - The id is range checked before use, because ItemQueue and StaticData index Items[] with it
+ *     directly, so a malformed or stale packet must never reach them.
+ *   - Grants are a delta (counts increment, the next free jiggy/honeycomb slot is taken) and are
+ *     deliberately not deduplicated here. Delivering the same packet twice grants the item twice,
+ *     and a grant cannot be taken back, so at-most-once delivery is the sender's responsibility.
  */
 
-uint8_t incomingIceTrapsFromAnchor = 0;
-
-void Anchor::SendPacket_GiveItem(u16 modId, s16 getItemId) {
-    if (!IsSaveLoaded() || isProcessingIncomingPacket || !roomState.syncItemsAndFlags) {
+void Anchor::SendPacket_GiveItem(s32 randoItemId) {
+    if (!IS_RANDO || !IsSaveLoaded() || isProcessingIncomingPacket || !roomState.syncItemsAndFlags) {
         return;
     }
 
-    // if (modId == MOD_RANDOMIZER && getItemId == RG_ICE_TRAP && incomingIceTrapsFromAnchor > 0) {
-    //     incomingIceTrapsFromAnchor = MAX(incomingIceTrapsFromAnchor - 1, 0);
-    //     return;
-    // }
-
-    //// Ignore sending master sword in final Ganon fight
-    // if (modId == MOD_RANDOMIZER && getItemId == RG_MASTER_SWORD && gPlayState->sceneNum == SCENE_GANON_BOSS) {
-    //     return;
-    // }
+    if (randoItemId <= RI_UNKNOWN || randoItemId >= RI_MAX) {
+        return;
+    }
 
     nlohmann::json payload;
     payload["type"] = GIVE_ITEM;
     payload["targetTeamId"] = CVarGetString(CVAR_REMOTE_ANCHOR("TeamId"), "default");
     payload["addToQueue"] = true;
-    payload["modId"] = modId;
-    payload["getItemId"] = getItemId;
+    payload["randoItemId"] = randoItemId;
 
     SendJsonToRemote(payload);
 }
 
 void Anchor::HandlePacket_GiveItem(nlohmann::json& payload) {
-    if (!IsSaveLoaded() || !roomState.syncItemsAndFlags) {
+    if (!IS_RANDO || !IsSaveLoaded()) {
         return;
     }
 
-    uint32_t clientId = payload.at("clientId").get<uint32_t>();
-    AnchorClient& client = clients[clientId];
-    u16 modId = payload.at("modId").get<u16>();
-    u16 getItemId = payload.at("getItemId").get<u16>();
+    // The public room is full of strangers, and this packet writes straight to the save.
+    if (IsGlobalRoom()) {
+        return;
+    }
 
-    // GetItemEntry getItemEntry;
-    // if (modId == MOD_NONE) {
-    //     getItemEntry = ItemTableManager::Instance->RetrieveItemEntry(MOD_NONE, getItemId);
-    // } else {
-    //     getItemEntry = Rando::StaticData::RetrieveItem(static_cast<RandomizerGet>(getItemId)).GetGIEntry_Copy();
-    // }
+    // Not gated on roomState.syncItemsAndFlags: that switch governs passive world mirroring
+    // between co-op peers, while this is an explicit directed grant. Requiring it would force a
+    // remote item source to also opt its player into full item and flag sync.
 
-    // if (getItemEntry.modIndex == MOD_NONE) {
-    //     if (getItemEntry.getItemId == GI_SWORD_BGS) {
-    //         gSaveContext.bgsFlag = true;
-    //     }
-    //     Item_Give(gPlayState, getItemEntry.itemId);
-    // } else if (getItemEntry.modIndex == MOD_RANDOMIZER) {
-    //     if (getItemEntry.getItemId == RG_ICE_TRAP) {
-    //         gSaveContext.ship.pendingIceTrapCount++;
-    //         incomingIceTrapsFromAnchor++;
-    //     } else {
-    //         Randomizer_Item_Give(gPlayState, getItemEntry);
-    //     }
-    // }
+    s32 randoItemId = payload.value("randoItemId", (s32)RI_UNKNOWN);
+    if (randoItemId <= RI_UNKNOWN || randoItemId >= RI_MAX) {
+        return;
+    }
 
-    //// Full heal if getting a heart container or piece
-    // if (getItemEntry.gid == GID_HEART_CONTAINER || getItemEntry.gid == GID_HEART_PIECE) {
-    //     gSaveContext.healthAccumulator = 0x140;
-    // }
-
-    //// Handle if the player gets a 4th heart piece (usually handled in z_message)
-    // s32 heartPieces = (s32)(gSaveContext.inventory.questItems & 0xF0000000) >> (QUEST_HEART_PIECE + 4);
-    // if (heartPieces >= 4) {
-    //     gSaveContext.inventory.questItems &= ~0xF0000000;
-    //     gSaveContext.inventory.questItems += (heartPieces % 4) << (QUEST_HEART_PIECE + 4);
-    //     gSaveContext.healthCapacity += 0x10 * (heartPieces / 4);
-    //     gSaveContext.health += 0x10 * (heartPieces / 4);
-    // }
-
-    // if (getItemEntry.getItemCategory != ITEM_CATEGORY_JUNK) {
-    //     if (getItemEntry.modIndex == MOD_NONE) {
-    //         Notification::Emit({
-    //             .itemIcon = GetTextureForItemId(getItemEntry.itemId),
-    //             .prefix = client.name,
-    //             .message = "found",
-    //             .suffix = SohUtils::GetItemName(getItemEntry.itemId),
-    //         });
-    //     } else if (getItemEntry.modIndex == MOD_RANDOMIZER) {
-    //         Notification::Emit({
-    //             .prefix = client.name,
-    //             .message = "found",
-    //             .suffix = Rando::StaticData::RetrieveItem((RandomizerGet)getItemEntry.getItemId).GetName().english,
-    //         });
-    //     }
-    // }
+    ItemQueue::GiveItem((RandoItemId)randoItemId);
+    // Self-gates on the rando notification CVar, same as a local pickup.
+    ItemQueue::SendNotification((RandoItemId)randoItemId);
 }


### PR DESCRIPTION
`Anchor::HandlePacket_GiveItem` was an empty function with about sixty lines of commented-out OoT code under it, carried over from SoH. A `GIVE_ITEM` packet arriving over Anchor did nothing at all. This wires it up on top of the `ItemQueue` API that already exists.

The motivation is an external item source. A multiworld or remote randomizer client needs some way to say "this item is yours now" to a running game. `SET_CHECK_STATUS` does not cover that, because it mirrors a check a teammate already collected rather than granting something outright.

## Payload

```json
{
  "type": "GIVE_ITEM",
  "targetTeamId": "default",
  "addToQueue": true,
  "randoItemId": 42
}
```

`randoItemId` is a `RandoItemId`. It must satisfy `RI_UNKNOWN < randoItemId < RI_MAX`.

The old `modId` and `getItemId` fields are gone. They described OoT item tables (`MOD_RANDOMIZER`, `RandomizerGet`) and have no meaning in Lighthouse, so keeping them would have meant inventing a translation layer for concepts this port does not have.

`Anchor.h` declares the send helper as `void SendPacket_GiveItem(s32 randoItemId)` rather than taking `RandoItemId` directly, matching `AdoptRemoteCheck(s32 rc)` and `SendPacket_SetCheckStatus(s32 rc, s32 map)` nearby. That keeps `Rando/Types.h` out of a header that is included widely.

## Handling

The receive path checks, in order:

1. `IS_RANDO` and `IsSaveLoaded()`. A vanilla save has nowhere to put a `RandoItemId`.
2. `IsGlobalRoom()`. Rejected, see below.
3. `RI_UNKNOWN < randoItemId < RI_MAX`.

The range check is not defensive padding. `ItemQueue::GiveItem` and `Rando::StaticData` index `Items[]` with this value directly, so a malformed or stale packet has to be stopped before it reaches them. It is the same idiom `SetCheckStatus.cpp` uses for `RandoCheckId`.

The grant itself is `ItemQueue::GiveItem`, followed by `ItemQueue::SendNotification`. The notification call self-gates on the existing notification CVar, so a remote grant is announced under exactly the same conditions as a local pickup. I did not additionally gate it on `ShouldShowNotifications()`, since that setting covers network event toasts rather than item pickups.

Items with `RITYPE_AP_ITEM` are already an explicit no-op inside `ItemQueue::GiveItem`, so placeholder ids need no special handling here.

## Safety and idempotency

**Grants are not idempotent and this handler does not deduplicate.** `ItemQueue::GiveItem` applies a delta: counts increment, and the next free jiggy or honeycomb slot is taken. Delivering the same packet twice grants the item twice, and there is no way to take a grant back. At-most-once delivery is the sender's responsibility.

That is a deliberate choice rather than an oversight. Deduplication needs a notion of item instance identity that this packet does not carry, and inventing one here would push multiworld semantics into the port.

The obvious griefing question is whether a stranger can dump items into your save. `IsGlobalRoom()` is rejected on the receive path for that reason. The public room has no trust relationship, and this packet writes straight to save data.

**One decision worth arguing about:** the receive path is not gated on `roomState.syncItemsAndFlags`, though the send path still is. My reasoning is that the flag governs passive world mirroring between co-op peers, while this is an explicit directed grant, and requiring it would force anyone using a remote item source to also opt into full item and flag sync. If you would rather have the gate for consistency, it is a one-line change and I will make it.

## Testing

I could not build this locally. The build needs Torch asset generation from a ROM, which I do not have, so the change has not been compiled or run.

`clang-format` 14 passes clean with `--dry-run --Werror` against `src/port/.clang-format`. No tests were added because the repo has no test harness; CI packs `lighthouse.o2r` and builds.

Review of the actual behaviour would be welcome, particularly from anyone who can run a rando save and send the packet.
