### PR TITLE
Implement Anchor GIVE_ITEM receive handler

### DIFF
--- a/src/port/Network/Anchor/Packets/GiveItem.cpp
+++ b/src/port/Network/Anchor/Packets/GiveItem.cpp
@@ -1,33 +1,46 @@
 #include "port/Network/Anchor/Anchor.h"
 #include <nlohmann/json.hpp>
 #include <libultraship/libultraship.h>
-#include "port/UI/Notification.h"
 
-#include "functions.h"
-// extern PlayState* gPlayState;
+#include "port/UI/cvar_prefixes.h"
+#include "port/Rando/Rando.h"
+#include "port/Rando/ItemQueue/ItemQueue.h"
 
 /**
  * GIVE_ITEM
  *
- * unimplemented
+ * Hands a single item to this client. SET_CHECK_STATUS mirrors a check a teammate already
+ * obtained; GIVE_ITEM instead says "this item is yours now", which is what an external item source
+ * needs when it decides an item belongs to this player.
+ *
+ * Payload (unchanged from the packet this file inherited, so existing senders keep working):
+ *   modId      u16  which item table getItemId belongs to
+ *                     0  vanilla item table, not implemented here, ignored
+ *                     1  randomizer item table, getItemId is a RandoItemId
+ *   getItemId  s16  the item id, read according to modId
+ *
+ * Only the randomizer table is implemented. A packet with any other modId is dropped rather than
+ * guessed at.
+ *
+ * Safety:
+ *   - Guarded like every other world packet: rando save loaded and room item sync on. That also
+ *     covers the public global room, where HandlePacket_UpdateRoomState forces syncItemsAndFlags
+ *     to 0 and OnIncomingJson then drops GIVE_ITEM before it reaches this handler.
+ *   - getItemId is range checked before use, because ItemQueue and StaticData index Items[] with
+ *     it directly, so a malformed or stale packet must never reach them.
+ *   - A grant is a delta: counts increment, and the next free jiggy or honeycomb slot is taken.
+ *     Nothing here deduplicates, so the same packet delivered twice grants the item twice, and a
+ *     grant cannot be taken back. At-most-once delivery is the sender's responsibility.
  */
 
