### PR TITLE
Two bug fixes taken from the Vita fork

### DIFF
--- a/src/port/Resource/Type/Sprite.cpp
+++ b/src/port/Resource/Type/Sprite.cpp
@@ -26,25 +26,25 @@ void Sprite::BuildSpriteStructure() {
     for (int frameIdx = 0; frameIdx < frameCount; frameIdx++) {
         const auto& frameData = frames[frameIdx];
 
-        size_t frameSize = sizeof(BKSpriteFrame);
+        size_t frameStart = totalSize;
+        size_t cursor = frameStart + sizeof(BKSpriteFrame);
 
         if (!frameData.paletteData.empty()) {
-            // Palette must be at Align8(sizeof(BKSpriteFrame)) = offset 24.
-            // print_getLettersFromFont aligns (frame_ptr+1) to 8 before reading palette,
-            // and spriteRender_drawWithSegment does the same.
-            frameSize = Align8(frameSize);
-            frameSize += frameData.paletteData.size();
+            // Palette must start at the next 8-byte boundary from basePtr.
+            cursor = Align8(cursor);
+            cursor += frameData.paletteData.size();
         }
 
         for (const auto& chunk : frameData.chunks) {
-            frameSize += sizeof(BKSpriteTextureBlock);
-            frameSize = Align8(frameSize);
-            frameSize += chunk.textureData.size();
+            cursor += sizeof(BKSpriteTextureBlock);
+            cursor = Align8(cursor);
+            cursor += chunk.textureData.size();
         }
 
+        size_t frameSize = cursor - frameStart;
         frameSizes.push_back(frameSize);
-        frameOffsets.push_back(totalSize);
-        totalSize += frameSize;
+        frameOffsets.push_back(frameStart);
+        totalSize = frameStart + frameSize;
     }
 
     // Allocate single contiguous buffer for entire sprite
@@ -84,11 +84,9 @@ void Sprite::BuildSpriteStructure() {
         *frame = frameData.frameHeader;
         offset += sizeof(BKSpriteFrame);
 
-        // Write palette at Align8(sizeof(BKSpriteFrame)) = offset 24.
-        // Both print_getLettersFromFont and spriteRender_drawWithSegment walk (frame_ptr+1)
-        // up to the next 8-byte alignment before reading the palette.
+        // Write palette at the next 8-byte boundary from basePtr.
         if (!frameData.paletteData.empty()) {
-            offset = Align8(offset);
+            offset = Align8(frameOffset + offset) - frameOffset;
             std::memcpy(framePtr + offset, frameData.paletteData.data(), frameData.paletteData.size());
             offset += frameData.paletteData.size();
         }
@@ -111,7 +109,7 @@ void Sprite::BuildSpriteStructure() {
             }
 
             // Write texture data
-            offset = Align8(offset);
+            offset = Align8(frameOffset + offset) - frameOffset;
             std::memcpy(framePtr + offset, chunkData.textureData.data(), chunkData.textureData.size());
 
             // [port] RGBA16 texture data stays in N64 big-endian byte order.

--- a/src/port/Save/SaveManager.cpp
+++ b/src/port/Save/SaveManager.cpp
@@ -8,6 +8,8 @@
 #include "port/UI/cvar_prefixes.h"
 #include "port/UI/LighthouseModMenuWindow.h"
 #include "port/UI/Notification.h"
+#include <cstddef>
+#include <cstring>
 #include <fstream>
 #include <filesystem>
 #include <regex>
@@ -889,17 +891,7 @@ void SaveManager_Init() {
     REGISTER_LISTENER(OnSaveClear, EVENT_PRIORITY_NORMAL, [](IEvent* event) {
         OnSaveClear* ev = (OnSaveClear*)event;
         SaveData* saveData = (SaveData*)ev->result;
-
-        ShipSaveData ship = saveData->shipSaveData; // Retain ShipSaveData during Save Process
-
-        u8* savedata = (u8*)saveData;
-        int i;
-        for (i = 0; i < sizeof(SaveData); i++) {
-            savedata[i] = 0;
-        }
-
-        saveData = (SaveData*)savedata;
-        saveData->shipSaveData = ship;
+        memset(saveData, 0, offsetof(SaveData, shipSaveData));
 
         event->Cancelled = true;
     });


### PR DESCRIPTION
- Sprite frame palettes and texture data were aligned relative to the start of each frame, but the game reads them at the next 8-byte boundary of the absolute address, so any frame whose start offset wasn't itself 8-aligned had its palette read 4 bytes off. (https://github.com/Rinnegatamante/Lighthouse/commit/994273b0a866fa566b5c027df6e4192329e16b33)
- Clearing a save file copied the ~42KB `ShipSaveData` block to a stack local and back around the zeroing pass, which is now done by zeroing only the bytes ahead of it in `SaveData` instead for the same result, no copy.

Re: misaligned sprite read/write, frame 0 is always 8-aligned on 64-bit (`sizeof(BKSprite) 16 + n×8`), so on desktop this only hits frames after one whose texture data length isn't a multiple of 8, with font glyphs being the likely case. On 32-bit the frame pointer array is 4 bytes per entry, so an odd frame count misaligns frame 0 too. 32-bit just notices the bug more quickly.

<!--- section:artifacts:start -->
### Build Artifacts
  - [Lighthouse-mac.zip](https://nightly.link/HarbourMasters/Lighthouse/actions/artifacts/9268527867.zip)
  - [Lighthouse-windows.zip](https://nightly.link/HarbourMasters/Lighthouse/actions/artifacts/9267899549.zip)
  - [Lighthouse-linux.zip](https://nightly.link/HarbourMasters/Lighthouse/actions/artifacts/9267751218.zip)
<!--- section:artifacts:end -->