### PR TITLE
Fix Chimpy softlock in Anchor

### DIFF
--- a/src/port/Enhancements/Events/Hooks/List/GameEvent.h
+++ b/src/port/Enhancements/Events/Hooks/List/GameEvent.h
@@ -16,6 +16,8 @@ DEFINE_EVENT(OnGameFlagSet, int32_t flagSpace; int32_t index; int32_t value; int
 DEFINE_EVENT(OnItemCountChanged, int32_t item; int32_t count;)
 // kind = AnchorCollectibleSpace.
 DEFINE_EVENT(OnCollectibleCollected, int32_t kind; int32_t id;)
+// A carried actor leaving the player's hands; markerId = marker_e, start/target are f32[3].
+DEFINE_EVENT(OnCarryThrow, int32_t markerId; float* start; float* target;)
 // move = ability_e; value = 1 learned, 0 cleared.
 DEFINE_EVENT(OnAbilityLearned, int32_t move; int32_t value;)
 DEFINE_EVENT(OnJiggySpawned, int32_t jiggyId; float x; float y; float z;)

--- a/src/port/Enhancements/Events/PortEnhancements.cpp
+++ b/src/port/Enhancements/Events/PortEnhancements.cpp
@@ -83,6 +83,7 @@ void PortEnhancements_Register() {
     REGISTER_EVENT(OnGameFlagSet);
     REGISTER_EVENT(OnItemCountChanged);
     REGISTER_EVENT(OnCollectibleCollected);
+    REGISTER_EVENT(OnCarryThrow);
     REGISTER_EVENT(OnAbilityLearned);
     REGISTER_EVENT(OnJiggySpawned);
     REGISTER_EVENT(OnHoneycombDropSpawn);

--- a/src/port/Enhancements/Fixes/GameFixes.cpp
+++ b/src/port/Enhancements/Fixes/GameFixes.cpp
@@ -164,6 +164,43 @@ void RegisterChimpyStumpRumble_Init() {
     });
 }
 
+// Chimpy softlock prevention
+static bool sChimpyDeliveryInFlight = false;
+
+// Lazily expires the in-flight flag.
+static bool ChimpyDeliveryStillInFlight() {
+    if (sChimpyDeliveryInFlight) {
+        sChimpyDeliveryInFlight =
+            gsworld_getMap() == MAP_2_MM_MUMBOS_MOUNTAIN && !mapSpecificFlags_get(MM_SPECIFIC_FLAG_3_CHIMPY_HAS_LEFT);
+    }
+    return sChimpyDeliveryInFlight;
+}
+
+void RegisterChimpySoftlock_Init() {
+    REGISTER_LISTENER(OnCarryThrow, EVENT_PRIORITY_NORMAL, [](IEvent* event) {
+        auto* ev = reinterpret_cast<OnCarryThrow*>(event);
+
+        if (ev->markerId == MARKER_36_ORANGE_COLLECTIBLE && gsworld_getMap() == MAP_2_MM_MUMBOS_MOUNTAIN) {
+            sChimpyDeliveryInFlight = true;
+        }
+    });
+
+    REGISTER_LISTENER(OnIsJiggyScoreSpawned, EVENT_PRIORITY_HIGH, [](IEvent* event) {
+        auto* ev = reinterpret_cast<OnIsJiggyScoreSpawned*>(event);
+
+        if (ev->jiggyId == JIGGY_9_MM_CHIMPY && ChimpyDeliveryStillInFlight()) {
+            event->Cancelled = true;
+            ev->result = 0;
+        }
+    });
+
+    REGISTER_VB_SHOULD(VB_OVERRIDE_JIGGY_SPAWN, EVENT_PRIORITY_LOW, {
+        if (va_arg(args, int) == JIGGY_9_MM_CHIMPY && jiggyscore_isCollected(JIGGY_9_MM_CHIMPY)) {
+            *should = true;
+        }
+    });
+}
+
 // Mumbo token duplicate-id fix: rewrite the resolved id for the two tokens that share an id.
 void RegisterMumboTokenIdResolve_Init() {
     COND_HOOK(OnMumboTokenIdResolve, EVENT_PRIORITY_NORMAL,
@@ -213,5 +250,6 @@ static RegisterShipInitFunc initGruntyBounceFunc(RegisterGruntyBounce_Init, { CV
 static RegisterShipInitFunc initYumYumDropFunc(RegisterYumYumDrop_Init);
 static RegisterShipInitFunc initCongaDialogFunc(RegisterCongaDialog_Init, { CVAR_CONGA_TEXT });
 static RegisterShipInitFunc initChimpyStumpRumbleFunc(RegisterChimpyStumpRumble_Init, { CVAR_STUMP_RUMBLE });
+static RegisterShipInitFunc initChimpySoftlockFunc(RegisterChimpySoftlock_Init);
 static RegisterShipInitFunc initMumboTokenIdResolveFunc(RegisterMumboTokenIdResolve_Init,
                                                         { CVAR_TOKEN_MMM, CVAR_TOKEN_CCW });

--- a/src/port/Network/Anchor/Packets/CarryThrow.cpp
+++ b/src/port/Network/Anchor/Packets/CarryThrow.cpp
@@ -41,6 +41,8 @@ void Anchor::HandlePacket_CarryThrow(nlohmann::json& payload) {
 }
 
 extern "C" void port_anchor_onCarryThrow(s32 markerId, f32 start[3], f32 target[3]) {
+    CALL_EVENT(OnCarryThrow, markerId, start, target);
+
     Anchor* anchor = Anchor::GetInstance();
     if (anchor == nullptr || !anchor->isConnected) {
         return;


### PR DESCRIPTION
This attempts to address the Chimpy anchor softlock.

- Holds `jiggyscore_isSpawned(JIGGY_9)` false for the couple of seconds a local delivery is playing out; the orange throw is the only way in, Chimpy walking off or the map going away the only way out
- Rando's answer for `RC_MM_JIGGY_CHIMPY` drops the `.obtained` term that `AdoptRemoteCheck` flips mid-map
- Refuses a second `Jiggy #9` when the team already has one, so finishing the scene late can't double up

<!--- section:artifacts:start -->
### Build Artifacts
  - [Lighthouse-windows.zip](https://nightly.link/HarbourMasters/Lighthouse/actions/artifacts/9304518551.zip)
  - [Lighthouse-linux.zip](https://nightly.link/HarbourMasters/Lighthouse/actions/artifacts/9304248030.zip)
  - [Lighthouse-mac.zip](https://nightly.link/HarbourMasters/Lighthouse/actions/artifacts/9303954726.zip)
<!--- section:artifacts:end -->