-uint8_t incomingIceTrapsFromAnchor = 0;
+// Which item table modId selects. The values match the sender this packet came from.
+static constexpr u16 GIVE_ITEM_MOD_VANILLA = 0;
+static constexpr u16 GIVE_ITEM_MOD_RANDOMIZER = 1;
 
 void Anchor::SendPacket_GiveItem(u16 modId, s16 getItemId) {
     if (!IsSaveLoaded() || isProcessingIncomingPacket || !roomState.syncItemsAndFlags) {
         return;
     }
-
-    // if (modId == MOD_RANDOMIZER && getItemId == RG_ICE_TRAP && incomingIceTrapsFromAnchor > 0) {
-    //     incomingIceTrapsFromAnchor = MAX(incomingIceTrapsFromAnchor - 1, 0);
-    //     return;
-    // }
-
-    //// Ignore sending master sword in final Ganon fight
-    // if (modId == MOD_RANDOMIZER && getItemId == RG_MASTER_SWORD && gPlayState->sceneNum == SCENE_GANON_BOSS) {
-    //     return;
-    // }
 
     nlohmann::json payload;
     payload["type"] = GIVE_ITEM;
@@ -40,64 +53,23 @@ void Anchor::SendPacket_GiveItem(u16 modId, s16 getItemId) {
 }
 
 void Anchor::HandlePacket_GiveItem(nlohmann::json& payload) {
-    if (!IsSaveLoaded() || !roomState.syncItemsAndFlags) {
+    if (!IS_RANDO || !IsSaveLoaded() || !roomState.syncItemsAndFlags) {
         return;
     }
 
-    uint32_t clientId = payload.at("clientId").get<uint32_t>();
-    AnchorClient& client = clients[clientId];
-    u16 modId = payload.at("modId").get<u16>();
-    u16 getItemId = payload.at("getItemId").get<u16>();
+    u16 modId = payload.value("modId", (u16)GIVE_ITEM_MOD_VANILLA);
+    if (modId != GIVE_ITEM_MOD_RANDOMIZER) {
+        return;
+    }
 
-    // GetItemEntry getItemEntry;
-    // if (modId == MOD_NONE) {
-    //     getItemEntry = ItemTableManager::Instance->RetrieveItemEntry(MOD_NONE, getItemId);
-    // } else {
-    //     getItemEntry = Rando::StaticData::RetrieveItem(static_cast<RandomizerGet>(getItemId)).GetGIEntry_Copy();
-    // }
+    // Read into s32 so a value outside the RandoItemId range is rejected below rather than
+    // wrapping into a valid id.
+    s32 getItemId = payload.value("getItemId", (s32)RI_UNKNOWN);
+    if (getItemId <= RI_UNKNOWN || getItemId >= RI_MAX) {
+        return;
+    }
 
-    // if (getItemEntry.modIndex == MOD_NONE) {
-    //     if (getItemEntry.getItemId == GI_SWORD_BGS) {
-    //         gSaveContext.bgsFlag = true;
-    //     }
-    //     Item_Give(gPlayState, getItemEntry.itemId);
-    // } else if (getItemEntry.modIndex == MOD_RANDOMIZER) {
-    //     if (getItemEntry.getItemId == RG_ICE_TRAP) {
-    //         gSaveContext.ship.pendingIceTrapCount++;
-    //         incomingIceTrapsFromAnchor++;
-    //     } else {
-    //         Randomizer_Item_Give(gPlayState, getItemEntry);
-    //     }
-    // }
-
-    //// Full heal if getting a heart container or piece
-    // if (getItemEntry.gid == GID_HEART_CONTAINER || getItemEntry.gid == GID_HEART_PIECE) {
-    //     gSaveContext.healthAccumulator = 0x140;
-    // }
-
-    //// Handle if the player gets a 4th heart piece (usually handled in z_message)
-    // s32 heartPieces = (s32)(gSaveContext.inventory.questItems & 0xF0000000) >> (QUEST_HEART_PIECE + 4);
-    // if (heartPieces >= 4) {
-    //     gSaveContext.inventory.questItems &= ~0xF0000000;
-    //     gSaveContext.inventory.questItems += (heartPieces % 4) << (QUEST_HEART_PIECE + 4);
-    //     gSaveContext.healthCapacity += 0x10 * (heartPieces / 4);
-    //     gSaveContext.health += 0x10 * (heartPieces / 4);
-    // }
-
-    // if (getItemEntry.getItemCategory != ITEM_CATEGORY_JUNK) {
-    //     if (getItemEntry.modIndex == MOD_NONE) {
-    //         Notification::Emit({
-    //             .itemIcon = GetTextureForItemId(getItemEntry.itemId),
-    //             .prefix = client.name,
-    //             .message = "found",
-    //             .suffix = SohUtils::GetItemName(getItemEntry.itemId),
-    //         });
-    //     } else if (getItemEntry.modIndex == MOD_RANDOMIZER) {
-    //         Notification::Emit({
-    //             .prefix = client.name,
-    //             .message = "found",
-    //             .suffix = Rando::StaticData::RetrieveItem((RandomizerGet)getItemEntry.getItemId).GetName().english,
-    //         });
-    //     }
-    // }
+    ItemQueue::GiveItem((RandoItemId)getItemId);
+    // Self-gates on the rando notification CVar, same as a local pickup.
+    ItemQueue::SendNotification((RandoItemId)getItemId);
 }


### PR DESCRIPTION
`HandlePacket_GiveItem` is a commented-out stub carried over from Ship of Harkinian, so a `GIVE_ITEM` packet that arrives from a remote item source is parsed and then dropped. This implements the receive side against the randomizer item queue so the item actually lands in the player's save.

This replaces #504, which changed the packet contract. That turned out to be unnecessary, so this version keeps the existing contract and is much smaller.

## What changed

One file, `src/port/Network/Anchor/Packets/GiveItem.cpp`. `Anchor.h` is untouched.

`SendPacket_GiveItem` keeps its `(u16 modId, s16 getItemId)` signature and the payload keeps its `modId` and `getItemId` fields, so any existing sender keeps working. The send path is otherwise unchanged apart from dropping commented-out OoT logic (ice traps, the Ganon boss scene) and the unused `incomingIceTrapsFromAnchor` global that only that dead code referenced.

## Packet contract

`modId` selects which item table `getItemId` belongs to. It keeps the meaning it had in the packet this file inherited:

| `modId` | meaning |
|---|---|
| `0` | vanilla item table, not implemented here, dropped |
| `1` | randomizer item table, `getItemId` is a `RandoItemId` |

Only the randomizer table is implemented. A packet with any other `modId` is dropped rather than guessed at, which leaves room for the vanilla table later without changing the wire format.

## Validation

The handler uses the same guards as the other world packets: `IS_RANDO`, `IsSaveLoaded()`, and `roomState.syncItemsAndFlags`.

`getItemId` is read into an `s32` and checked with `getItemId <= RI_UNKNOWN || getItemId >= RI_MAX` before anything uses it. Reading into a wider type first means an out of range value is rejected instead of wrapping into a valid id. The check matters because `ItemQueue` and `StaticData` index `Items[]` with this value directly, so a malformed or stale packet must not reach them.

Missing fields fall back to defaults that fail validation, and a field of the wrong JSON type throws inside the `try` block in `Anchor::ProcessIncomingPackets`, so neither case reaches the item queue.

There is no explicit `IsGlobalRoom()` guard because the existing code already covers it. `HandlePacket_UpdateRoomState` forces `syncItemsAndFlags` to `0` when `IsGlobalRoom()`, and `GIVE_ITEM` is not in `AllowedWithoutGameSync`, so `OnIncomingJson` drops the packet before dispatch. Adding a second check would only restate that.

## Idempotency

A grant is a delta, not a set. Counts increment and the next free jiggy or honeycomb slot is taken, so nothing here deduplicates. The same packet delivered twice grants the item twice, and a grant cannot be taken back. At-most-once delivery is the sender's responsibility.

## Notifications

`ItemQueue::SendNotification` self gates on the randomizer notification CVar, so a remote grant is announced on the same terms as a local pickup.

## Testing

`clang-format` 14 is clean on the changed file. The repo has no test harness, so nothing was added there.

I have not compiled this locally. The machine I am on has no C++ toolchain installed, so I am relying on the CI build. The change is one translation unit and only calls existing public APIs (`ItemQueue::GiveItem`, `ItemQueue::SendNotification`), so please flag anything the build catches and I will fix it.
