### PR TITLE
Resolve anchor bugs in #525, #526, and #528

### DIFF
--- a/src/port/Network/Anchor/Anchor.h
+++ b/src/port/Network/Anchor/Anchor.h
@@ -232,6 +232,8 @@ public:
 
     void SendPacket_AuthorityState(u8 activity, bool claimed);
     void SendPacket_ClearTeamState(std::string teamId);
+    void ClearMismatchedTeamState(std::string teamId);
+    bool LocalGameMatchesRoom();
     void SendPacket_DamagePlayer(u32 clientId, u8 damageEffect, u8 damage);
     void SendPacket_EntranceDiscovered(u16 entranceIndex);
     void SendPacket_GameComplete();

--- a/src/port/Network/Anchor/Anchor.h
+++ b/src/port/Network/Anchor/Anchor.h
@@ -193,6 +193,8 @@ public:
     RoomState roomState;
     std::string lastWarnedRomhackLabel;
     std::string lastWarnedRandoState;
+    std::string lastClearedTeamStateSig;
+    bool gameMismatchWithTeam = false;
     bool hasCheckedRandoCompat = false;
 
     void Enable();

--- a/src/port/Network/Anchor/HookHandlers.cpp
+++ b/src/port/Network/Anchor/HookHandlers.cpp
@@ -26,6 +26,7 @@ extern "C" void port_fpTwinkly_release(void) {
 }
 
 s32 Anchor_LevelOfMap(s32 map);
+void Anchor_DespawnCollectedCollectibles();
 
 // Every listener below that alters vanilla behaviour is wrapped in this. Presence-only rooms
 // (the global room, or sync turned off) must play exactly like single player.
@@ -194,6 +195,7 @@ void Anchor::RegisterHooks() {
         auto* anchor = Anchor::GetInstance();
         if (Anchor_WorldSyncActive() && ev->nextMap != MAP_91_FILE_SELECT && ev->nextMap != MAP_1E_CS_START_NINTENDO &&
             ev->nextMap != MAP_1F_CS_START_RAREWARE) {
+            Anchor_DespawnCollectedCollectibles();
             anchor->SendPacket_RequestScopedState((GameMap)ev->nextMap);
 
             s32 enteredFlag = -1;
@@ -242,6 +244,7 @@ void Anchor::RegisterHooks() {
         auto* anchor = Anchor::GetInstance();
         anchor->hasCheckedRandoCompat = false;
         anchor->reloadMapOnTeamState = false;
+        anchor->gameMismatchWithTeam = false;
         anchor->SendPacket_RequestTeamState(true);
     });
 

--- a/src/port/Network/Anchor/HookHandlers.cpp
+++ b/src/port/Network/Anchor/HookHandlers.cpp
@@ -240,11 +240,10 @@ void Anchor::RegisterHooks() {
         Anchor::GetInstance()->SendPacket_MapLoad((GameMap)getDefaultBootMap(), gsworld_getExit());
     });
 
