### PR TITLE
Widen the actorlocal struct for 64-bit

### DIFF
--- a/include/prop.h
+++ b/include/prop.h
@@ -230,8 +230,9 @@ typedef struct actor_s{
         ActorLocal_Jinjo jinjo;
         ActorLocal_SM_4070 sm_4070;
         u8  local[1];
-        struct{ 
-            u8  unk7C[0x40];
+        struct{
+//          u8  unk7C[0x40];
+            u8  unk7C[0x70];
             u8  unkBC[0x30];
         };
         

--- a/src/core2/actor_array.c
+++ b/src/core2/actor_array.c
@@ -957,7 +957,8 @@ Actor *actor_new(s32 position[3], s32 yaw, ActorInfo* actorInfo, u32 flags){
     suLastBaddie->alpha_124_19 = 0xff;
     suLastBaddie->depth_mode = MODEL_RENDER_DEPTH_FULL;
     suLastBaddie->unk124_0 = suLastBaddie->unk138_31 = 1;
-    for(i = 0; i < 0x10; i++){
+//  for(i = 0; i < 0x10; i++){
+    for(i = 0; i < 0x1C; i++){ // [port] unk7C widened to 0x70
         ((s32 *)suLastBaddie->unk7C)[i] = 0;
     }
     for(i = 0; i < 0x0C; i++){


### PR DESCRIPTION
Actor-local scratch overflows into the Bundle struct on 64-bit. A sister to #470, which correctly guards an id going in at spawn by clamping `collision_getUnkBit7(arg2)` to 5. This pull request guards that id being overwritten afterwards by the actor's own local.

<!--- section:artifacts:start -->
### Build Artifacts
  - [Lighthouse-windows.zip](https://nightly.link/HarbourMasters/Lighthouse/actions/artifacts/9300477914.zip)
  - [Lighthouse-linux.zip](https://nightly.link/HarbourMasters/Lighthouse/actions/artifacts/9300343643.zip)
  - [Lighthouse-mac.zip](https://nightly.link/HarbourMasters/Lighthouse/actions/artifacts/9300242916.zip)
<!--- section:artifacts:end -->