### PR TITLE
Fix uncollectible bundle notes after a witch switch cutscene in rando

### DIFF
--- a/src/port/Rando/ObjectBehavior/ObjectBehavior.cpp
+++ b/src/port/Rando/ObjectBehavior/ObjectBehavior.cpp
@@ -305,9 +305,9 @@ void Rando::ObjectBehavior::Init() {
             return;
         }
 
-        randoSaveState.insert(
-            { (RandoCheckId)ev->actor->marker->randoCheckId,
-              { ev->actor->marker->propPtr->x, ev->actor->marker->propPtr->y, ev->actor->marker->propPtr->z } });
+        randoSaveState[(RandoCheckId)ev->actor->marker->randoCheckId] =
+            std::make_tuple((int32_t)ev->actor->marker->propPtr->x, (int32_t)ev->actor->marker->propPtr->y,
+                            (int32_t)ev->actor->marker->propPtr->z);
     })
 
     COND_HOOK(OnLoadActorSaveState, EVENT_PRIORITY_NORMAL, IS_RANDO, [](IEvent* event) {
@@ -345,6 +345,7 @@ void Rando::ObjectBehavior::Init() {
         // The check already has a live actor. Restoring would stack a second one on
         // top of it, so drop the restore entirely.
         if (CustomObject::CheckSpawnedIdList(randoCheckId)) {
+            randoSaveState.erase(randoCheckId);
             event->Cancelled = true;
             return;
         }


### PR DESCRIPTION
Witch-switch cutscenes restore the world's map savestate, and rando's position lookup for restored checks kept a stale entry, so bundle notes (BGS mud hut) came back without a check id and couldn't be picked up.

<!--- section:artifacts:start -->
### Build Artifacts
  - [Lighthouse-windows.zip](https://nightly.link/HarbourMasters/Lighthouse/actions/artifacts/9306544857.zip)
  - [Lighthouse-linux.zip](https://nightly.link/HarbourMasters/Lighthouse/actions/artifacts/9306194062.zip)
  - [Lighthouse-mac.zip](https://nightly.link/HarbourMasters/Lighthouse/actions/artifacts/9306008933.zip)
<!--- section:artifacts:end -->