### PR TITLE
Visual polish for ultrawide and shadows

### DIFF
--- a/src/core2/fx/badShad.c
+++ b/src/core2/fx/badShad.c
@@ -73,6 +73,7 @@ f32 func_802D7038(Actor *this) {
         D_8037DE10[0] = this->spawn_position[0];
         D_8037DE10[1] = this->spawn_position[1];
         D_8037DE10[2] = this->spawn_position[2];
+        ml_vec3f_clear(D_8037DE20); // [port] Clear any previous math from leaked actors
     } else {
         this->spawn_position[0] = this->position[0];
         this->spawn_position[2] = this->position[2];
@@ -96,7 +97,8 @@ void func_802D7124(Actor *actor, f32 arg1) {
     f32 mul = port_drawDistanceMul();
 
     viewport_getPosition_vec3f(vp);
-    if ((actor->position[0] - vp[0]) * (actor->position[0] - vp[0]) + (actor->position[2] - vp[2]) * (actor->position[2] - vp[2]) < 12250000.0f * mul * mul) {
+    if (port_shouldDisableLOD()
+        || (actor->position[0] - vp[0]) * (actor->position[0] - vp[0]) + (actor->position[2] - vp[2]) * (actor->position[2] - vp[2]) < 12250000.0f * mul * mul) {
         func_802D729C(actor, arg1);
     }
 }

--- a/src/core2/gc/bound.c
+++ b/src/core2/gc/bound.c
@@ -3,6 +3,7 @@
 #include "functions.h"
 #include "variables.h"
 #include "gc/gcbound.h"
+#include "port/Engine.h"
 
 /* .data */
 extern s32 D_803688E0 = 0; //_gcBoundAlpha
@@ -27,8 +28,9 @@ u8 _gcbound_blue; //D_80380902
 void  _gcbound_draw(Gfx** dl, s32 a, s32 r, s32 g, s32 b){
     gSPDisplayList((*dl)++, D_803688E8);
     gDPSetPrimColor((*dl)++, 0, 0, r, g, b, a);
-    // [port] Overscan past the 4:3 native bounds so the fade still fills the screen
-    gSPWideTextureRectangle((*dl)++, -1024, -1024, 2048, 2048, 0, 0, 0, 0x100, 0x100);
+    gSPWideTextureRectangle((*dl)++, OTRGetRectDimensionFromLeftEdge(0) << 2, -1024,
+                            OTRGetRectDimensionFromRightEdge((f32)gFramebufferWidth) << 2, 2048, 0, 0, 0, 0x100,
+                            0x100);
 }
 
 void gcbound_draw(Gfx** dl){

--- a/src/core2/model/modelRender.c
+++ b/src/core2/model/modelRender.c
@@ -1127,7 +1127,8 @@ BKModelBin *modelRender_draw(Gfx **gfx, Mtx **mtx, f32 position[3], f32 rotation
         spD4 = sSecondaryModelData.unk4;
     }
     camera_focus_distance = gu_sqrtf(camera_focus[0]*camera_focus[0] + camera_focus[1]*camera_focus[1] + camera_focus[2]*camera_focus[2]);
-    if( 4000.0f <= camera_focus_distance && spD4*scale*D_8038370C*50.0f < D_80383708){
+//  if( 4000.0f <= camera_focus_distance && spD4*scale*D_8038370C*50.0f < D_80383708){
+    if( !port_shouldDisableLOD() && 4000.0f <= camera_focus_distance && spD4*scale*D_8038370C*50.0f < D_80383708){
         D_80383708 = spD4*scale*D_8038370C*50.0f;
     }
 

--- a/src/port/Patches/CameraPatches.cpp
+++ b/src/port/Patches/CameraPatches.cpp
@@ -11,6 +11,7 @@
 #include "functions.h"
 #include "variables.h"
 
+#include <algorithm>
 #include <cmath>
 
 #ifndef M_PI
@@ -260,16 +261,25 @@ void RegisterCameraPatches_Init() {
             return;
         }
         auto* ev = (ViewportFrustumUpdate*)event;
-        const float kFrustumZ = 45.168514251708984f;
-        const float kMargin = 1.10f;
+        const float kDegToRad = (float)(M_PI / 180.0);
+        const float kFrustumZX = 45.168514251708984f;  // must match viewport.c
+        const float kFrustumZY = 34.20201110839844f;   // must match viewport.c
+        const float kVanillaFrustumX = 89.21774f;      // must match viewport_update()
+        const float kVanillaFrustumY = 93.9692611694336f;
+        const float kPad = 3.0f * kDegToRad; // slack that keeps actors from popping in at the edge
+        const float kMaxHalfAngle = 88.0f * kDegToRad;
+
+        float halfFovY = (sViewportFOVy * 0.5f) * kDegToRad;
         float aspect = GameEngine_GetAspectRatio();
-        if (aspect < sViewportAspect) {
-            aspect = sViewportAspect;
-        }
-        float halfFovYRad = (sViewportFOVy * 0.5f) * (float)(M_PI / 180.0);
-        float halfFovXRad = std::atan(std::tan(halfFovYRad) * aspect * kMargin);
-        *ev->frustumX = kFrustumZ / std::tan(halfFovXRad);
-        *ev->frustumY = 93.9692611694336f * 1.15f;
+        float visibleTanX = std::tan(halfFovY) * (sViewportAspect / (4.0f / 3.0f)) * aspect;
+
+        float halfX = std::max(std::atan(visibleTanX) + kPad, std::atan(kFrustumZX / kVanillaFrustumX));
+        float halfY = std::max(halfFovY + kPad, std::atan(kFrustumZY / kVanillaFrustumY));
+        halfX = std::min(halfX, kMaxHalfAngle);
+        halfY = std::min(halfY, kMaxHalfAngle);
+
+        *ev->frustumX = kFrustumZX / std::tan(halfX);
+        *ev->frustumY = kFrustumZY / std::tan(halfY);
     });
 }
 

--- a/src/port/Patches/CameraPatches.cpp
+++ b/src/port/Patches/CameraPatches.cpp
@@ -262,9 +262,9 @@ void RegisterCameraPatches_Init() {
         }
         auto* ev = (ViewportFrustumUpdate*)event;
         const float kDegToRad = (float)(M_PI / 180.0);
-        const float kFrustumZX = 45.168514251708984f;  // must match viewport.c
-        const float kFrustumZY = 34.20201110839844f;   // must match viewport.c
-        const float kVanillaFrustumX = 89.21774f;      // must match viewport_update()
+        const float kFrustumZX = 45.168514251708984f; // must match viewport.c
+        const float kFrustumZY = 34.20201110839844f;  // must match viewport.c
+        const float kVanillaFrustumX = 89.21774f;     // must match viewport_update()
         const float kVanillaFrustumY = 93.9692611694336f;
         const float kPad = 3.0f * kDegToRad; // slack that keeps actors from popping in at the edge
         const float kMaxHalfAngle = 88.0f * kDegToRad;

--- a/src/port/Patches/GraphicsPatches.cpp
+++ b/src/port/Patches/GraphicsPatches.cpp
@@ -95,6 +95,9 @@ int port_spriteSizeCulled(float depth, float size, float baseThreshold, int disa
 }
 
 int port_shouldDisableLOD(void) {
+    if (IsDemoMode() && getGameMode() != GAME_MODE_4_PAUSED) {
+        return 0;
+    }
     return sDisableLOD;
 }
 }


### PR DESCRIPTION
May resolve #515, should be tested on real ultrawide hardware.

- DisableLOD forced off for demos, with intent to preserve determinism
- Modify viewport frustum math similar to previous camerapatches update for dynamic frustum scaling
- Fix shadows using stale slope math from previous actor in list (most noticed with Quarries in SM)
- Try fixing the overscan math for the tint rectangle (underwater, transitions etc)

<!--- section:artifacts:start -->
### Build Artifacts
  - [Lighthouse-windows.zip](https://nightly.link/HarbourMasters/Lighthouse/actions/artifacts/9302901021.zip)
  - [Lighthouse-linux.zip](https://nightly.link/HarbourMasters/Lighthouse/actions/artifacts/9302595739.zip)
  - [Lighthouse-mac.zip](https://nightly.link/HarbourMasters/Lighthouse/actions/artifacts/9302177770.zip)
<!--- section:artifacts:end -->