-    COND_HOOK(OnGameLoad, EVENT_PRIORITY_NORMAL, isConnected, [](IEvent* event) {
+    COND_HOOK(OnGameStart, EVENT_PRIORITY_NORMAL, isConnected, [](IEvent* event) {
         auto* anchor = Anchor::GetInstance();
         anchor->hasCheckedRandoCompat = false;
         anchor->reloadMapOnTeamState = false;
-        anchor->gameMismatchWithTeam = false;
         anchor->SendPacket_RequestTeamState(true);
     });
 

--- a/src/port/Network/Anchor/Menu.cpp
+++ b/src/port/Network/Anchor/Menu.cpp
@@ -279,6 +279,16 @@ void AnchorAdminMenu(WidgetInfo& info) {
     }
     UIWidgets::PopStyleButton();
 
+    UIWidgets::CVarCheckbox(
+        "Clear Mismatched Team State Without Asking", CVAR_REMOTE_ANCHOR("RoomSettings.AutoClearMismatchedState"),
+        UIWidgets::CheckboxOptions()
+            .DefaultValue(false)
+            .Color(THEME_COLOR)
+            .Tooltip(
+                "A team save recorded under a different game is never applied to your file. By default you're asked "
+                "whether to clear the copy the server is holding; enable this to clear it without asking. Only applies "
+                "to you as the room owner, and never while a teammate is playing from that save."));
+
     // if (UIWidgets::CVarCombobox("PvP Mode:", CVAR_REMOTE_ANCHOR("RoomSettings.PvpMode"), pvpModes,
     //                             UIWidgets::ComboboxOptions()
     //                                 .DefaultIndex(1)

--- a/src/port/Network/Anchor/Menu.cpp
+++ b/src/port/Network/Anchor/Menu.cpp
@@ -274,6 +274,7 @@ void AnchorAdminMenu(WidgetInfo& info) {
         anchor->roomState.seed = IS_RANDO ? (int32_t)RANDO_SEED : 0;
         anchor->lastWarnedRomhackLabel.clear();
         anchor->lastWarnedRandoState.clear();
+        anchor->lastClearedTeamStateSig.clear();
         anchor->SendPacket_UpdateRoomState();
     }
     UIWidgets::PopStyleButton();

--- a/src/port/Network/Anchor/Packets/CollectItem.cpp
+++ b/src/port/Network/Anchor/Packets/CollectItem.cpp
@@ -13,6 +13,33 @@ static const char* const kJiggyLevelNames[10] = {
     "Gruntilda's Lair", "Gobi's Valley",       "Click Clock Wood", "Rusty Bucket Bay",  "Mad Monster Mansion",
 };
 
+void Anchor_DespawnCollectedCollectibles() {
+    for (s32 id = 1; id < 0x65; id++) {
+        if (port_jiggyscore_isCollectedRaw((enum jiggy_e)id)) {
+            ActorMarker* m = func_8032B16C((enum jiggy_e)id);
+            if (m != nullptr) {
+                marker_despawn(m);
+            }
+        }
+    }
+    for (s32 id = 1; id < 0x19; id++) { // HONEYCOMB_COUNT
+        if (port_honeycombscore_getRaw((enum honeycomb_e)id)) {
+            ActorMarker* m = actorArray_findHoneycombMarkerById((enum honeycomb_e)id);
+            if (m != nullptr) {
+                marker_despawn(m);
+            }
+        }
+    }
+    for (s32 id = 1; id < 126; id++) { // MUMBO_TOKEN_COUNT
+        if (mumboscore_get((enum mumbotoken_e)id)) {
+            ActorMarker* m = actorArray_findMumboTokenMarkerById((enum mumbotoken_e)id);
+            if (m != nullptr) {
+                marker_despawn(m);
+            }
+        }
+    }
+}
+
 /**
  * COLLECT_ITEM
  */

--- a/src/port/Network/Anchor/Packets/RequestTeamState.cpp
+++ b/src/port/Network/Anchor/Packets/RequestTeamState.cpp
@@ -16,8 +16,8 @@
  */
 
 void Anchor::SendPacket_RequestTeamState(bool force) {
-    // `force` bypasses the IsSaveLoaded check: OnGameLoad fires from gameFile_load while the map is
-    // still FILE_SELECT, so the save is loading but IsSaveLoaded() is still false.
+    // `force` bypasses the IsSaveLoaded check: OnGameStart fires from the file-select state machine
+    // while the map is still FILE_SELECT, so the save is loaded but IsSaveLoaded() is still false.
     if ((!force && !IsSaveLoaded()) || !roomState.syncItemsAndFlags) {
         return;
     }

--- a/src/port/Network/Anchor/Packets/SetItemCount.cpp
+++ b/src/port/Network/Anchor/Packets/SetItemCount.cpp
@@ -36,10 +36,10 @@ void Anchor::HandlePacket_SetItemCount(nlohmann::json& payload) {
     s16 item = payload.at("item").get<s16>();
     s32 count = payload.at("count").get<s32>();
 
-    // Jiggy-total increase is a teammate's collect: apply silently (paired COLLECT_ITEM pops the
-    // HUD counter). Decreases (pedestal spends) keep the vanilla total pop.
-    if (item == ITEM_26_JIGGY_TOTAL && count > item_getCount(ITEM_26_JIGGY_TOTAL)) {
-        item_adjustByDiff((enum item_e)item, count - item_getCount(ITEM_26_JIGGY_TOTAL), 1, 0);
+    if (item == ITEM_26_JIGGY_TOTAL) {
+        s32 delta = count - item_getCount(ITEM_26_JIGGY_TOTAL);
+        s32 noHud = (delta > 0 || func_802FADD4(ITEM_2B_UNKNOWN)) ? 1 : 0;
+        item_adjustByDiff((enum item_e)item, delta, noHud, 0);
         return;
     }
 

--- a/src/port/Network/Anchor/Packets/UpdateRoomState.cpp
+++ b/src/port/Network/Anchor/Packets/UpdateRoomState.cpp
@@ -7,6 +7,7 @@
 #include "port/Rando/Rando.h"
 #include "port/UI/LighthouseGui.hpp"
 #include "port/UI/LighthouseModals.h"
+#include "port/UI/Notification.h"
 
 #include "variables.h"
 
@@ -38,8 +39,13 @@ nlohmann::json Anchor::PrepRoomState() {
     payload["shareConsumables"] = CVarGetInteger(CVAR_REMOTE_ANCHOR("RoomSettings.ShareConsumables"), 0);
     payload["isRomHack"] = port_isRomhack();
     payload["romhackName"] = Lighthouse::CurrentRomhackLabel();
-    payload["isRando"] = (bool)IS_RANDO;
-    payload["seed"] = (int32_t)(IS_RANDO ? RANDO_SEED : 0);
+    if (selectedFileNum != DEFAULT_FILE_NUM) {
+        payload["isRando"] = (bool)IS_RANDO;
+        payload["seed"] = (int32_t)(IS_RANDO ? RANDO_SEED : 0);
+    } else {
+        payload["isRando"] = roomState.isRando;
+        payload["seed"] = roomState.seed;
+    }
 
     return payload;
 }
@@ -71,9 +77,19 @@ void Anchor::HandlePacket_UpdateRoomState(nlohmann::json& payload) {
 
     roomState.isRomhack = payload["state"]["isRomHack"].get<bool>();
     roomState.romhackName = payload["state"]["romhackName"].get<std::string>();
+    roomState.ownerClientId = payload["state"]["ownerClientId"].get<uint32_t>();
     const std::string localLabel = Lighthouse::CurrentRomhackLabel();
     if (roomState.romhackName != localLabel) {
-        if (roomState.romhackName != lastWarnedRomhackLabel) {
+        // Only act on ownership the server has actually handed out.
+        if (ownClientId != 0 && roomState.ownerClientId == ownClientId) {
+            roomState.isRomhack = port_isRomhack();
+            roomState.romhackName = localLabel;
+            lastWarnedRomhackLabel.clear();
+            SendPacket_UpdateRoomState();
+            Notification::Emit({
+                .message = "Room now set to " + localLabel,
+            });
+        } else if (roomState.romhackName != lastWarnedRomhackLabel) {
             lastWarnedRomhackLabel = roomState.romhackName;
             std::string msg = "There's a romhack mismatch between your client and the server:\n\n";
             msg += Lighthouse::DescribeRomhackMismatch(port_isRomhack(), localLabel, roomState.isRomhack,
@@ -87,7 +103,6 @@ void Anchor::HandlePacket_UpdateRoomState(nlohmann::json& payload) {
         lastWarnedRomhackLabel.clear();
     }
 
-    roomState.ownerClientId = payload["state"]["ownerClientId"].get<uint32_t>();
     roomState.pvpMode = payload["state"]["pvpMode"].get<u8>();
     roomState.showLocationsMode = payload["state"]["showLocationsMode"].get<u8>();
     roomState.teleportMode = payload["state"]["teleportMode"].get<u8>();
@@ -127,6 +142,20 @@ void Anchor::CheckRandoRoomCompatibility() {
 
     if (msg.empty()) {
         lastWarnedRandoState.clear();
+        return;
+    }
+
+    // As with the romhack label above: the room's recorded seed is only as fresh as the last
+    // session that pushed it, and the owner is the one who says what the room is running.
+    if (ownClientId != 0 && roomState.ownerClientId == ownClientId) {
+        roomState.isRando = localRando;
+        roomState.seed = localSeed;
+        lastWarnedRandoState.clear();
+        SendPacket_UpdateRoomState();
+        Notification::Emit({
+            .message = localRando ? "Room now set to randomizer seed " + std::to_string(localSeed)
+                                  : "Room now set to a no-rando game",
+        });
         return;
     }
 

--- a/src/port/Network/Anchor/Packets/UpdateTeamState.cpp
+++ b/src/port/Network/Anchor/Packets/UpdateTeamState.cpp
@@ -3,9 +3,13 @@
 #include <nlohmann/json.hpp>
 #include <libultraship/libultraship.h>
 #include "port/UI/Notification.h"
+#include "port/UI/LighthouseGui.hpp"
+#include "port/UI/LighthouseModals.h"
 #include "port/Enhancements/Retention/Retention.h"
+#include "port/Romhack/RomhackCompat.h"
 #include "port/Rando/Rando.h"
 #include <algorithm>
+#include <string>
 #include <vector>
 
 #include "variables.h"
@@ -37,6 +41,15 @@ extern void port_hutSmash_restore(const std::vector<int32_t>& flat);
  * the team queue (assumed drained); receiving replays any queued packets after applying state.
  */
 
+// Identifies the game a team state was captured under.
+static std::string TeamStateSignature() {
+    std::string sig = Lighthouse::CurrentRomhackLabel();
+    if (IS_RANDO) {
+        sig += " (rando:" + std::to_string((int32_t)RANDO_SEED) + ")";
+    }
+    return sig;
+}
+
 // Snapshot a decomp byte-array score/flag section into a JSON byte array.
 static std::vector<u8> ScoreBytes(void (*getSizeAndPtr)(s32*, u8**)) {
     s32 size;
@@ -46,7 +59,9 @@ static std::vector<u8> ScoreBytes(void (*getSizeAndPtr)(s32*, u8**)) {
 }
 
 void Anchor::SendPacket_UpdateTeamState() {
-    if (!IsSaveLoaded() || !roomState.syncItemsAndFlags) {
+    // Keep a mismatched client from overwriting the team's stored save
+    // with progress that doesn't apply to it.
+    if (!IsSaveLoaded() || !roomState.syncItemsAndFlags || gameMismatchWithTeam) {
         return;
     }
 
@@ -54,6 +69,7 @@ void Anchor::SendPacket_UpdateTeamState() {
     payload["type"] = UPDATE_TEAM_STATE;
     payload["targetTeamId"] = CVarGetString(CVAR_REMOTE_ANCHOR("TeamId"), "default");
     payload["queue"] = json::array();
+    payload["state"]["gameSig"] = TeamStateSignature();
     payload["state"]["fileProgressFlags"] = ScoreBytes(fileProgressFlag_getSizeAndPtr);
     payload["state"]["jiggies"] = ScoreBytes(jiggyscore_getSizeAndPtr);
     payload["state"]["honeycombs"] = ScoreBytes(honeycombscore_getSizeAndPtr);
@@ -118,6 +134,50 @@ static void ApplyTeamBytes(nlohmann::json& bytes, void (*getSizeAndPtr)(s32*, u8
 void Anchor::HandlePacket_UpdateTeamState(nlohmann::json& payload) {
     if (!roomState.syncItemsAndFlags) {
         return;
+    }
+
+    if (payload.contains("state") && payload["state"].contains("gameSig")) {
+        const std::string incoming = payload["state"]["gameSig"].get<std::string>();
+        const std::string local = TeamStateSignature();
+        if (incoming != local) {
+            const std::string ownTeam = CVarGetString(CVAR_REMOTE_ANCHOR("TeamId"), "default");
+            bool teammatePlaying = false;
+            for (auto& [clientId, client] : clients) {
+                if (!client.self && client.online && client.isSaveLoaded && client.teamId == ownTeam) {
+                    teammatePlaying = true;
+                    break;
+                }
+            }
+
+            if (!teammatePlaying) {
+                if (incoming != lastClearedTeamStateSig) {
+                    lastClearedTeamStateSig = incoming;
+                    SendPacket_ClearTeamState(ownTeam);
+                    SendPacket_UpdateTeamState(); // no-op until a file is loaded
+                    Notification::Emit({
+                        .message = "Reset team state to current game/save",
+                    });
+                }
+                return;
+            }
+
+            // Someone is mid-session on a different game. Our progress doesn't belong in their
+            // save any more than theirs belongs in ours, so stop sending ours too until we match.
+            gameMismatchWithTeam = true;
+            if (incoming != lastClearedTeamStateSig) {
+                lastClearedTeamStateSig = incoming;
+                std::string msg = "This team is playing a different game, so their save was not\n"
+                                  "applied to your file.\n\n";
+                msg += "    Their game:  " + incoming + "\n";
+                msg += "    Your file:   " + local + "\n\n";
+                msg += "Your save is untouched, and nothing of yours is being shared with them.\n"
+                       "Load a file that matches theirs, or start a new one, to join the session.";
+                LighthouseGui::RegisterPopup("Team State Mismatch", msg);
+            }
+            return;
+        }
+        lastClearedTeamStateSig.clear();
+        gameMismatchWithTeam = false;
     }
 
     isHandlingUpdateTeamState = true;

--- a/src/port/Network/Anchor/Packets/UpdateTeamState.cpp
+++ b/src/port/Network/Anchor/Packets/UpdateTeamState.cpp
@@ -58,10 +58,25 @@ static std::vector<u8> ScoreBytes(void (*getSizeAndPtr)(s32*, u8**)) {
     return std::vector<u8>(addr, addr + size);
 }
 
+bool Anchor::LocalGameMatchesRoom() {
+    if (roomState.romhackName.empty()) {
+        return true;
+    }
+
+    if (Lighthouse::CurrentRomhackLabel() != roomState.romhackName) {
+        return false;
+    }
+    const bool localRando = IS_RANDO;
+    if (localRando != roomState.isRando) {
+        return false;
+    }
+    return !localRando || (int32_t)RANDO_SEED == roomState.seed;
+}
+
 void Anchor::SendPacket_UpdateTeamState() {
-    // Keep a mismatched client from overwriting the team's stored save
-    // with progress that doesn't apply to it.
-    if (!IsSaveLoaded() || !roomState.syncItemsAndFlags || gameMismatchWithTeam) {
+    // Don't overwrite the team's stored save with progress from a different game than the room is
+    // running. This covers answering a teammate's request as well as our own saves.
+    if (!IsSaveLoaded() || !roomState.syncItemsAndFlags || !LocalGameMatchesRoom()) {
         return;
     }
 
@@ -120,6 +135,16 @@ void Anchor::SendPacket_ClearTeamState(std::string teamId) {
     SendJsonToRemote(payload);
 }
 
+// Drops the room's stored team save and reseeds it from our own file, so the room carries the game
+// we're actually playing. Only ever called for the room owner with nobody playing from the old one.
+void Anchor::ClearMismatchedTeamState(std::string teamId) {
+    SendPacket_ClearTeamState(teamId);
+    SendPacket_UpdateTeamState();
+    Notification::Emit({
+        .message = "Cleared team state from a different game",
+    });
+}
+
 // Overwrites a local byte section with the authoritative team-state array (no additive merge).
 static void ApplyTeamBytes(nlohmann::json& bytes, void (*getSizeAndPtr)(s32*, u8**)) {
     s32 size;
@@ -137,6 +162,9 @@ void Anchor::HandlePacket_UpdateTeamState(nlohmann::json& payload) {
     }
 
     if (payload.contains("state") && payload["state"].contains("gameSig")) {
+        if (selectedFileNum == DEFAULT_FILE_NUM) {
+            return;
+        }
         const std::string incoming = payload["state"]["gameSig"].get<std::string>();
         const std::string local = TeamStateSignature();
         if (incoming != local) {
@@ -148,36 +176,38 @@ void Anchor::HandlePacket_UpdateTeamState(nlohmann::json& payload) {
                     break;
                 }
             }
+            const bool mayClear = ownClientId != 0 && roomState.ownerClientId == ownClientId && !teammatePlaying;
 
-            if (!teammatePlaying) {
-                if (incoming != lastClearedTeamStateSig) {
-                    lastClearedTeamStateSig = incoming;
-                    SendPacket_ClearTeamState(ownTeam);
-                    SendPacket_UpdateTeamState(); // no-op until a file is loaded
-                    Notification::Emit({
-                        .message = "Reset team state to current game/save",
-                    });
-                }
+            if (incoming == lastClearedTeamStateSig) {
+                return;
+            }
+            lastClearedTeamStateSig = incoming;
+
+            std::string msg = "The team save stored for this room was recorded under a different\n"
+                              "game, so it was not applied to your file.\n\n";
+            msg += "    Stored save:  " + incoming + "\n";
+            msg += "    Your file:    " + local + "\n\n";
+            msg += "Your save is untouched, and nothing of yours is being shared with it.\n";
+
+            if (!mayClear) {
+                // Someone else's session to resolve: either they own the room, or a teammate is
+                // mid-session on it. Say what's happening and leave their save alone.
+                msg += "\nLoad a file that matches it, or start a new one, to join the session.";
+                LighthouseGui::RegisterPopup("Team State Mismatch", msg);
                 return;
             }
 
-            // Someone is mid-session on a different game. Our progress doesn't belong in their
-            // save any more than theirs belongs in ours, so stop sending ours too until we match.
-            gameMismatchWithTeam = true;
-            if (incoming != lastClearedTeamStateSig) {
-                lastClearedTeamStateSig = incoming;
-                std::string msg = "This team is playing a different game, so their save was not\n"
-                                  "applied to your file.\n\n";
-                msg += "    Their game:  " + incoming + "\n";
-                msg += "    Your file:   " + local + "\n\n";
-                msg += "Your save is untouched, and nothing of yours is being shared with them.\n"
-                       "Load a file that matches theirs, or start a new one, to join the session.";
-                LighthouseGui::RegisterPopup("Team State Mismatch", msg);
+            if (CVarGetInteger(CVAR_REMOTE_ANCHOR("RoomSettings.AutoClearMismatchedState"), 0)) {
+                ClearMismatchedTeamState(ownTeam);
+                return;
             }
+
+            msg += "\nClear it and start this room fresh on your game?";
+            LighthouseGui::RegisterPopup("Team State Mismatch", msg, "Clear It", "Keep It",
+                                         [this, ownTeam]() { ClearMismatchedTeamState(ownTeam); });
             return;
         }
         lastClearedTeamStateSig.clear();
-        gameMismatchWithTeam = false;
     }
 
     isHandlingUpdateTeamState = true;


### PR DESCRIPTION
#525: Collectibles duplicated when teammate is in sub-area
- Adds `Anchor_DespawnCollectedCollectibles()`, run from the Anchor map-load hook which fires after `mapSavestate_apply` to despawn any jiggy, honeycomb or mumbo token whose score bit is already set.

#528 - Double jiggy HUD popup
- Anchor's notification is now conditioned on `func_802FADD4(ITEM_2B_UNKNOWN)`, so jiggy total popups are no longer redundant. If a player already has a variant showing, a second one doesn't appear.

#526 - Clearing room state in private rooms
- The server keeps the last team state a team sent and replays it to whoever loads a file when no teammate is online with a save loaded, so a room reused for a different game pasted the old game's save over the new one.
- Team state now carries a `gameSig` (romhack label plus rando seed). A mismatched state is refused instead of applied, along with the packet queue riding on it.
- When nobody on the team is playing, the stale copy is cleared automatically and reseeded from the local file, with a notification. No hunting for an admin-only button.
- When a teammate is playing, their state is left alone and the local player is told instead; outbound team state is also suppressed, so a mismatched client can't poison the room's stored save.
- Room identity had the same staleness: the handshake only seeds it at room creation, so a reused room kept its old romhack/seed. The owner now refreshes it (with a notification) rather than being warned about their own room; non-owners still get the mismatch warning.
- `PrepRoomState` no longer publishes `isRando/seed` while no file is selected. Doing so reset the room's randomizer identity for everyone still in it. Also fixes the pre-existing version of this via the room-settings widgets.
- Owner checks require a server-assigned client id, since both `ownClientId` and `roomState.ownerClientId` default to 0 and would otherwise match before `ALL_CLIENT_STATE` arrives.

There is a greater accessibility problem that will be a separate ticket.

<!--- section:artifacts:start -->
### Build Artifacts
  - [Lighthouse-windows.zip](https://nightly.link/HarbourMasters/Lighthouse/actions/artifacts/9739121935.zip)
  - [Lighthouse-linux.zip](https://nightly.link/HarbourMasters/Lighthouse/actions/artifacts/9738973805.zip)
  - [Lighthouse-mac.zip](https://nightly.link/HarbourMasters/Lighthouse/actions/artifacts/9738807626.zip)
<!--- section:artifacts:end -->