### PR TITLE
Add disable culling option

### DIFF
--- a/src/CC/ma/clanker.c
+++ b/src/CC/ma/clanker.c
@@ -66,24 +66,6 @@ enum maClankerState_e {
     MACLANKER_STATE_3_IDLE_RAISED
 };
 
-// LIGHTHOUSE_ALWAYS_LOAD_CLANKER_CC_V1
-// LIGHTHOUSE_ALWAYS_LOAD_CLANKER_CC_V2
-extern s32 getGameMode(void);
-
-static s32 lighthouse_clankerInDemoPlayback(void) {
-    switch (getGameMode()) {
-        case GAME_MODE_2_UNKNOWN:
-        case GAME_MODE_6_FILE_PLAYBACK:
-        case GAME_MODE_7_ATTRACT_DEMO:
-        case GAME_MODE_8_BOTTLES_BONUS:
-        case GAME_MODE_9_BANJO_AND_KAZOOIE:
-        case GAME_MODE_A_SNS_PICTURE:
-            return TRUE;
-        default:
-            return FALSE;
-    }
-}
-
 BKCollisionTriangle *__maClanker_getClankerCollisionTris(f32 arg0[3], f32 arg1[3], f32 arg2[3], u32 arg3){ // [port] pointer-width args
     BKCollisionTriangle *collision_tris;
 
@@ -173,7 +155,7 @@ void maClanker_draw(Gfx **gfx, Mtx **mtx, Vtx **vtx){
     
     viewport_getPosition_vec3f(viewport_position);
         
-    if ((!port_shouldDisableCulling() || lighthouse_clankerInDemoPlayback()) &&
+    if ((!port_shouldDisableCulling() || port_isDemoPlayback()) &&
         (viewport_position[0] < -2600.0f || 11600.0f < viewport_position[0]))
         return;
 

--- a/src/CC/ma/clanker.c
+++ b/src/CC/ma/clanker.c
@@ -5,6 +5,7 @@
 #include "variables.h"
 
 #include "core2/modelRender.h"
+#include "port/Patches/Patches.h"
 
 extern BKCollisionTriangle *func_8028EF48(void);
 extern void func_8030E9FC(enum sfx_e uid, f32 arg1, f32 arg2, u32 arg3, f32 arg4[3], f32 arg5, f32 arg6);
@@ -64,6 +65,24 @@ enum maClankerState_e {
     MACLANKER_STATE_2_LIFTING,
     MACLANKER_STATE_3_IDLE_RAISED
 };
+
+// LIGHTHOUSE_ALWAYS_LOAD_CLANKER_CC_V1
+// LIGHTHOUSE_ALWAYS_LOAD_CLANKER_CC_V2
+extern s32 getGameMode(void);
+
+static s32 lighthouse_clankerInDemoPlayback(void) {
+    switch (getGameMode()) {
+        case GAME_MODE_2_UNKNOWN:
+        case GAME_MODE_6_FILE_PLAYBACK:
+        case GAME_MODE_7_ATTRACT_DEMO:
+        case GAME_MODE_8_BOTTLES_BONUS:
+        case GAME_MODE_9_BANJO_AND_KAZOOIE:
+        case GAME_MODE_A_SNS_PICTURE:
+            return TRUE;
+        default:
+            return FALSE;
+    }
+}
 
 BKCollisionTriangle *__maClanker_getClankerCollisionTris(f32 arg0[3], f32 arg1[3], f32 arg2[3], u32 arg3){ // [port] pointer-width args
     BKCollisionTriangle *collision_tris;
@@ -154,7 +173,8 @@ void maClanker_draw(Gfx **gfx, Mtx **mtx, Vtx **vtx){
     
     viewport_getPosition_vec3f(viewport_position);
         
-    if(viewport_position[0] <  -2600.0f || 11600.0f < viewport_position[0])
+    if ((!port_shouldDisableCulling() || lighthouse_clankerInDemoPlayback()) &&
+        (viewport_position[0] < -2600.0f || 11600.0f < viewport_position[0]))
         return;
 
     bone_transform_list = skeletalAnim_getBoneTransformList(maClanker.skeletonAnim);

--- a/src/core1/viewport.c
+++ b/src/core1/viewport.c
@@ -31,7 +31,7 @@ MtxF sViewportMatrix;
 MtxF sViewportDefaultMatrix;
 s32 sViewportStackIndex;
 
-// Disable Culling V2: preserve exact demo/playback culling state.
+// Preserve the original demo/playback frustum state while visual culling is disabled.
 static bool lighthouse_cullV2_frustumChecksEnabled = true;
 
 void lighthouse_cullV2_setFrustumChecksEnabled(bool enabled) {

--- a/src/core1/viewport.c
+++ b/src/core1/viewport.c
@@ -31,6 +31,69 @@ MtxF sViewportMatrix;
 MtxF sViewportDefaultMatrix;
 s32 sViewportStackIndex;
 
+// Disable Culling V2: preserve exact demo/playback culling state.
+static bool lighthouse_cullV2_frustumChecksEnabled = true;
+
+void lighthouse_cullV2_setFrustumChecksEnabled(bool enabled) {
+    lighthouse_cullV2_frustumChecksEnabled = enabled;
+}
+
+bool lighthouse_cullV2_inPlaybackMode(void) {
+    switch (getGameMode()) {
+        case GAME_MODE_2_UNKNOWN:
+        case GAME_MODE_6_FILE_PLAYBACK:
+        case GAME_MODE_7_ATTRACT_DEMO:
+        case GAME_MODE_8_BOTTLES_BONUS:
+        case GAME_MODE_A_SNS_PICTURE:
+        case GAME_MODE_9_BANJO_AND_KAZOOIE:
+            return true;
+        default:
+            return false;
+    }
+}
+
+// Disable-Culling menu + widescreen demo-sync state.
+static bool lighthouse_menuCull_frustumChecksEnabled = true;
+
+void lighthouse_menuCull_setFrustumChecksEnabled(bool enabled) {
+    lighthouse_menuCull_frustumChecksEnabled = enabled;
+}
+
+static bool lighthouse_menuCull_inPlaybackMode(void) {
+    switch (getGameMode()) {
+        case GAME_MODE_2_UNKNOWN:
+        case GAME_MODE_6_FILE_PLAYBACK:
+        case GAME_MODE_7_ATTRACT_DEMO:
+        case GAME_MODE_8_BOTTLES_BONUS:
+        case GAME_MODE_A_SNS_PICTURE:
+        case GAME_MODE_9_BANJO_AND_KAZOOIE:
+            return true;
+        default:
+            return false;
+    }
+}
+
+// widescreen demo culling state.
+static bool lighthouse_demoSync_frustum_checks_enabled = true;
+
+void lighthouse_demoSync_setFrustumChecksEnabled(bool enabled) {
+    lighthouse_demoSync_frustum_checks_enabled = enabled;
+}
+
+static bool lighthouse_demoSync_inPlaybackMode(void) {
+    switch (getGameMode()) {
+        case GAME_MODE_2_UNKNOWN:
+        case GAME_MODE_6_FILE_PLAYBACK:
+        case GAME_MODE_7_ATTRACT_DEMO:
+        case GAME_MODE_8_BOTTLES_BONUS:
+        case GAME_MODE_A_SNS_PICTURE:
+        case GAME_MODE_9_BANJO_AND_KAZOOIE:
+            return true;
+        default:
+            return false;
+    }
+}
+
 void viewport_moveAlongZAxis(f32 offset) {
     f32 delta_position[3];
 
@@ -291,6 +354,10 @@ void viewport_setFrustumPlanes(f32 arg0[4], f32 arg1[4], f32 arg2[4], f32 arg3[4
 }
 
 bool viewport_isBoundingBoxInFrustum(f32 min[3], f32 max[3]) {
+    if (port_shouldDisableCulling() && !lighthouse_cullV2_inPlaybackMode()) {
+        return true;
+    }
+
 
     if (((sViewportFrustumPlanes[0][0] * min[0] + sViewportFrustumPlanes[0][1] * min[1] + sViewportFrustumPlanes[0][2] * min[2] + sViewportFrustumPlanes[0][3]) >= 0.0f) &&
         ((sViewportFrustumPlanes[0][0] * min[0] + sViewportFrustumPlanes[0][1] * min[1] + sViewportFrustumPlanes[0][2] * max[2] + sViewportFrustumPlanes[0][3]) >= 0.0f) &&
@@ -385,6 +452,25 @@ bool viewport_cube_isInFrustum2(Cube *cube) {
 
 // viewport_distanceFromPlane ?
 bool viewport_func_8024DB50(f32 pos[3], f32 distance) {
+    if (port_shouldDisableCulling()) {
+        if (!lighthouse_cullV2_inPlaybackMode() || !lighthouse_cullV2_frustumChecksEnabled) {
+            return true;
+        }
+
+        // Original N64 sphere/frustum math for demo-sync state.
+        f32 delta[3];
+        s32 i;
+        delta[0] = pos[0] - sViewportPosition[0];
+        delta[1] = pos[1] - sViewportPosition[1];
+        delta[2] = pos[2] - sViewportPosition[2];
+        for (i = 0; i < 4; i++) {
+            if (distance <= ml_vec3f_dot_product(delta, sViewportFrustumPlanes[i])) {
+                return false;
+            }
+        }
+        return true;
+    }
+
     f32 delta[3];
     s32 i;
 
@@ -405,6 +491,10 @@ bool viewport_func_8024DB50(f32 pos[3], f32 distance) {
 }
 
 bool viewport_isPointOutsideFrustum_3f(f32 x, f32 y, f32 z) {
+    if (port_shouldDisableCulling() && !lighthouse_cullV2_inPlaybackMode()) {
+        return false;
+    }
+
     if ((sViewportFrustumPlanes[0][0] * x + sViewportFrustumPlanes[0][1] * y + sViewportFrustumPlanes[0][2] * z + sViewportFrustumPlanes[0][3] <= 0.0f) &&
         (sViewportFrustumPlanes[1][0] * x + sViewportFrustumPlanes[1][1] * y + sViewportFrustumPlanes[1][2] * z + sViewportFrustumPlanes[1][3] <= 0.0f) &&
         (sViewportFrustumPlanes[2][0] * x + sViewportFrustumPlanes[2][1] * y + sViewportFrustumPlanes[2][2] * z + sViewportFrustumPlanes[2][3] <= 0.0f) &&
@@ -420,6 +510,10 @@ bool viewport_isPointOutsideFrustum_vec3f(f32 arg0[3]) {
 
 // need to figure out, what plane 2 is (neg/pos x/y ?)
 bool viewport_isPointPlane_3f(f32 arg0, f32 arg1, f32 arg2) {
+    if (port_shouldDisableCulling() && !lighthouse_cullV2_inPlaybackMode()) {
+        return false;
+    }
+
     return ((sViewportFrustumPlanes[2][0]*arg0 + sViewportFrustumPlanes[2][1]*arg1 + sViewportFrustumPlanes[2][2]*arg2 + sViewportFrustumPlanes[2][3]) <= 0.0f);
 }
 

--- a/src/core1/viewport.c
+++ b/src/core1/viewport.c
@@ -52,48 +52,6 @@ bool lighthouse_cullV2_inPlaybackMode(void) {
     }
 }
 
-// Disable-Culling menu + widescreen demo-sync state.
-static bool lighthouse_menuCull_frustumChecksEnabled = true;
-
-void lighthouse_menuCull_setFrustumChecksEnabled(bool enabled) {
-    lighthouse_menuCull_frustumChecksEnabled = enabled;
-}
-
-static bool lighthouse_menuCull_inPlaybackMode(void) {
-    switch (getGameMode()) {
-        case GAME_MODE_2_UNKNOWN:
-        case GAME_MODE_6_FILE_PLAYBACK:
-        case GAME_MODE_7_ATTRACT_DEMO:
-        case GAME_MODE_8_BOTTLES_BONUS:
-        case GAME_MODE_A_SNS_PICTURE:
-        case GAME_MODE_9_BANJO_AND_KAZOOIE:
-            return true;
-        default:
-            return false;
-    }
-}
-
-// widescreen demo culling state.
-static bool lighthouse_demoSync_frustum_checks_enabled = true;
-
-void lighthouse_demoSync_setFrustumChecksEnabled(bool enabled) {
-    lighthouse_demoSync_frustum_checks_enabled = enabled;
-}
-
-static bool lighthouse_demoSync_inPlaybackMode(void) {
-    switch (getGameMode()) {
-        case GAME_MODE_2_UNKNOWN:
-        case GAME_MODE_6_FILE_PLAYBACK:
-        case GAME_MODE_7_ATTRACT_DEMO:
-        case GAME_MODE_8_BOTTLES_BONUS:
-        case GAME_MODE_A_SNS_PICTURE:
-        case GAME_MODE_9_BANJO_AND_KAZOOIE:
-            return true;
-        default:
-            return false;
-    }
-}
-
 void viewport_moveAlongZAxis(f32 offset) {
     f32 delta_position[3];
 

--- a/src/core1/viewport.c
+++ b/src/core1/viewport.c
@@ -32,10 +32,10 @@ MtxF sViewportDefaultMatrix;
 s32 sViewportStackIndex;
 
 // Preserve the original demo/playback frustum state while visual culling is disabled.
-static bool lighthouse_cullV2_frustumChecksEnabled = true;
+static bool lighthouse_frustumChecksEnabled = true;
 
-void lighthouse_cullV2_setFrustumChecksEnabled(bool enabled) {
-    lighthouse_cullV2_frustumChecksEnabled = enabled;
+void lighthouse_setFrustumChecksEnabled(bool enabled) {
+    lighthouse_frustumChecksEnabled = enabled;
 }
 
 void viewport_moveAlongZAxis(f32 offset) {
@@ -397,7 +397,7 @@ bool viewport_cube_isInFrustum2(Cube *cube) {
 // viewport_distanceFromPlane ?
 bool viewport_func_8024DB50(f32 pos[3], f32 distance) {
     if (port_shouldDisableCulling()) {
-        if (!port_isDemoPlayback() || !lighthouse_cullV2_frustumChecksEnabled) {
+        if (!port_isDemoPlayback() || !lighthouse_frustumChecksEnabled) {
             return true;
         }
 

--- a/src/core1/viewport.c
+++ b/src/core1/viewport.c
@@ -38,20 +38,6 @@ void lighthouse_cullV2_setFrustumChecksEnabled(bool enabled) {
     lighthouse_cullV2_frustumChecksEnabled = enabled;
 }
 
-bool lighthouse_cullV2_inPlaybackMode(void) {
-    switch (getGameMode()) {
-        case GAME_MODE_2_UNKNOWN:
-        case GAME_MODE_6_FILE_PLAYBACK:
-        case GAME_MODE_7_ATTRACT_DEMO:
-        case GAME_MODE_8_BOTTLES_BONUS:
-        case GAME_MODE_A_SNS_PICTURE:
-        case GAME_MODE_9_BANJO_AND_KAZOOIE:
-            return true;
-        default:
-            return false;
-    }
-}
-
 void viewport_moveAlongZAxis(f32 offset) {
     f32 delta_position[3];
 
@@ -312,7 +298,7 @@ void viewport_setFrustumPlanes(f32 arg0[4], f32 arg1[4], f32 arg2[4], f32 arg3[4
 }
 
 bool viewport_isBoundingBoxInFrustum(f32 min[3], f32 max[3]) {
-    if (port_shouldDisableCulling() && !lighthouse_cullV2_inPlaybackMode()) {
+    if (port_shouldDisableCulling() && !port_isDemoPlayback()) {
         return true;
     }
 
@@ -411,7 +397,7 @@ bool viewport_cube_isInFrustum2(Cube *cube) {
 // viewport_distanceFromPlane ?
 bool viewport_func_8024DB50(f32 pos[3], f32 distance) {
     if (port_shouldDisableCulling()) {
-        if (!lighthouse_cullV2_inPlaybackMode() || !lighthouse_cullV2_frustumChecksEnabled) {
+        if (!port_isDemoPlayback() || !lighthouse_cullV2_frustumChecksEnabled) {
             return true;
         }
 
@@ -449,7 +435,7 @@ bool viewport_func_8024DB50(f32 pos[3], f32 distance) {
 }
 
 bool viewport_isPointOutsideFrustum_3f(f32 x, f32 y, f32 z) {
-    if (port_shouldDisableCulling() && !lighthouse_cullV2_inPlaybackMode()) {
+    if (port_shouldDisableCulling() && !port_isDemoPlayback()) {
         return false;
     }
 
@@ -468,7 +454,7 @@ bool viewport_isPointOutsideFrustum_vec3f(f32 arg0[3]) {
 
 // need to figure out, what plane 2 is (neg/pos x/y ?)
 bool viewport_isPointPlane_3f(f32 arg0, f32 arg1, f32 arg2) {
-    if (port_shouldDisableCulling() && !lighthouse_cullV2_inPlaybackMode()) {
+    if (port_shouldDisableCulling() && !port_isDemoPlayback()) {
         return false;
     }
 

--- a/src/core2/actor_array.c
+++ b/src/core2/actor_array.c
@@ -11,7 +11,9 @@
 #include "port/Patches/Patches.h"
 
 extern s32 D_80370990;
+extern s32 cur_model_would_have_been_culled_in_demo;
 extern f32 GameEngine_GetAspectRatio(void);
+extern bool lighthouse_demoCubeVisualOnly(void);
 
 #define DIST_SQ_VEC3F(v1, v2) ((v1[0] - v2[0])*(v1[0] - v2[0]) + (v1[1] - v2[1])*(v1[1] - v2[1]) + (v1[2] - v2[2])*(v1[2] - v2[2]))
 
@@ -155,10 +157,21 @@ void actor_predrawMethod(Actor *this){
         this->unkF4_29 = NOT(this->unkF4_29);
     }//L80325594
 
-    // [port] In widescreen, only run the predraw callback if the actor would
-    // have been visible in the original 4:3 frustum, preserving game logic.
-    if(this->unk130 && (GameEngine_GetAspectRatio() <= 1.34f || D_80370990)){
-        this->unk130(this);
+    if (port_shouldDisableCulling()) {
+        // widescreen logic. Outside playback the flag is always false.
+        if (!cur_model_would_have_been_culled_in_demo) {
+            if (this->unk130) {
+                if (!lighthouse_demoCubeVisualOnly()) {
+                    this->unk130(this);
+                }
+            }
+        }
+    } else {
+        if(this->unk130 && (GameEngine_GetAspectRatio() <= 1.34f || D_80370990)){
+            if (!lighthouse_demoCubeVisualOnly()) {
+                this->unk130(this);
+            }
+        }
     }
 
     if(this->unk148 && !this->marker->unk20){
@@ -207,12 +220,26 @@ void func_80325760(Actor *this) {
 // [port] In widescreen, actors outside the 4:3 frustum are still drawn but
 // should not be marked as visible for game logic purposes.
 void actor_postdrawMethod(ActorMarker *marker){
-    if (GameEngine_GetAspectRatio() <= 1.34f || D_80370990) {
-        marker->unk14_21 = true;
+    if (lighthouse_demoCubeVisualOnly()) {
+        return;
+    }
+
+    if (port_shouldDisableCulling()) {
+        if (!cur_model_would_have_been_culled_in_demo) {
+            marker->unk14_21 = true;
+        }
+    } else {
+        if (GameEngine_GetAspectRatio() <= 1.34f || D_80370990) {
+            marker->unk14_21 = true;
+        }
     }
 }
 
 void func_803257A4(ActorMarker *marker){
+    if (lighthouse_demoCubeVisualOnly()) {
+        return;
+    }
+
     marker->unk14_21 = true;
 }
 

--- a/src/core2/actor_cubepropsystem.c
+++ b/src/core2/actor_cubepropsystem.c
@@ -315,45 +315,6 @@ void func_8032CD60(Prop *prop) {
     }
 }
 
-static bool sLighthouseSpritePrepassActive = false;
-
-void lighthouse_spritePrepassBegin(void) {
-    sLighthouseSpritePrepassActive = true;
-}
-
-void lighthouse_spritePrepassEnd(void) {
-    sLighthouseSpritePrepassActive = false;
-}
-
-bool lighthouse_spritePrepassActive(void) {
-    return sLighthouseSpritePrepassActive;
-}
-
-void lighthouse_spritePrepassUpdateCube(Cube *cube) {
-    Prop *prop;
-    s32 i;
-
-    if (cube == NULL || cube->prop2Ptr == NULL || cube->prop2Cnt == 0) {
-        return;
-    }
-
-    for (i = 0; i < cube->prop2Cnt; i++) {
-        prop = &cube->prop2Ptr[i];
-
-        if (!prop->unk8_4) {
-            continue;
-        }
-
-        if (!prop->unk8_1
-            || (prop->markerFlag
-                && prop->actorProp.marker != NULL
-                && prop->actorProp.marker->modelId != 0
-                && !ResourceMgr_IsModelAsset(prop->actorProp.marker->modelId))) {
-            func_8032CD60(prop);
-        }
-    }
-}
-
 void cube_sortAbsolute(Cube *cube){
     if(cube->prop2Cnt >= 2)
         __cube_sort(cube, 1);
@@ -549,9 +510,7 @@ void func_8032D510(Cube *cube, Gfx **gfx, Mtx **mtx, Vtx **vtx){
                     && iProp->actorProp.marker->modelId != 0
                     && !ResourceMgr_IsModelAsset(iProp->actorProp.marker->modelId))){
                 if (!lighthouse_demoCubeVisualOnly()) {
-                    if (!lighthouse_spritePrepassActive()) {
-                        func_8032CD60(iProp);
-                    }
+                    func_8032CD60(iProp);
                 }
             }
             if(iProp->markerFlag){//actorProp;

--- a/src/core2/actor_cubepropsystem.c
+++ b/src/core2/actor_cubepropsystem.c
@@ -509,9 +509,9 @@ void func_8032D510(Cube *cube, Gfx **gfx, Mtx **mtx, Vtx **vtx){
                 || (iProp->markerFlag && iProp->actorProp.marker != NULL
                     && iProp->actorProp.marker->modelId != 0
                     && !ResourceMgr_IsModelAsset(iProp->actorProp.marker->modelId))){
-                if (!lighthouse_demoCubeVisualOnly()) {
-                    func_8032CD60(iProp);
-                }
+                // Sprite frame state is visual; update extra demo-rendered sprites when this cube is traversed.
+                // This replaces the old full-world sprite prepass without freezing normally culled demo sprites.
+                func_8032CD60(iProp);
             }
             if(iProp->markerFlag){//actorProp;
                 // [port] marker is NULL until actor spawns

--- a/src/core2/actor_cubepropsystem.c
+++ b/src/core2/actor_cubepropsystem.c
@@ -349,7 +349,7 @@ static bool lighthouse_demoCubeSafeMarkerDraw(ActorMarker *marker) {
         return true;
     }
 
-    // V3: generic sprite-actor renderers.
+    // Generic sprite-actor renderers.
     // These use Lighthouse's normal sprite renderer and marker-visible
     // callback path. The existing visual-only demo guards suppress the
     // marker-visible game-logic update while still allowing the sprite draw.
@@ -359,9 +359,7 @@ static bool lighthouse_demoCubeSafeMarkerDraw(ActorMarker *marker) {
         return true;
     }
 
-    // Truly custom per-actor draw functions remain stock-culled for now.
-    // ALL36 CUSTOM ACTOR TEST START
-    // All 36 marker IDs that were stable in separate A/B tests.
+    // Custom per-actor draw functions that are known to be safe for visual-only demo rendering.
     switch (marker->id) {
         case 3:
         case 53:
@@ -403,7 +401,6 @@ static bool lighthouse_demoCubeSafeMarkerDraw(ActorMarker *marker) {
         default:
             break;
     }
-    // ALL36 CUSTOM ACTOR TEST END
     return false;
 }
 

--- a/src/core2/actor_cubepropsystem.c
+++ b/src/core2/actor_cubepropsystem.c
@@ -11,6 +11,13 @@
 #include "port/Interpolation/FrameInterpolation.h"
 
 extern int ResourceMgr_IsModelAsset(uint32_t assetId);
+Actor *func_80325F2C(ActorMarker *marker, Gfx **gfx, Mtx **mtx, Vtx **vtx);
+Actor *actor_drawFullDepth(ActorMarker *marker, Gfx **gfx, Mtx **mtx, Vtx **vtx);
+Actor *actor_draw(ActorMarker *marker, Gfx **gfx, Mtx **mtx, Vtx **vtx);
+extern bool lighthouse_demoCubeVisualOnly(void);
+Actor *func_80325CAC(ActorMarker *marker, Gfx **gfx, Mtx **mtx, Vtx **vtx);
+Actor *func_80325AE0(ActorMarker *marker, Gfx **gfx, Mtx **mtx, Vtx **vtx);
+Actor *fxTouchSparkle_draw(ActorMarker *marker, Gfx **gfx, Mtx **mtx, Vtx **vtx);
 
 #define AssetCacheSize 0x3D5
 
@@ -308,6 +315,45 @@ void func_8032CD60(Prop *prop) {
     }
 }
 
+static bool sLighthouseSpritePrepassActive = false;
+
+void lighthouse_spritePrepassBegin(void) {
+    sLighthouseSpritePrepassActive = true;
+}
+
+void lighthouse_spritePrepassEnd(void) {
+    sLighthouseSpritePrepassActive = false;
+}
+
+bool lighthouse_spritePrepassActive(void) {
+    return sLighthouseSpritePrepassActive;
+}
+
+void lighthouse_spritePrepassUpdateCube(Cube *cube) {
+    Prop *prop;
+    s32 i;
+
+    if (cube == NULL || cube->prop2Ptr == NULL || cube->prop2Cnt == 0) {
+        return;
+    }
+
+    for (i = 0; i < cube->prop2Cnt; i++) {
+        prop = &cube->prop2Ptr[i];
+
+        if (!prop->unk8_4) {
+            continue;
+        }
+
+        if (!prop->unk8_1
+            || (prop->markerFlag
+                && prop->actorProp.marker != NULL
+                && prop->actorProp.marker->modelId != 0
+                && !ResourceMgr_IsModelAsset(prop->actorProp.marker->modelId))) {
+            func_8032CD60(prop);
+        }
+    }
+}
+
 void cube_sortAbsolute(Cube *cube){
     if(cube->prop2Cnt >= 2)
         __cube_sort(cube, 1);
@@ -316,6 +362,88 @@ void cube_sortAbsolute(Cube *cube){
 void cube_sortRelative(Cube *cube){
     if(cube->prop2Cnt >= 2)
         __cube_sort(cube, 0);
+}
+
+static bool lighthouse_demoCubeSafeMarkerDraw(ActorMarker *marker) {
+    if (!lighthouse_demoCubeVisualOnly()) {
+        return true;
+    }
+
+    if (marker == NULL || marker->drawFunc == NULL) {
+        return false;
+    }
+
+    if (marker->unk40_22) {
+        return false;
+    }
+
+    if (marker->unk40_19) {
+        return false;
+    }
+
+    // Standard 3D actor paths.
+    if (marker->drawFunc == (MarkerDrawFunc)actor_draw
+        || marker->drawFunc == (MarkerDrawFunc)actor_drawFullDepth
+        || marker->drawFunc == (MarkerDrawFunc)func_80325F2C) {
+        return true;
+    }
+
+    // V3: generic sprite-actor renderers.
+    // These use Lighthouse's normal sprite renderer and marker-visible
+    // callback path. The existing visual-only demo guards suppress the
+    // marker-visible game-logic update while still allowing the sprite draw.
+    if (marker->drawFunc == (MarkerDrawFunc)fxTouchSparkle_draw
+        || marker->drawFunc == (MarkerDrawFunc)func_80325AE0
+        || marker->drawFunc == (MarkerDrawFunc)func_80325CAC) {
+        return true;
+    }
+
+    // Truly custom per-actor draw functions remain stock-culled for now.
+    // ALL36 CUSTOM ACTOR TEST START
+    // All 36 marker IDs that were stable in separate A/B tests.
+    switch (marker->id) {
+        case 3:
+        case 53:
+        case 82:
+        case 479:
+        case 103:
+        case 184:
+        case 155:
+        case 96:
+        case 484:
+        case 71:
+        case 213:
+        case 194:
+        case 197:
+        case 196:
+        case 193:
+        case 218:
+        case 17:
+        case 252:
+        case 445:
+        case 449:
+        case 462:
+        case 482:
+        case 178:
+        case 463:
+        case 390:
+        case 467:
+        case 466:
+        case 591:
+        case 56:
+        case 595:
+        case 175:
+        case 176:
+        case 195:
+        case 421:
+        case 187:
+        case 172:
+            return true;
+        default:
+            break;
+    }
+    // ALL36 CUSTOM ACTOR TEST END
+    return false;
 }
 
 static void __marker_draw(ActorMarker *this, Gfx **gfx, Mtx **mtx, Vtx **vtx){
@@ -401,7 +529,9 @@ void func_8032D510(Cube *cube, Gfx **gfx, Mtx **mtx, Vtx **vtx){
 
     if(cube->prop2Cnt == 0 ) return;
 
-    __cube_sort(cube, 0);
+    if (!lighthouse_demoCubeVisualOnly()) {
+        __cube_sort(cube, 0);
+    }
     iOffset = 0;
     for(i = 0; i < cube->prop2Cnt; i++){//L8032D5A0
 
@@ -418,14 +548,23 @@ void func_8032D510(Cube *cube, Gfx **gfx, Mtx **mtx, Vtx **vtx){
                 || (iProp->markerFlag && iProp->actorProp.marker != NULL
                     && iProp->actorProp.marker->modelId != 0
                     && !ResourceMgr_IsModelAsset(iProp->actorProp.marker->modelId))){
-                func_8032CD60(iProp);
+                if (!lighthouse_demoCubeVisualOnly()) {
+                    if (!lighthouse_spritePrepassActive()) {
+                        func_8032CD60(iProp);
+                    }
+                }
             }
             if(iProp->markerFlag){//actorProp;
                 // [port] marker is NULL until actor spawns
                 if(iProp->actorProp.marker != NULL){
                     // [port] Fire one tick event per static prop for port-side features (e.g. nametags).
                     f32 propPos[3] = { (f32)iProp->actorProp.x, (f32)iProp->actorProp.y, (f32)iProp->actorProp.z };
-                    CALL_EVENT(OnPropTick, iProp->actorProp.marker, propPos);
+                    if (!lighthouse_demoCubeVisualOnly()) {
+                        CALL_EVENT(OnPropTick, iProp->actorProp.marker, propPos);
+                    }
+                    if (!lighthouse_demoCubeSafeMarkerDraw(iProp->actorProp.marker)) {
+                        continue;
+                    }
                     if(iProp->actorProp.marker->unk40_22){
                         markerPtr = (ActorMarker **)bk_vector_pushBackNew(&D_80383550);
                         *markerPtr = iProp->actorProp.marker;
@@ -468,7 +607,9 @@ void func_8032D510(Cube *cube, Gfx **gfx, Mtx **mtx, Vtx **vtx){
                         (u16)iProp->spriteProp.unk4[2]);
                     // [port] Fire one tick event per static sprite prop. Asset id
                     // is the raw sprite index offset (+ 0x572 is the asset base).
-                    CALL_EVENT(OnSpritePropTick, (s32)iProp->spriteProp.spriteId + 0x572, sp94);
+                    if (!lighthouse_demoCubeVisualOnly()) {
+                        CALL_EVENT(OnSpritePropTick, (s32)iProp->spriteProp.spriteId + 0x572, sp94);
+                    }
                     propModelList_drawSprite( gfx, mtx, vtx,
                         sp94, (f32)iProp->spriteProp.scale/100.0, iProp->spriteProp.spriteId, cube,
                         iProp->spriteProp.rgb_remove_red, iProp->spriteProp.rgb_remove_green, iProp->spriteProp.rgb_remove_blue,

--- a/src/core2/gccube.c
+++ b/src/core2/gccube.c
@@ -151,9 +151,6 @@ struct {
 } sCubeList;
 
 /* .code */
-extern void lighthouse_spritePrepassBegin(void);
-extern void lighthouse_spritePrepassEnd(void);
-extern void lighthouse_spritePrepassUpdateCube(Cube *cube);
 void __7AF80_func_80301F10(Cube *cube, Gfx **gfx, Mtx **mtx, Vtx **vtx){
     __code7AF80_func_80308F0C(cube);
     func_8032D510(cube, gfx, mtx, vtx);
@@ -587,21 +584,6 @@ void func_80302C94(Gfx **gfx, Mtx **mtx, Vtx **vtx) {
 
     func_8032D3A8();
 
-    // Keep every sprite animation current when culling is disabled.
-    if (port_shouldDisableCulling()) {
-        Cube *lighthouseSpriteCube;
-
-        lighthouse_spritePrepassBegin();
-
-        for (lighthouseSpriteCube = sCubeList.cubes;
-             lighthouseSpriteCube < sCubeList.cubes + sCubeList.cubeCnt;
-             lighthouseSpriteCube++) {
-            lighthouse_spritePrepassUpdateCube(lighthouseSpriteCube);
-        }
-
-        lighthouse_spritePrepassUpdateCube(sCubeList.unk3C);
-        lighthouse_spritePrepassUpdateCube(sCubeList.unk40);
-    }
     viewport_getPosition_vec3f(vp_position);
     viewport_getRotation_vec3f(vp_rotation);
     ml_vec3f_clamp_deg360(vp_rotation);
@@ -713,7 +695,6 @@ void func_80302C94(Gfx **gfx, Mtx **mtx, Vtx **vtx) {
         func_80302634(gfx, mtx, vtx, vp_cube_indices, sp44, sp38);
     }
     func_80308D2C(gfx, mtx, vtx);
-    lighthouse_spritePrepassEnd();
 }
 
 void cube_positionToIndices(s32 indices[3], f32 position[3]) {

--- a/src/core2/gccube.c
+++ b/src/core2/gccube.c
@@ -186,20 +186,6 @@ static bool lighthouse_cubeWasInOriginalDemoRange(Cube *cube) {
         && iz >= sLighthouseDemoOriginalMin[2] && iz <= sLighthouseDemoOriginalMax[2];
 }
 
-static bool lighthouse_demoPlaybackModeExact(void) {
-    switch (getGameMode()) {
-        case GAME_MODE_2_UNKNOWN:
-        case GAME_MODE_6_FILE_PLAYBACK:
-        case GAME_MODE_7_ATTRACT_DEMO:
-        case GAME_MODE_8_BOTTLES_BONUS:
-        case GAME_MODE_A_SNS_PICTURE:
-        case GAME_MODE_9_BANJO_AND_KAZOOIE:
-            return true;
-        default:
-            return false;
-    }
-}
-
 static bool lighthouse_demoCubePassesOriginalDistance(Cube *cube) {
     f32 vp[3];
     f32 rel[3];
@@ -244,7 +230,7 @@ static void lighthouse_drawCubeSinglePass(
     }
 
     if (!port_shouldDisableCulling()
-        || !lighthouse_demoPlaybackModeExact()
+        || !port_isDemoPlayback()
         || !lighthouse_demoCubePassesOriginalDistance(cube)) {
         return;
     }
@@ -675,14 +661,11 @@ void func_80302C94(Gfx **gfx, Mtx **mtx, Vtx **vtx) {
         // [port] Extended draw distance: per-level cube iteration width.
         int width = 4;
         if (port_shouldDisableCulling() && !func_802E4A08()) {
-            // No-cull normal gameplay: consider the full prop-cube range.
+            // Disable Culling: consider the full prop-cube range in the modes handled here.
             width = sCubeList.width[i];
         } else {
-            // Culling ON, or demo/playback: completely stock range behavior.
+            // Preserve the existing draw-distance event behavior in the remaining modes.
             CALL_EVENT(DrawDistanceCubeWidth, sCubeList.width[i], &width);
-        if (port_shouldDisableCullingCubeRange()) {
-            width = sCubeList.width[i];
-        }
         }
 
         if(vp_cube_indices[i] - sp44[i] > width){
@@ -696,7 +679,7 @@ void func_80302C94(Gfx **gfx, Mtx **mtx, Vtx **vtx) {
     // Save the ORIGINAL demo bounds for logic, then widen only the render
     // traversal to the original +/-4-cube distance around the camera.
     sLighthouseDemoExpandedRangeActive = false;
-    if (port_shouldDisableCulling() && lighthouse_demoPlaybackModeExact()) {
+    if (port_shouldDisableCulling() && port_isDemoPlayback()) {
         for (i = 0; i < 3; i++) {
             sLighthouseDemoOriginalMin[i] = sp44[i];
             sLighthouseDemoOriginalMax[i] = sp38[i];

--- a/src/core2/gccube.c
+++ b/src/core2/gccube.c
@@ -657,7 +657,7 @@ void func_80302C94(Gfx **gfx, Mtx **mtx, Vtx **vtx) {
             sp38[i] = vp_cube_indices[i] + width;
         }
     }
-    // Single-Pass Demo Object No-Cull V2:
+    // Demo visual-only cube rendering:
     // Save the ORIGINAL demo bounds for logic, then widen only the render
     // traversal to the original +/-4-cube distance around the camera.
     sLighthouseDemoExpandedRangeActive = false;

--- a/src/core2/gccube.c
+++ b/src/core2/gccube.c
@@ -255,6 +255,19 @@ static void lighthouse_drawCubeSinglePass(
     D_803860F4 = randF4;
 }
 
+static void lighthouse_drawCubeTraversal(Cube *cube, Gfx **gfx, Mtx **mtx, Vtx **vtx) {
+    bool originallyInRange;
+    bool originallyFrustumVisible;
+
+    if (cube == NULL || cube->prop2Cnt == 0) {
+        return;
+    }
+
+    originallyInRange = lighthouse_cubeWasInOriginalDemoRange(cube);
+    originallyFrustumVisible = originallyInRange && viewport_cube_isInFrustum2(cube) != 0;
+    lighthouse_drawCubeSinglePass(cube, originallyInRange, originallyFrustumVisible, gfx, mtx, vtx);
+}
+
 void func_80301F50(Gfx **gfx, Mtx **mtx, Vtx **vtx, s32 arg3[3], s32 arg4[3], s32 arg5[3]) {
     s32 sp54;
     s32 sp50;
@@ -272,14 +285,7 @@ void func_80301F50(Gfx **gfx, Mtx **mtx, Vtx **vtx, s32 arg3[3], s32 arg4[3], s3
             var_s1 = arg4[2];
             var_s0 = var_fp + var_s1*sCubeList.stride[1];
             while(var_s1 < arg3[2]) {
-                if (var_s0->prop2Cnt != 0) {
-                    bool lighthouseOriginalCubeInRange = lighthouse_cubeWasInOriginalDemoRange(var_s0);
-                    bool lighthouseOriginalCubeVisible =
-                        lighthouseOriginalCubeInRange && viewport_cube_isInFrustum2(var_s0) != 0;
-                    lighthouse_drawCubeSinglePass(
-                        var_s0, lighthouseOriginalCubeInRange, lighthouseOriginalCubeVisible, gfx, mtx, vtx
-                    );
-                }
+                lighthouse_drawCubeTraversal(var_s0, gfx, mtx, vtx);
                 var_s1++;
                 var_s0 += sCubeList.stride[1];
             }
@@ -287,14 +293,7 @@ void func_80301F50(Gfx **gfx, Mtx **mtx, Vtx **vtx, s32 arg3[3], s32 arg4[3], s3
             var_s1 = arg5[2];
             var_s0 = var_fp + var_s1*sCubeList.stride[1];
             while( var_s1 >= arg3[2]) {
-                if (var_s0->prop2Cnt != 0) {
-                    bool lighthouseOriginalCubeInRange = lighthouse_cubeWasInOriginalDemoRange(var_s0);
-                    bool lighthouseOriginalCubeVisible =
-                        lighthouseOriginalCubeInRange && viewport_cube_isInFrustum2(var_s0) != 0;
-                    lighthouse_drawCubeSinglePass(
-                        var_s0, lighthouseOriginalCubeInRange, lighthouseOriginalCubeVisible, gfx, mtx, vtx
-                    );
-                }
+                lighthouse_drawCubeTraversal(var_s0, gfx, mtx, vtx);
                 var_s1--;
                 var_s0 -= sCubeList.stride[1];
             }
@@ -308,14 +307,7 @@ void func_80301F50(Gfx **gfx, Mtx **mtx, Vtx **vtx, s32 arg3[3], s32 arg4[3], s3
             var_s1 = arg4[2];
             var_s0 = var_fp + var_s1*sCubeList.stride[1];
             while(var_s1 < arg3[2]) {
-                if (var_s0->prop2Cnt != 0) {
-                    bool lighthouseOriginalCubeInRange = lighthouse_cubeWasInOriginalDemoRange(var_s0);
-                    bool lighthouseOriginalCubeVisible =
-                        lighthouseOriginalCubeInRange && viewport_cube_isInFrustum2(var_s0) != 0;
-                    lighthouse_drawCubeSinglePass(
-                        var_s0, lighthouseOriginalCubeInRange, lighthouseOriginalCubeVisible, gfx, mtx, vtx
-                    );
-                }
+                lighthouse_drawCubeTraversal(var_s0, gfx, mtx, vtx);
                 var_s1++;
                 var_s0 += sCubeList.stride[1];
             }
@@ -323,14 +315,7 @@ void func_80301F50(Gfx **gfx, Mtx **mtx, Vtx **vtx, s32 arg3[3], s32 arg4[3], s3
             var_s1 = arg5[2];
             var_s0 = var_fp + var_s1*sCubeList.stride[1];
             while(var_s1 >= arg3[2]) {
-                if (var_s0->prop2Cnt != 0) {
-                    bool lighthouseOriginalCubeInRange = lighthouse_cubeWasInOriginalDemoRange(var_s0);
-                    bool lighthouseOriginalCubeVisible =
-                        lighthouseOriginalCubeInRange && viewport_cube_isInFrustum2(var_s0) != 0;
-                    lighthouse_drawCubeSinglePass(
-                        var_s0, lighthouseOriginalCubeInRange, lighthouseOriginalCubeVisible, gfx, mtx, vtx
-                    );
-                }
+                lighthouse_drawCubeTraversal(var_s0, gfx, mtx, vtx);
                 var_s1--;
                 var_s0 -= sCubeList.stride[1];
             }
@@ -352,14 +337,7 @@ void func_80301F50(Gfx **gfx, Mtx **mtx, Vtx **vtx, s32 arg3[3], s32 arg4[3], s3
             var_s1 = arg4[2];
             var_s0 = var_fp + var_s1*sCubeList.stride[1];
             while( var_s1 < arg3[2]) {
-                if (var_s0->prop2Cnt != 0) {
-                    bool lighthouseOriginalCubeInRange = lighthouse_cubeWasInOriginalDemoRange(var_s0);
-                    bool lighthouseOriginalCubeVisible =
-                        lighthouseOriginalCubeInRange && viewport_cube_isInFrustum2(var_s0) != 0;
-                    lighthouse_drawCubeSinglePass(
-                        var_s0, lighthouseOriginalCubeInRange, lighthouseOriginalCubeVisible, gfx, mtx, vtx
-                    );
-                }
+                lighthouse_drawCubeTraversal(var_s0, gfx, mtx, vtx);
                 var_s1++;
                 var_s0 += sCubeList.stride[1];
             }
@@ -367,14 +345,7 @@ void func_80301F50(Gfx **gfx, Mtx **mtx, Vtx **vtx, s32 arg3[3], s32 arg4[3], s3
             var_s1 = arg5[2];
             var_s0 = var_fp + var_s1*sCubeList.stride[1];
             while( var_s1 >= arg3[2]) {
-                if (var_s0->prop2Cnt != 0) {
-                    bool lighthouseOriginalCubeInRange = lighthouse_cubeWasInOriginalDemoRange(var_s0);
-                    bool lighthouseOriginalCubeVisible =
-                        lighthouseOriginalCubeInRange && viewport_cube_isInFrustum2(var_s0) != 0;
-                    lighthouse_drawCubeSinglePass(
-                        var_s0, lighthouseOriginalCubeInRange, lighthouseOriginalCubeVisible, gfx, mtx, vtx
-                    );
-                }
+                lighthouse_drawCubeTraversal(var_s0, gfx, mtx, vtx);
                 var_s1--;
                 var_s0 -= sCubeList.stride[1];
             }
@@ -388,14 +359,7 @@ void func_80301F50(Gfx **gfx, Mtx **mtx, Vtx **vtx, s32 arg3[3], s32 arg4[3], s3
             var_s1 = arg4[2];            
             var_s0 = var_fp + var_s1*sCubeList.stride[1];
             while(var_s1 < arg3[2]) {
-                if (var_s0->prop2Cnt != 0) {
-                    bool lighthouseOriginalCubeInRange = lighthouse_cubeWasInOriginalDemoRange(var_s0);
-                    bool lighthouseOriginalCubeVisible =
-                        lighthouseOriginalCubeInRange && viewport_cube_isInFrustum2(var_s0) != 0;
-                    lighthouse_drawCubeSinglePass(
-                        var_s0, lighthouseOriginalCubeInRange, lighthouseOriginalCubeVisible, gfx, mtx, vtx
-                    );
-                }
+                lighthouse_drawCubeTraversal(var_s0, gfx, mtx, vtx);
                 var_s1++;
                 var_s0 += sCubeList.stride[1];
             }
@@ -403,14 +367,7 @@ void func_80301F50(Gfx **gfx, Mtx **mtx, Vtx **vtx, s32 arg3[3], s32 arg4[3], s3
             var_s1 = arg5[2];            
             var_s0 = var_fp + var_s1*sCubeList.stride[1];
             while(var_s1 >= arg3[2]) {
-                if (var_s0->prop2Cnt != 0) {
-                    bool lighthouseOriginalCubeInRange = lighthouse_cubeWasInOriginalDemoRange(var_s0);
-                    bool lighthouseOriginalCubeVisible =
-                        lighthouseOriginalCubeInRange && viewport_cube_isInFrustum2(var_s0) != 0;
-                    lighthouse_drawCubeSinglePass(
-                        var_s0, lighthouseOriginalCubeInRange, lighthouseOriginalCubeVisible, gfx, mtx, vtx
-                    );
-                }
+                lighthouse_drawCubeTraversal(var_s0, gfx, mtx, vtx);
                 var_s1--;
                 var_s0 -= sCubeList.stride[1];
             }
@@ -439,27 +396,13 @@ void func_80302634(Gfx **gfx, Mtx **mtx, Vtx **vtx, s32 arg3[3], s32 arg4[3], s3
         for(sp54 = arg4[2]; sp54 < arg3[2]; sp54++) {
             var_fp = var_s0 + arg4[0];
             for(var_s1 = arg4[0]; var_s1 < arg3[0]; var_s1++) {
-                if (var_fp->prop2Cnt != 0) {
-                    bool lighthouseOriginalCubeInRange = lighthouse_cubeWasInOriginalDemoRange(var_fp);
-                    bool lighthouseOriginalCubeVisible =
-                        lighthouseOriginalCubeInRange && viewport_cube_isInFrustum2(var_fp) != 0;
-                    lighthouse_drawCubeSinglePass(
-                        var_fp, lighthouseOriginalCubeInRange, lighthouseOriginalCubeVisible, gfx, mtx, vtx
-                    );
-                }
+                lighthouse_drawCubeTraversal(var_fp, gfx, mtx, vtx);
                 var_fp++;
             }
 
             var_fp = var_s0 + arg5[0];
             for(var_s1 = arg5[0]; var_s1 >= arg3[0]; var_s1--) {
-                if (var_fp->prop2Cnt != 0) {
-                    bool lighthouseOriginalCubeInRange = lighthouse_cubeWasInOriginalDemoRange(var_fp);
-                    bool lighthouseOriginalCubeVisible =
-                        lighthouseOriginalCubeInRange && viewport_cube_isInFrustum2(var_fp) != 0;
-                    lighthouse_drawCubeSinglePass(
-                        var_fp, lighthouseOriginalCubeInRange, lighthouseOriginalCubeVisible, gfx, mtx, vtx
-                    );
-                }
+                lighthouse_drawCubeTraversal(var_fp, gfx, mtx, vtx);
                 var_fp--;
             }
             var_s0 += sCubeList.stride[1];
@@ -470,27 +413,13 @@ void func_80302634(Gfx **gfx, Mtx **mtx, Vtx **vtx, s32 arg3[3], s32 arg4[3], s3
         for(sp54 = arg5[2]; sp54 >= arg3[2]; sp54--) {
             var_fp = var_s0 + arg4[0];
             for(var_s1 = arg4[0]; var_s1 < arg3[0]; var_s1++) {
-                if (var_fp->prop2Cnt != 0) {
-                    bool lighthouseOriginalCubeInRange = lighthouse_cubeWasInOriginalDemoRange(var_fp);
-                    bool lighthouseOriginalCubeVisible =
-                        lighthouseOriginalCubeInRange && viewport_cube_isInFrustum2(var_fp) != 0;
-                    lighthouse_drawCubeSinglePass(
-                        var_fp, lighthouseOriginalCubeInRange, lighthouseOriginalCubeVisible, gfx, mtx, vtx
-                    );
-                }
+                lighthouse_drawCubeTraversal(var_fp, gfx, mtx, vtx);
                 var_fp++;
             }
 
             var_fp = var_s0 + arg5[0];
             for(var_s1 = arg5[0]; var_s1 >= arg3[0]; var_s1--) {
-                if (var_fp->prop2Cnt != 0) {
-                    bool lighthouseOriginalCubeInRange = lighthouse_cubeWasInOriginalDemoRange(var_fp);
-                    bool lighthouseOriginalCubeVisible =
-                        lighthouseOriginalCubeInRange && viewport_cube_isInFrustum2(var_fp) != 0;
-                    lighthouse_drawCubeSinglePass(
-                        var_fp, lighthouseOriginalCubeInRange, lighthouseOriginalCubeVisible, gfx, mtx, vtx
-                    );
-                }
+                lighthouse_drawCubeTraversal(var_fp, gfx, mtx, vtx);
                 var_fp--;
             }
             var_s0 -= sCubeList.stride[1];
@@ -507,27 +436,13 @@ void func_80302634(Gfx **gfx, Mtx **mtx, Vtx **vtx, s32 arg3[3], s32 arg4[3], s3
         for(sp54 = arg4[2]; sp54 < arg3[2]; sp54++) {
             var_fp = var_s0 + arg4[0];
             for(var_s1 = arg4[0]; var_s1 < arg3[0]; var_s1++) {
-                if (var_fp->prop2Cnt != 0) {
-                    bool lighthouseOriginalCubeInRange = lighthouse_cubeWasInOriginalDemoRange(var_fp);
-                    bool lighthouseOriginalCubeVisible =
-                        lighthouseOriginalCubeInRange && viewport_cube_isInFrustum2(var_fp) != 0;
-                    lighthouse_drawCubeSinglePass(
-                        var_fp, lighthouseOriginalCubeInRange, lighthouseOriginalCubeVisible, gfx, mtx, vtx
-                    );
-                }
+                lighthouse_drawCubeTraversal(var_fp, gfx, mtx, vtx);
                 var_fp++;
             }
 
             var_fp = var_s0 + arg5[0];
             for(var_s1 = arg5[0]; var_s1 >= arg3[0]; var_s1--) {
-                if (var_fp->prop2Cnt != 0) {
-                    bool lighthouseOriginalCubeInRange = lighthouse_cubeWasInOriginalDemoRange(var_fp);
-                    bool lighthouseOriginalCubeVisible =
-                        lighthouseOriginalCubeInRange && viewport_cube_isInFrustum2(var_fp) != 0;
-                    lighthouse_drawCubeSinglePass(
-                        var_fp, lighthouseOriginalCubeInRange, lighthouseOriginalCubeVisible, gfx, mtx, vtx
-                    );
-                }
+                lighthouse_drawCubeTraversal(var_fp, gfx, mtx, vtx);
                 var_fp--;
             }
             var_s0 += sCubeList.stride[1];
@@ -538,27 +453,13 @@ void func_80302634(Gfx **gfx, Mtx **mtx, Vtx **vtx, s32 arg3[3], s32 arg4[3], s3
         for(sp54 = arg5[2]; sp54 >= arg3[2]; sp54--) {
             var_fp = var_s0 + arg4[0];
             for(var_s1 = arg4[0]; var_s1 < arg3[0]; var_s1++) {
-                if (var_fp->prop2Cnt != 0) {
-                    bool lighthouseOriginalCubeInRange = lighthouse_cubeWasInOriginalDemoRange(var_fp);
-                    bool lighthouseOriginalCubeVisible =
-                        lighthouseOriginalCubeInRange && viewport_cube_isInFrustum2(var_fp) != 0;
-                    lighthouse_drawCubeSinglePass(
-                        var_fp, lighthouseOriginalCubeInRange, lighthouseOriginalCubeVisible, gfx, mtx, vtx
-                    );
-                }
+                lighthouse_drawCubeTraversal(var_fp, gfx, mtx, vtx);
                 var_fp++;
             }
 
             var_fp = var_s0 + arg5[0];
             for(var_s1 = arg5[0]; var_s1 >= arg3[0]; var_s1--) {
-                if (var_fp->prop2Cnt != 0) {
-                    bool lighthouseOriginalCubeInRange = lighthouse_cubeWasInOriginalDemoRange(var_fp);
-                    bool lighthouseOriginalCubeVisible =
-                        lighthouseOriginalCubeInRange && viewport_cube_isInFrustum2(var_fp) != 0;
-                    lighthouse_drawCubeSinglePass(
-                        var_fp, lighthouseOriginalCubeInRange, lighthouseOriginalCubeVisible, gfx, mtx, vtx
-                    );
-                }
+                lighthouse_drawCubeTraversal(var_fp, gfx, mtx, vtx);
                 var_fp--;
             }
             var_s0 -= sCubeList.stride[1];

--- a/src/core2/gccube.c
+++ b/src/core2/gccube.c
@@ -3,6 +3,7 @@
 #include "core1/core1.h"
 #include "functions.h"
 #include "variables.h"
+#include "enums.h"
 #include "bk_math.h" // [port] TUPLE macros
 
 #include <core2/file.h>
@@ -53,6 +54,13 @@ bool func_80308F54(s32 cube_index);
 
 extern ActorInfo D_803675F0;
 extern ActorInfo gWorldExitPad;
+extern s32 getGameMode(void);
+extern s32 D_803860E0;
+extern s32 D_803860E4;
+extern s32 D_803860E8;
+extern s32 D_803860EC;
+extern s32 D_803860F0;
+extern s32 D_803860F4;
 
 /* .data */
 s32 sSpawnableActorSize = 0; //0x8036A9B0
@@ -143,9 +151,125 @@ struct {
 } sCubeList;
 
 /* .code */
+extern void lighthouse_spritePrepassBegin(void);
+extern void lighthouse_spritePrepassEnd(void);
+extern void lighthouse_spritePrepassUpdateCube(Cube *cube);
 void __7AF80_func_80301F10(Cube *cube, Gfx **gfx, Mtx **mtx, Vtx **vtx){
     __code7AF80_func_80308F0C(cube);
     func_8032D510(cube, gfx, mtx, vtx);
+}
+
+static bool sLighthouseDemoCubeVisualOnly = false;
+static bool sLighthouseDemoExpandedRangeActive = false;
+static s32 sLighthouseDemoOriginalMin[3] = { 0, 0, 0 };
+static s32 sLighthouseDemoOriginalMax[3] = { 0, 0, 0 };
+
+bool lighthouse_demoCubeVisualOnly(void) {
+    return sLighthouseDemoCubeVisualOnly;
+}
+
+static bool lighthouse_cubeWasInOriginalDemoRange(Cube *cube) {
+    s32 ix;
+    s32 iy;
+    s32 iz;
+
+    if (!sLighthouseDemoExpandedRangeActive) {
+        return true;
+    }
+
+    ix = cube->x - sCubeList.min[0];
+    iy = cube->y - sCubeList.min[1];
+    iz = cube->z - sCubeList.min[2];
+
+    return ix >= sLighthouseDemoOriginalMin[0] && ix <= sLighthouseDemoOriginalMax[0]
+        && iy >= sLighthouseDemoOriginalMin[1] && iy <= sLighthouseDemoOriginalMax[1]
+        && iz >= sLighthouseDemoOriginalMin[2] && iz <= sLighthouseDemoOriginalMax[2];
+}
+
+static bool lighthouse_demoPlaybackModeExact(void) {
+    switch (getGameMode()) {
+        case GAME_MODE_2_UNKNOWN:
+        case GAME_MODE_6_FILE_PLAYBACK:
+        case GAME_MODE_7_ATTRACT_DEMO:
+        case GAME_MODE_8_BOTTLES_BONUS:
+        case GAME_MODE_A_SNS_PICTURE:
+        case GAME_MODE_9_BANJO_AND_KAZOOIE:
+            return true;
+        default:
+            return false;
+    }
+}
+
+static bool lighthouse_demoCubePassesOriginalDistance(Cube *cube) {
+    f32 vp[3];
+    f32 rel[3];
+    f32 mul;
+
+    if (cube->x == -16) {
+        return true;
+    }
+
+    viewport_getPosition_vec3f(vp);
+    rel[0] = (f32)((cube->x * 1000) + 500) - vp[0];
+    rel[1] = (f32)((cube->y * 1000) + 500) - vp[1];
+    rel[2] = (f32)((cube->z * 1000) + 500) - vp[2];
+
+    mul = port_drawDistanceMul();
+    return ((rel[0] * rel[0]) + (rel[1] * rel[1]) + (rel[2] * rel[2]))
+        <= (1.6e7f * mul * mul);
+}
+
+static void lighthouse_drawCubeSinglePass(
+    Cube *cube,
+    bool originallyInRange,
+    bool originallyFrustumVisible,
+    Gfx **gfx,
+    Mtx **mtx,
+    Vtx **vtx
+) {
+    s32 randE0;
+    s32 randE4;
+    s32 randE8;
+    s32 randEC;
+    s32 randF0;
+    s32 randF4;
+
+    if (cube == NULL || cube->prop2Cnt == 0) {
+        return;
+    }
+
+    if (originallyInRange && originallyFrustumVisible) {
+        __7AF80_func_80301F10(cube, gfx, mtx, vtx);
+        return;
+    }
+
+    if (!port_shouldDisableCulling()
+        || !lighthouse_demoPlaybackModeExact()
+        || !lighthouse_demoCubePassesOriginalDistance(cube)) {
+        return;
+    }
+
+    randE0 = D_803860E0;
+    randE4 = D_803860E4;
+    randE8 = D_803860E8;
+    randEC = D_803860EC;
+    randF0 = D_803860F0;
+    randF4 = D_803860F4;
+
+    sLighthouseDemoCubeVisualOnly = true;
+
+    // Do not mark this cube visited; the original demo culled it.
+    // This is a SINGLE render pass at the normal traversal point.
+    func_8032D510(cube, gfx, mtx, vtx);
+
+    sLighthouseDemoCubeVisualOnly = false;
+
+    D_803860E0 = randE0;
+    D_803860E4 = randE4;
+    D_803860E8 = randE8;
+    D_803860EC = randEC;
+    D_803860F0 = randF0;
+    D_803860F4 = randF4;
 }
 
 void func_80301F50(Gfx **gfx, Mtx **mtx, Vtx **vtx, s32 arg3[3], s32 arg4[3], s32 arg5[3]) {
@@ -165,8 +289,13 @@ void func_80301F50(Gfx **gfx, Mtx **mtx, Vtx **vtx, s32 arg3[3], s32 arg4[3], s3
             var_s1 = arg4[2];
             var_s0 = var_fp + var_s1*sCubeList.stride[1];
             while(var_s1 < arg3[2]) {
-                if ((var_s0->prop2Cnt != 0) && viewport_cube_isInFrustum2(var_s0) != 0) {
-                    __7AF80_func_80301F10(var_s0, gfx, mtx, vtx);
+                if (var_s0->prop2Cnt != 0) {
+                    bool lighthouseOriginalCubeInRange = lighthouse_cubeWasInOriginalDemoRange(var_s0);
+                    bool lighthouseOriginalCubeVisible =
+                        lighthouseOriginalCubeInRange && viewport_cube_isInFrustum2(var_s0) != 0;
+                    lighthouse_drawCubeSinglePass(
+                        var_s0, lighthouseOriginalCubeInRange, lighthouseOriginalCubeVisible, gfx, mtx, vtx
+                    );
                 }
                 var_s1++;
                 var_s0 += sCubeList.stride[1];
@@ -175,8 +304,13 @@ void func_80301F50(Gfx **gfx, Mtx **mtx, Vtx **vtx, s32 arg3[3], s32 arg4[3], s3
             var_s1 = arg5[2];
             var_s0 = var_fp + var_s1*sCubeList.stride[1];
             while( var_s1 >= arg3[2]) {
-                if ((var_s0->prop2Cnt != 0) && viewport_cube_isInFrustum2(var_s0) != 0) {
-                    __7AF80_func_80301F10(var_s0, gfx, mtx, vtx);
+                if (var_s0->prop2Cnt != 0) {
+                    bool lighthouseOriginalCubeInRange = lighthouse_cubeWasInOriginalDemoRange(var_s0);
+                    bool lighthouseOriginalCubeVisible =
+                        lighthouseOriginalCubeInRange && viewport_cube_isInFrustum2(var_s0) != 0;
+                    lighthouse_drawCubeSinglePass(
+                        var_s0, lighthouseOriginalCubeInRange, lighthouseOriginalCubeVisible, gfx, mtx, vtx
+                    );
                 }
                 var_s1--;
                 var_s0 -= sCubeList.stride[1];
@@ -191,8 +325,13 @@ void func_80301F50(Gfx **gfx, Mtx **mtx, Vtx **vtx, s32 arg3[3], s32 arg4[3], s3
             var_s1 = arg4[2];
             var_s0 = var_fp + var_s1*sCubeList.stride[1];
             while(var_s1 < arg3[2]) {
-                if ((var_s0->prop2Cnt != 0) && viewport_cube_isInFrustum2(var_s0) != 0) {
-                    __7AF80_func_80301F10(var_s0, gfx, mtx, vtx);
+                if (var_s0->prop2Cnt != 0) {
+                    bool lighthouseOriginalCubeInRange = lighthouse_cubeWasInOriginalDemoRange(var_s0);
+                    bool lighthouseOriginalCubeVisible =
+                        lighthouseOriginalCubeInRange && viewport_cube_isInFrustum2(var_s0) != 0;
+                    lighthouse_drawCubeSinglePass(
+                        var_s0, lighthouseOriginalCubeInRange, lighthouseOriginalCubeVisible, gfx, mtx, vtx
+                    );
                 }
                 var_s1++;
                 var_s0 += sCubeList.stride[1];
@@ -201,8 +340,13 @@ void func_80301F50(Gfx **gfx, Mtx **mtx, Vtx **vtx, s32 arg3[3], s32 arg4[3], s3
             var_s1 = arg5[2];
             var_s0 = var_fp + var_s1*sCubeList.stride[1];
             while(var_s1 >= arg3[2]) {
-                if ((var_s0->prop2Cnt != 0) && viewport_cube_isInFrustum2(var_s0) != 0) {
-                    __7AF80_func_80301F10(var_s0, gfx, mtx, vtx);
+                if (var_s0->prop2Cnt != 0) {
+                    bool lighthouseOriginalCubeInRange = lighthouse_cubeWasInOriginalDemoRange(var_s0);
+                    bool lighthouseOriginalCubeVisible =
+                        lighthouseOriginalCubeInRange && viewport_cube_isInFrustum2(var_s0) != 0;
+                    lighthouse_drawCubeSinglePass(
+                        var_s0, lighthouseOriginalCubeInRange, lighthouseOriginalCubeVisible, gfx, mtx, vtx
+                    );
                 }
                 var_s1--;
                 var_s0 -= sCubeList.stride[1];
@@ -225,8 +369,13 @@ void func_80301F50(Gfx **gfx, Mtx **mtx, Vtx **vtx, s32 arg3[3], s32 arg4[3], s3
             var_s1 = arg4[2];
             var_s0 = var_fp + var_s1*sCubeList.stride[1];
             while( var_s1 < arg3[2]) {
-                if ((var_s0->prop2Cnt != 0) && viewport_cube_isInFrustum2(var_s0) != 0) {
-                    __7AF80_func_80301F10(var_s0, gfx, mtx, vtx);
+                if (var_s0->prop2Cnt != 0) {
+                    bool lighthouseOriginalCubeInRange = lighthouse_cubeWasInOriginalDemoRange(var_s0);
+                    bool lighthouseOriginalCubeVisible =
+                        lighthouseOriginalCubeInRange && viewport_cube_isInFrustum2(var_s0) != 0;
+                    lighthouse_drawCubeSinglePass(
+                        var_s0, lighthouseOriginalCubeInRange, lighthouseOriginalCubeVisible, gfx, mtx, vtx
+                    );
                 }
                 var_s1++;
                 var_s0 += sCubeList.stride[1];
@@ -235,8 +384,13 @@ void func_80301F50(Gfx **gfx, Mtx **mtx, Vtx **vtx, s32 arg3[3], s32 arg4[3], s3
             var_s1 = arg5[2];
             var_s0 = var_fp + var_s1*sCubeList.stride[1];
             while( var_s1 >= arg3[2]) {
-                if ((var_s0->prop2Cnt != 0) && viewport_cube_isInFrustum2(var_s0) != 0) {
-                    __7AF80_func_80301F10(var_s0, gfx, mtx, vtx);
+                if (var_s0->prop2Cnt != 0) {
+                    bool lighthouseOriginalCubeInRange = lighthouse_cubeWasInOriginalDemoRange(var_s0);
+                    bool lighthouseOriginalCubeVisible =
+                        lighthouseOriginalCubeInRange && viewport_cube_isInFrustum2(var_s0) != 0;
+                    lighthouse_drawCubeSinglePass(
+                        var_s0, lighthouseOriginalCubeInRange, lighthouseOriginalCubeVisible, gfx, mtx, vtx
+                    );
                 }
                 var_s1--;
                 var_s0 -= sCubeList.stride[1];
@@ -251,8 +405,13 @@ void func_80301F50(Gfx **gfx, Mtx **mtx, Vtx **vtx, s32 arg3[3], s32 arg4[3], s3
             var_s1 = arg4[2];            
             var_s0 = var_fp + var_s1*sCubeList.stride[1];
             while(var_s1 < arg3[2]) {
-                if ((var_s0->prop2Cnt != 0) && viewport_cube_isInFrustum2(var_s0) != 0) {
-                    __7AF80_func_80301F10(var_s0, gfx, mtx, vtx);
+                if (var_s0->prop2Cnt != 0) {
+                    bool lighthouseOriginalCubeInRange = lighthouse_cubeWasInOriginalDemoRange(var_s0);
+                    bool lighthouseOriginalCubeVisible =
+                        lighthouseOriginalCubeInRange && viewport_cube_isInFrustum2(var_s0) != 0;
+                    lighthouse_drawCubeSinglePass(
+                        var_s0, lighthouseOriginalCubeInRange, lighthouseOriginalCubeVisible, gfx, mtx, vtx
+                    );
                 }
                 var_s1++;
                 var_s0 += sCubeList.stride[1];
@@ -261,8 +420,13 @@ void func_80301F50(Gfx **gfx, Mtx **mtx, Vtx **vtx, s32 arg3[3], s32 arg4[3], s3
             var_s1 = arg5[2];            
             var_s0 = var_fp + var_s1*sCubeList.stride[1];
             while(var_s1 >= arg3[2]) {
-                if ((var_s0->prop2Cnt != 0) && viewport_cube_isInFrustum2(var_s0) != 0) {
-                    __7AF80_func_80301F10(var_s0, gfx, mtx, vtx);
+                if (var_s0->prop2Cnt != 0) {
+                    bool lighthouseOriginalCubeInRange = lighthouse_cubeWasInOriginalDemoRange(var_s0);
+                    bool lighthouseOriginalCubeVisible =
+                        lighthouseOriginalCubeInRange && viewport_cube_isInFrustum2(var_s0) != 0;
+                    lighthouse_drawCubeSinglePass(
+                        var_s0, lighthouseOriginalCubeInRange, lighthouseOriginalCubeVisible, gfx, mtx, vtx
+                    );
                 }
                 var_s1--;
                 var_s0 -= sCubeList.stride[1];
@@ -292,16 +456,26 @@ void func_80302634(Gfx **gfx, Mtx **mtx, Vtx **vtx, s32 arg3[3], s32 arg4[3], s3
         for(sp54 = arg4[2]; sp54 < arg3[2]; sp54++) {
             var_fp = var_s0 + arg4[0];
             for(var_s1 = arg4[0]; var_s1 < arg3[0]; var_s1++) {
-                if ((var_fp->prop2Cnt != 0) && viewport_cube_isInFrustum2(var_fp) != 0) {
-                    __7AF80_func_80301F10(var_fp, gfx, mtx, vtx);
+                if (var_fp->prop2Cnt != 0) {
+                    bool lighthouseOriginalCubeInRange = lighthouse_cubeWasInOriginalDemoRange(var_fp);
+                    bool lighthouseOriginalCubeVisible =
+                        lighthouseOriginalCubeInRange && viewport_cube_isInFrustum2(var_fp) != 0;
+                    lighthouse_drawCubeSinglePass(
+                        var_fp, lighthouseOriginalCubeInRange, lighthouseOriginalCubeVisible, gfx, mtx, vtx
+                    );
                 }
                 var_fp++;
             }
 
             var_fp = var_s0 + arg5[0];
             for(var_s1 = arg5[0]; var_s1 >= arg3[0]; var_s1--) {
-                if ((var_fp->prop2Cnt != 0) && viewport_cube_isInFrustum2(var_fp) != 0) {
-                    __7AF80_func_80301F10(var_fp, gfx, mtx, vtx);
+                if (var_fp->prop2Cnt != 0) {
+                    bool lighthouseOriginalCubeInRange = lighthouse_cubeWasInOriginalDemoRange(var_fp);
+                    bool lighthouseOriginalCubeVisible =
+                        lighthouseOriginalCubeInRange && viewport_cube_isInFrustum2(var_fp) != 0;
+                    lighthouse_drawCubeSinglePass(
+                        var_fp, lighthouseOriginalCubeInRange, lighthouseOriginalCubeVisible, gfx, mtx, vtx
+                    );
                 }
                 var_fp--;
             }
@@ -313,16 +487,26 @@ void func_80302634(Gfx **gfx, Mtx **mtx, Vtx **vtx, s32 arg3[3], s32 arg4[3], s3
         for(sp54 = arg5[2]; sp54 >= arg3[2]; sp54--) {
             var_fp = var_s0 + arg4[0];
             for(var_s1 = arg4[0]; var_s1 < arg3[0]; var_s1++) {
-                if ((var_fp->prop2Cnt != 0) && viewport_cube_isInFrustum2(var_fp) != 0) {
-                    __7AF80_func_80301F10(var_fp, gfx, mtx, vtx);
+                if (var_fp->prop2Cnt != 0) {
+                    bool lighthouseOriginalCubeInRange = lighthouse_cubeWasInOriginalDemoRange(var_fp);
+                    bool lighthouseOriginalCubeVisible =
+                        lighthouseOriginalCubeInRange && viewport_cube_isInFrustum2(var_fp) != 0;
+                    lighthouse_drawCubeSinglePass(
+                        var_fp, lighthouseOriginalCubeInRange, lighthouseOriginalCubeVisible, gfx, mtx, vtx
+                    );
                 }
                 var_fp++;
             }
 
             var_fp = var_s0 + arg5[0];
             for(var_s1 = arg5[0]; var_s1 >= arg3[0]; var_s1--) {
-                if ((var_fp->prop2Cnt != 0) && viewport_cube_isInFrustum2(var_fp) != 0) {
-                    __7AF80_func_80301F10(var_fp, gfx, mtx, vtx);
+                if (var_fp->prop2Cnt != 0) {
+                    bool lighthouseOriginalCubeInRange = lighthouse_cubeWasInOriginalDemoRange(var_fp);
+                    bool lighthouseOriginalCubeVisible =
+                        lighthouseOriginalCubeInRange && viewport_cube_isInFrustum2(var_fp) != 0;
+                    lighthouse_drawCubeSinglePass(
+                        var_fp, lighthouseOriginalCubeInRange, lighthouseOriginalCubeVisible, gfx, mtx, vtx
+                    );
                 }
                 var_fp--;
             }
@@ -340,16 +524,26 @@ void func_80302634(Gfx **gfx, Mtx **mtx, Vtx **vtx, s32 arg3[3], s32 arg4[3], s3
         for(sp54 = arg4[2]; sp54 < arg3[2]; sp54++) {
             var_fp = var_s0 + arg4[0];
             for(var_s1 = arg4[0]; var_s1 < arg3[0]; var_s1++) {
-                if ((var_fp->prop2Cnt != 0) && viewport_cube_isInFrustum2(var_fp) != 0) {
-                    __7AF80_func_80301F10(var_fp, gfx, mtx, vtx);
+                if (var_fp->prop2Cnt != 0) {
+                    bool lighthouseOriginalCubeInRange = lighthouse_cubeWasInOriginalDemoRange(var_fp);
+                    bool lighthouseOriginalCubeVisible =
+                        lighthouseOriginalCubeInRange && viewport_cube_isInFrustum2(var_fp) != 0;
+                    lighthouse_drawCubeSinglePass(
+                        var_fp, lighthouseOriginalCubeInRange, lighthouseOriginalCubeVisible, gfx, mtx, vtx
+                    );
                 }
                 var_fp++;
             }
 
             var_fp = var_s0 + arg5[0];
             for(var_s1 = arg5[0]; var_s1 >= arg3[0]; var_s1--) {
-                if ((var_fp->prop2Cnt != 0) && viewport_cube_isInFrustum2(var_fp) != 0) {
-                    __7AF80_func_80301F10(var_fp, gfx, mtx, vtx);
+                if (var_fp->prop2Cnt != 0) {
+                    bool lighthouseOriginalCubeInRange = lighthouse_cubeWasInOriginalDemoRange(var_fp);
+                    bool lighthouseOriginalCubeVisible =
+                        lighthouseOriginalCubeInRange && viewport_cube_isInFrustum2(var_fp) != 0;
+                    lighthouse_drawCubeSinglePass(
+                        var_fp, lighthouseOriginalCubeInRange, lighthouseOriginalCubeVisible, gfx, mtx, vtx
+                    );
                 }
                 var_fp--;
             }
@@ -361,16 +555,26 @@ void func_80302634(Gfx **gfx, Mtx **mtx, Vtx **vtx, s32 arg3[3], s32 arg4[3], s3
         for(sp54 = arg5[2]; sp54 >= arg3[2]; sp54--) {
             var_fp = var_s0 + arg4[0];
             for(var_s1 = arg4[0]; var_s1 < arg3[0]; var_s1++) {
-                if ((var_fp->prop2Cnt != 0) && viewport_cube_isInFrustum2(var_fp) != 0) {
-                    __7AF80_func_80301F10(var_fp, gfx, mtx, vtx);
+                if (var_fp->prop2Cnt != 0) {
+                    bool lighthouseOriginalCubeInRange = lighthouse_cubeWasInOriginalDemoRange(var_fp);
+                    bool lighthouseOriginalCubeVisible =
+                        lighthouseOriginalCubeInRange && viewport_cube_isInFrustum2(var_fp) != 0;
+                    lighthouse_drawCubeSinglePass(
+                        var_fp, lighthouseOriginalCubeInRange, lighthouseOriginalCubeVisible, gfx, mtx, vtx
+                    );
                 }
                 var_fp++;
             }
 
             var_fp = var_s0 + arg5[0];
             for(var_s1 = arg5[0]; var_s1 >= arg3[0]; var_s1--) {
-                if ((var_fp->prop2Cnt != 0) && viewport_cube_isInFrustum2(var_fp) != 0) {
-                    __7AF80_func_80301F10(var_fp, gfx, mtx, vtx);
+                if (var_fp->prop2Cnt != 0) {
+                    bool lighthouseOriginalCubeInRange = lighthouse_cubeWasInOriginalDemoRange(var_fp);
+                    bool lighthouseOriginalCubeVisible =
+                        lighthouseOriginalCubeInRange && viewport_cube_isInFrustum2(var_fp) != 0;
+                    lighthouse_drawCubeSinglePass(
+                        var_fp, lighthouseOriginalCubeInRange, lighthouseOriginalCubeVisible, gfx, mtx, vtx
+                    );
                 }
                 var_fp--;
             }
@@ -396,6 +600,22 @@ void func_80302C94(Gfx **gfx, Mtx **mtx, Vtx **vtx) {
 #endif
 
     func_8032D3A8();
+
+    // Keep every sprite animation current when culling is disabled.
+    if (port_shouldDisableCulling()) {
+        Cube *lighthouseSpriteCube;
+
+        lighthouse_spritePrepassBegin();
+
+        for (lighthouseSpriteCube = sCubeList.cubes;
+             lighthouseSpriteCube < sCubeList.cubes + sCubeList.cubeCnt;
+             lighthouseSpriteCube++) {
+            lighthouse_spritePrepassUpdateCube(lighthouseSpriteCube);
+        }
+
+        lighthouse_spritePrepassUpdateCube(sCubeList.unk3C);
+        lighthouse_spritePrepassUpdateCube(sCubeList.unk40);
+    }
     viewport_getPosition_vec3f(vp_position);
     viewport_getRotation_vec3f(vp_rotation);
     ml_vec3f_clamp_deg360(vp_rotation);
@@ -406,51 +626,64 @@ void func_80302C94(Gfx **gfx, Mtx **mtx, Vtx **vtx) {
     sp38[0] = sCubeList.width[0] - 1;\
     sp38[1] = sCubeList.width[1] - 1;\
     sp38[2] = sCubeList.width[2] - 1;
-    if ((vp_rotation[0]> 250.0f) && (vp_rotation[0]< 290.0f)) {
-        if ((vp_rotation[1] >= 225.0f) && (vp_rotation[1] <= 315.0f)) {
-            sp44[0] = (vp_cube_indices[0] > sp44[0]) ? vp_cube_indices[0] - 1 : sp44[0];
-        } else {
-            if ((vp_rotation[1] >= 45.0f) && (vp_rotation[1] <= 135.0f)) {
-                sp38[0] = vp_cube_indices[0];
+    // Disable Culling ON + normal gameplay: do not prune prop cubes by camera direction.
+    // Disable Culling OFF: execute the original Lighthouse culling below.
+    // Demo/playback: also execute the original culling for sync.
+    if (!(port_shouldDisableCulling() && !func_802E4A08())) {
+        if ((vp_rotation[0]> 250.0f) && (vp_rotation[0]< 290.0f)) {
+            if ((vp_rotation[1] >= 225.0f) && (vp_rotation[1] <= 315.0f)) {
+                sp44[0] = (vp_cube_indices[0] > sp44[0]) ? vp_cube_indices[0] - 1 : sp44[0];
+            } else {
+                if ((vp_rotation[1] >= 45.0f) && (vp_rotation[1] <= 135.0f)) {
+                    sp38[0] = vp_cube_indices[0];
+                }
             }
-        }
 
-        if ((vp_rotation[0]>= 45.0f) && (vp_rotation[0]<= 135.0f)) {
-            sp44[1] = vp_cube_indices[1];
-        } else if ((vp_rotation[0]>= 225.0f) && (vp_rotation[0]<= 315.0f)) {
-            sp38[1] = vp_cube_indices[1];
-        }
-        if ((vp_rotation[1] >= 135.0f) && (vp_rotation[1] <= 225.0f)) {
-            sp44[2] = (vp_cube_indices[2] > sp44[2]) ? vp_cube_indices[2] - 1 : sp44[2];
-        } else if ((315.0f <= vp_rotation[1]) || (vp_rotation[1] <= 45.0f)) {
-            sp38[2] = vp_cube_indices[2];
-        }
-    } else {
-        if ((vp_rotation[1] >= 225.0f) && (vp_rotation[1] <= 315.0f)) {
-            sp44[0] = vp_cube_indices[0];
-        } else {
-            if ((vp_rotation[1] >= 45.0f) && (vp_rotation[1] <= 135.0f)) {
-                sp38[0] = vp_cube_indices[0];
+            if ((vp_rotation[0]>= 45.0f) && (vp_rotation[0]<= 135.0f)) {
+                sp44[1] = vp_cube_indices[1];
+            } else if ((vp_rotation[0]>= 225.0f) && (vp_rotation[0]<= 315.0f)) {
+                sp38[1] = vp_cube_indices[1];
             }
-        }
+            if ((vp_rotation[1] >= 135.0f) && (vp_rotation[1] <= 225.0f)) {
+                sp44[2] = (vp_cube_indices[2] > sp44[2]) ? vp_cube_indices[2] - 1 : sp44[2];
+            } else if ((315.0f <= vp_rotation[1]) || (vp_rotation[1] <= 45.0f)) {
+                sp38[2] = vp_cube_indices[2];
+            }
+        } else {
+            if ((vp_rotation[1] >= 225.0f) && (vp_rotation[1] <= 315.0f)) {
+                sp44[0] = vp_cube_indices[0];
+            } else {
+                if ((vp_rotation[1] >= 45.0f) && (vp_rotation[1] <= 135.0f)) {
+                    sp38[0] = vp_cube_indices[0];
+                }
+            }
 
-        if ((vp_rotation[0]>= 45.0f) && (vp_rotation[0]<= 135.0f)) {
-            sp44[1] = vp_cube_indices[1];
-        } else if ((vp_rotation[0]>= 225.0f) && (vp_rotation[0]<= 315.0f)) {
-            sp38[1] = vp_cube_indices[1];
-        }
+            if ((vp_rotation[0]>= 45.0f) && (vp_rotation[0]<= 135.0f)) {
+                sp44[1] = vp_cube_indices[1];
+            } else if ((vp_rotation[0]>= 225.0f) && (vp_rotation[0]<= 315.0f)) {
+                sp38[1] = vp_cube_indices[1];
+            }
         
-        if ((vp_rotation[1] >= 135.0f) && (vp_rotation[1] <= 225.0f)) {
-            sp44[2] = vp_cube_indices[2];
-        } else if ((315.0f <= vp_rotation[1]) || (vp_rotation[1] <= 45.0f)) {
-            sp38[2] = vp_cube_indices[2];
+            if ((vp_rotation[1] >= 135.0f) && (vp_rotation[1] <= 225.0f)) {
+                sp44[2] = vp_cube_indices[2];
+            } else if ((315.0f <= vp_rotation[1]) || (vp_rotation[1] <= 45.0f)) {
+                sp38[2] = vp_cube_indices[2];
+            }
         }
     }
-
     for(i = 0; i < 3; i++){
         // [port] Extended draw distance: per-level cube iteration width.
         int width = 4;
-        CALL_EVENT(DrawDistanceCubeWidth, sCubeList.width[i], &width);
+        if (port_shouldDisableCulling() && !func_802E4A08()) {
+            // No-cull normal gameplay: consider the full prop-cube range.
+            width = sCubeList.width[i];
+        } else {
+            // Culling ON, or demo/playback: completely stock range behavior.
+            CALL_EVENT(DrawDistanceCubeWidth, sCubeList.width[i], &width);
+        if (port_shouldDisableCullingCubeRange()) {
+            width = sCubeList.width[i];
+        }
+        }
 
         if(vp_cube_indices[i] - sp44[i] > width){
             sp44[i] = vp_cube_indices[i] - width;
@@ -459,6 +692,31 @@ void func_80302C94(Gfx **gfx, Mtx **mtx, Vtx **vtx) {
             sp38[i] = vp_cube_indices[i] + width;
         }
     }
+    // Single-Pass Demo Object No-Cull V2:
+    // Save the ORIGINAL demo bounds for logic, then widen only the render
+    // traversal to the original +/-4-cube distance around the camera.
+    sLighthouseDemoExpandedRangeActive = false;
+    if (port_shouldDisableCulling() && lighthouse_demoPlaybackModeExact()) {
+        for (i = 0; i < 3; i++) {
+            sLighthouseDemoOriginalMin[i] = sp44[i];
+            sLighthouseDemoOriginalMax[i] = sp38[i];
+        }
+
+        sLighthouseDemoExpandedRangeActive = true;
+
+        for (i = 0; i < 3; i++) {
+            sp44[i] = vp_cube_indices[i] - 4;
+            sp38[i] = vp_cube_indices[i] + 4;
+
+            if (sp44[i] < 0) {
+                sp44[i] = 0;
+            }
+            if (sp38[i] >= sCubeList.width[i]) {
+                sp38[i] = sCubeList.width[i] - 1;
+            }
+        }
+    }
+
     if (sCubeList.unk3C != NULL) {
         func_8032D510(sCubeList.unk3C, gfx, mtx, vtx);
     }
@@ -472,6 +730,7 @@ void func_80302C94(Gfx **gfx, Mtx **mtx, Vtx **vtx) {
         func_80302634(gfx, mtx, vtx, vp_cube_indices, sp44, sp38);
     }
     func_80308D2C(gfx, mtx, vtx);
+    lighthouse_spritePrepassEnd();
 }
 
 void cube_positionToIndices(s32 indices[3], f32 position[3]) {

--- a/src/core2/gccube.c
+++ b/src/core2/gccube.c
@@ -3,7 +3,6 @@
 #include "core1/core1.h"
 #include "functions.h"
 #include "variables.h"
-#include "enums.h"
 #include "bk_math.h" // [port] TUPLE macros
 
 #include <core2/file.h>
@@ -54,7 +53,6 @@ bool func_80308F54(s32 cube_index);
 
 extern ActorInfo D_803675F0;
 extern ActorInfo gWorldExitPad;
-extern s32 getGameMode(void);
 extern s32 D_803860E0;
 extern s32 D_803860E4;
 extern s32 D_803860E8;

--- a/src/core2/model/modelRender.c
+++ b/src/core2/model/modelRender.c
@@ -39,8 +39,6 @@ extern AnimMtxList *animMtxList_defrag(AnimMtxList *);
 extern MtxF *animMtxList_get(AnimMtxList *this, s32 arg1);
 extern bool lighthouse_cullV2_inPlaybackMode(void);
 extern void lighthouse_cullV2_setFrustumChecksEnabled(bool enabled);
-extern void lighthouse_menuCull_setFrustumChecksEnabled(bool enabled);
-extern void lighthouse_demoSync_setFrustumChecksEnabled(bool enabled);
 extern void actor_postdrawMethod(ActorMarker *);
 extern void actor_predrawMethod(Actor *);
 

--- a/src/core2/model/modelRender.c
+++ b/src/core2/model/modelRender.c
@@ -12,7 +12,6 @@
 #include "port/Interpolation/FrameInterpolation.h"
 #include "port/Patches/GeoCull.h"
 
-
 #define ARRAYLEN(x) (sizeof(x) / sizeof((x)[0]))
 
 extern bool cameraAreaList_searchForEntryInBounds(BKCameraAreaList *this, u8 *id, u32 count);
@@ -22,7 +21,7 @@ extern void assetCache_free(void *);
 extern AnimMtxList *animMtxList_new();
 extern AnimMtxList *animMtxList_defrag(AnimMtxList *);
 extern MtxF *animMtxList_get(AnimMtxList *this, s32 arg1);
-extern void lighthouse_cullV2_setFrustumChecksEnabled(bool enabled);
+extern void lighthouse_setFrustumChecksEnabled(bool enabled);
 
 
 typedef struct{
@@ -1373,11 +1372,11 @@ BKModelBin *modelRender_draw(Gfx **gfx, Mtx **mtx, f32 position[3], f32 rotation
     // [port] Mirror mode: counter-mirror text-bearing models so text reads correctly
     if (_mirror_excluded) gSPClearExtraGeometryMode((*gfx)++, G_EX_INVERT_CULLING);
     if (port_shouldDisableCulling()) {
-        lighthouse_cullV2_setFrustumChecksEnabled(false);
+        lighthouse_setFrustumChecksEnabled(false);
     }
     modelRender_executeGeoCmds(gfx, mtx, (BKGeoCmd *)((u8 *)model_bin + model_bin->geo_list_offset));
     if (port_shouldDisableCulling()) {
-        lighthouse_cullV2_setFrustumChecksEnabled(true);
+        lighthouse_setFrustumChecksEnabled(true);
     }
     // [port] Mirror mode: restore culling inversion
     if (_mirror_excluded) gSPSetExtraGeometryMode((*gfx)++, G_EX_INVERT_CULLING);

--- a/src/core2/model/modelRender.c
+++ b/src/core2/model/modelRender.c
@@ -832,6 +832,29 @@ void modelRender_geoCmd_SORT(Gfx **gfx, Mtx **mtx, struct bk_geo_cmd_s *arg2){
 
     f14 = D_80383C68[0]*D_80383C78[0] + D_80383C68[1]*D_80383C78[1] + D_80383C68[2]*D_80383C78[2];
     f14 = -f14;
+    // [port] Disable Culling SORT one-sided geometry fix
+    // A one-sided SORT node normally submits only the camera-facing child.
+    // With Disable Culling, submit both children in camera order during normal gameplay.
+    // Demo/playback keeps the original branch selection for deterministic behavior.
+    if (port_shouldDisableCulling() && !port_isDemoPlayback() && (cmd->unk20 & 1)) {
+        D_80383C64 = f14;
+        if (0.0f <= f14) {
+            if (cmd->unk22) {
+                modelRender_executeGeoCmds(gfx, mtx, (BKGeoCmd*)((u8*)cmd + cmd->unk22));
+            }
+            if (cmd->unk24) {
+                modelRender_executeGeoCmds(gfx, mtx, (BKGeoCmd*)((u8*)cmd + cmd->unk24));
+            }
+        } else {
+            if (cmd->unk24) {
+                modelRender_executeGeoCmds(gfx, mtx, (BKGeoCmd*)((u8*)cmd + cmd->unk24));
+            }
+            if (cmd->unk22) {
+                modelRender_executeGeoCmds(gfx, mtx, (BKGeoCmd*)((u8*)cmd + cmd->unk22));
+            }
+        }
+        return;
+    }
     if(cmd->unk20 & 1){
         if(0.0f <= f14 && (tmp_v0 = cmd->unk24)){
             D_80383C64 = f14;
@@ -1258,10 +1281,15 @@ BKModelBin *modelRender_draw(Gfx **gfx, Mtx **mtx, f32 position[3], f32 rotation
     modelRendervertexList = modelRendervertexList ? modelRendervertexList : (BKVertexList *)((uintptr_t)modelRenderModelBin + (uintptr_t)(u32)modelRenderModelBin->vtx_list_offset);
     modelRenderCameraAreaList = (modelRenderModelBin->camera_area_list_offset == 0) ? NULL : (BKCameraAreaList *)((uintptr_t)model_bin + (uintptr_t)(u32)model_bin->camera_area_list_offset);
 
-    if (D_80383710 && (!port_shouldDisableCulling() || port_isDemoPlayback())) {
+    if (D_80383710) {
         tmp_f0 = D_80383708 - 500.0f;
         if(tmp_f0 < camera_focus_distance){
             alpha = (s32)((1.0f - (camera_focus_distance - tmp_f0)/500.0f)*255.0f);
+            // [port] Preserve model fading with Disable Culling
+            // No-cull can keep a model alive beyond the original final cutoff.
+            // Clamp the completed fade instead of allowing alpha to wrap.
+            if (alpha < 0) alpha = 0;
+            else if (alpha > 0xFF) alpha = 0xFF;
             EventSystem_Should(VB_MODEL_DRAWDIST_FADE_ALPHA, true, &alpha);
             if(modelRenderColorMode == COLOR_MODE_DYNAMIC_PRIM_AND_ENV){
                 modelRenderDynColors.prim[3] = (modelRenderDynColors.prim[3] * alpha) / 0xff;

--- a/src/core2/model/modelRender.c
+++ b/src/core2/model/modelRender.c
@@ -14,20 +14,6 @@
 
 extern s32 getGameMode(void);
 
-static s32 port_modelRenderInDemoPlayback(void) {
-    switch (getGameMode()) {
-        case GAME_MODE_2_UNKNOWN:
-        case GAME_MODE_6_FILE_PLAYBACK:
-        case GAME_MODE_7_ATTRACT_DEMO:
-        case GAME_MODE_8_BOTTLES_BONUS:
-        case GAME_MODE_9_BANJO_AND_KAZOOIE:
-        case GAME_MODE_A_SNS_PICTURE:
-            return TRUE;
-        default:
-            return FALSE;
-    }
-}
-
 #define ARRAYLEN(x) (sizeof(x) / sizeof((x)[0]))
 
 extern bool cameraAreaList_searchForEntryInBounds(BKCameraAreaList *this, u8 *id, u32 count);
@@ -37,7 +23,6 @@ extern void assetCache_free(void *);
 extern AnimMtxList *animMtxList_new();
 extern AnimMtxList *animMtxList_defrag(AnimMtxList *);
 extern MtxF *animMtxList_get(AnimMtxList *this, s32 arg1);
-extern bool lighthouse_cullV2_inPlaybackMode(void);
 extern void lighthouse_cullV2_setFrustumChecksEnabled(bool enabled);
 extern void actor_postdrawMethod(ActorMarker *);
 extern void actor_predrawMethod(Actor *);
@@ -1073,12 +1058,6 @@ void modelRender_geoCmd_UnkE(Gfx ** gfx, Mtx ** mtx, struct bk_geo_cmd_s *arg2){
     f32 sp34[3];
     f32 sp30;
     GeoCmdE * cmd = (GeoCmdE *)arg2;
-    if (port_shouldDisableCulling() && !lighthouse_cullV2_inPlaybackMode()) {
-        if (cmd->unk10) {
-            modelRender_executeGeoCmds(gfx, mtx, (BKGeoCmd*)((u8*)cmd + cmd->unk10));
-        }
-        return;
-    }
 
     if(cmd->unk12 == -1){
         s32 draw;
@@ -1124,12 +1103,6 @@ void modelRender_geoCmd_UnkE(Gfx ** gfx, Mtx ** mtx, struct bk_geo_cmd_s *arg2){
 //cmdF_??? (processes model_setup offset_0x20)
 void modelRender_geoCmd_CAMERA(Gfx ** gfx, Mtx ** mtx, struct bk_geo_cmd_s *arg2){
     GeoCmdF *cmd = (GeoCmdF *)arg2;
-    if (port_shouldDisableCulling() && !lighthouse_cullV2_inPlaybackMode()) {
-        if (cmd->unk8 != 0) {
-            modelRender_executeGeoCmds(gfx, mtx, (BKGeoCmd*)((u8*)cmd + cmd->unk8));
-        }
-        return;
-    }
     int tmp_v0 = cameraAreaList_searchForEntryInBounds(modelRenderCameraAreaList, cmd->unkC, cmd->unkA);
     int draw = (!tmp_v0 && (cmd->unkB & 1)) || (tmp_v0 && (cmd->unkB & 2));
     draw = port_geoCullDraw(OCCLUSION_CMD_CAMERA, cmd, modelRenderModelBin, draw, cmd->unkC, cmd->unkA, cmd->unkB, 0);
@@ -1211,7 +1184,7 @@ BKModelBin *modelRender_draw(Gfx **gfx, Mtx **mtx, f32 position[3], f32 rotation
     camera_focus[2] = object_position[2] - modelRenderCameraPosition[2];
 
     // [port] Disable Culling model distance gates V3.1
-    if ((!port_shouldDisableCulling() || port_modelRenderInDemoPlayback()) && ( ((camera_focus[0] < -17000.0f) || (17000.0f < camera_focus[0]))
+    if ((!port_shouldDisableCulling() || port_isDemoPlayback()) && ( ((camera_focus[0] < -17000.0f) || (17000.0f < camera_focus[0]))
         || ((camera_focus[1] < -17000.0f) || (17000.0f < camera_focus[1]))
         || ((camera_focus[2] < -17000.0f) || (17000.0f < camera_focus[2]))
     )) {
@@ -1249,13 +1222,13 @@ BKModelBin *modelRender_draw(Gfx **gfx, Mtx **mtx, f32 position[3], f32 rotation
         D_80383708 = spD4*scale*D_8038370C*50.0f;
     }
 
-    if ((!port_shouldDisableCulling() || port_modelRenderInDemoPlayback()) && D_80383708 <= camera_focus_distance) {
+    if ((!port_shouldDisableCulling() || port_isDemoPlayback()) && D_80383708 <= camera_focus_distance) {
         modelRender_reset();
         return 0;
     }
 
     if (port_shouldDisableCulling()) {
-        if (lighthouse_cullV2_inPlaybackMode()) {
+        if (port_isDemoPlayback()) {
             // Exact widescreen demo state: remember original visibility,
             // but keep the visual model alive during the draw.
             cur_model_would_have_been_culled_in_demo =
@@ -1285,7 +1258,7 @@ BKModelBin *modelRender_draw(Gfx **gfx, Mtx **mtx, f32 position[3], f32 rotation
     modelRendervertexList = modelRendervertexList ? modelRendervertexList : (BKVertexList *)((uintptr_t)modelRenderModelBin + (uintptr_t)(u32)modelRenderModelBin->vtx_list_offset);
     modelRenderCameraAreaList = (modelRenderModelBin->camera_area_list_offset == 0) ? NULL : (BKCameraAreaList *)((uintptr_t)model_bin + (uintptr_t)(u32)model_bin->camera_area_list_offset);
 
-    if (D_80383710 && (!port_shouldDisableCulling() || port_modelRenderInDemoPlayback())) {
+    if (D_80383710 && (!port_shouldDisableCulling() || port_isDemoPlayback())) {
         tmp_f0 = D_80383708 - 500.0f;
         if(tmp_f0 < camera_focus_distance){
             alpha = (s32)((1.0f - (camera_focus_distance - tmp_f0)/500.0f)*255.0f);
@@ -1483,7 +1456,7 @@ BKModelBin *modelRender_draw(Gfx **gfx, Mtx **mtx, f32 position[3], f32 rotation
 
     modelRender_reset();
     if (port_shouldDisableCulling()) {
-        if (lighthouse_cullV2_inPlaybackMode()) {
+        if (port_isDemoPlayback()) {
             // Critical Recomp behavior: expose original visibility after draw.
             D_80370990 = !cur_model_would_have_been_culled_in_demo;
         } else {

--- a/src/core2/model/modelRender.c
+++ b/src/core2/model/modelRender.c
@@ -12,7 +12,6 @@
 #include "port/Interpolation/FrameInterpolation.h"
 #include "port/Patches/GeoCull.h"
 
-extern s32 getGameMode(void);
 
 #define ARRAYLEN(x) (sizeof(x) / sizeof((x)[0]))
 
@@ -24,12 +23,6 @@ extern AnimMtxList *animMtxList_new();
 extern AnimMtxList *animMtxList_defrag(AnimMtxList *);
 extern MtxF *animMtxList_get(AnimMtxList *this, s32 arg1);
 extern void lighthouse_cullV2_setFrustumChecksEnabled(bool enabled);
-extern void actor_postdrawMethod(ActorMarker *);
-extern void actor_predrawMethod(Actor *);
-
-extern f32 sViewportPosition[3];
-extern f32 sViewportFrustumPlanes[4][4];
-extern void actor_postdrawMethod(ActorMarker *marker);
 
 
 typedef struct{
@@ -144,7 +137,6 @@ typedef struct {
     s32 size_4;
     s32 unk8;
 }GeoCmd10;
-
 
 
 void modelRender_geoCmd_Unk0(Gfx **, Mtx **, struct bk_geo_cmd_s *);
@@ -645,84 +637,6 @@ struct{
     model_render_post_draw_callback_f post_draw;
     void *post_draw_arg;
 } modelRenderCallback;
-
-// Original N64 sphere/frustum test used ONLY for demo actor logic.
-// This intentionally does not use Lighthouse's extended draw-distance multiplier.
-static bool modelRender_originalActorSphereInFrustum_demoSync(f32 pos[3], f32 distance) {
-    f32 delta[3];
-    s32 i;
-
-    delta[0] = pos[0] - sViewportPosition[0];
-    delta[1] = pos[1] - sViewportPosition[1];
-    delta[2] = pos[2] - sViewportPosition[2];
-
-    for (i = 0; i < 4; i++) {
-        if (distance <= delta[0] * sViewportFrustumPlanes[i][0] +
-                        delta[1] * sViewportFrustumPlanes[i][1] +
-                        delta[2] * sViewportFrustumPlanes[i][2]) {
-            return false;
-        }
-    }
-
-    return true;
-}
-
-static bool modelRender_isActorDraw_demoSync(void) {
-    return
-        modelRenderCallback.pre_draw == (model_render_pre_draw_callback_f)actor_predrawMethod ||
-        modelRenderCallback.post_draw == (model_render_post_draw_callback_f)actor_postdrawMethod;
-}
-
-// Original Banjo whole-model sphere/frustum test.
-// Used only to preserve demo/playback actor logic while visual culling stays disabled.
-static bool modelRender_originalSphereInFrustum(f32 pos[3], f32 distance) {
-    f32 delta[3];
-    s32 i;
-
-    delta[0] = pos[0] - sViewportPosition[0];
-    delta[1] = pos[1] - sViewportPosition[1];
-    delta[2] = pos[2] - sViewportPosition[2];
-
-    for (i = 0; i < 4; i++) {
-        if (distance <= delta[0] * sViewportFrustumPlanes[i][0] +
-                        delta[1] * sViewportFrustumPlanes[i][1] +
-                        delta[2] * sViewportFrustumPlanes[i][2]) {
-            return false;
-        }
-    }
-
-    return true;
-}
-
-// Demo-only actor culling. World/geo culling stays disabled.
-static bool modelRender_demoActorSphereInFrustum(f32 pos[3], f32 distance) {
-    f32 delta[3];
-    s32 i;
-
-    delta[0] = pos[0] - sViewportPosition[0];
-    delta[1] = pos[1] - sViewportPosition[1];
-    delta[2] = pos[2] - sViewportPosition[2];
-
-    for (i = 0; i < 4; i++) {
-        if (distance <= delta[0] * sViewportFrustumPlanes[i][0] +
-                        delta[1] * sViewportFrustumPlanes[i][1] +
-                        delta[2] * sViewportFrustumPlanes[i][2]) {
-            return false;
-        }
-    }
-
-    return true;
-}
-
-static bool modelRender_isDemoActorDraw(void) {
-    if (getGameMode() != GAME_MODE_7_ATTRACT_DEMO) {
-        return false;
-    }
-
-    return
-        modelRenderCallback.pre_draw == (model_render_pre_draw_callback_f)actor_predrawMethod ||
-        modelRenderCallback.post_draw == (model_render_post_draw_callback_f)actor_postdrawMethod;
-}
 
 s32 modelRenderDynEnvColor[4];
 
@@ -1454,7 +1368,6 @@ BKModelBin *modelRender_draw(Gfx **gfx, Mtx **mtx, f32 position[3], f32 rotation
     else{
         modelRenderRotation[0] = modelRenderRotation[1] = modelRenderRotation[2] = 0.0f;
     }
-
 
 
     // [port] Mirror mode: counter-mirror text-bearing models so text reads correctly

--- a/src/core2/model/modelRender.c
+++ b/src/core2/model/modelRender.c
@@ -21,6 +21,16 @@ extern void assetCache_free(void *);
 extern AnimMtxList *animMtxList_new();
 extern AnimMtxList *animMtxList_defrag(AnimMtxList *);
 extern MtxF *animMtxList_get(AnimMtxList *this, s32 arg1);
+extern bool lighthouse_cullV2_inPlaybackMode(void);
+extern void lighthouse_cullV2_setFrustumChecksEnabled(bool enabled);
+extern void lighthouse_menuCull_setFrustumChecksEnabled(bool enabled);
+extern void lighthouse_demoSync_setFrustumChecksEnabled(bool enabled);
+extern void actor_postdrawMethod(ActorMarker *);
+extern void actor_predrawMethod(Actor *);
+
+extern f32 sViewportPosition[3];
+extern f32 sViewportFrustumPlanes[4][4];
+extern void actor_postdrawMethod(ActorMarker *marker);
 
 
 typedef struct{
@@ -570,6 +580,7 @@ Gfx mipMapWrapDL[] =
 };
 
 s32 D_80370990 = 0;
+s32 cur_model_would_have_been_culled_in_demo = 0;
 
 BKGeoCmdFunc sGeoCmdList[] = {
     modelRender_geoCmd_Unk0,
@@ -635,6 +646,84 @@ struct{
     model_render_post_draw_callback_f post_draw;
     void *post_draw_arg;
 } modelRenderCallback;
+
+// Original N64 sphere/frustum test used ONLY for demo actor logic.
+// This intentionally does not use Lighthouse's extended draw-distance multiplier.
+static bool modelRender_originalActorSphereInFrustum_demoSync(f32 pos[3], f32 distance) {
+    f32 delta[3];
+    s32 i;
+
+    delta[0] = pos[0] - sViewportPosition[0];
+    delta[1] = pos[1] - sViewportPosition[1];
+    delta[2] = pos[2] - sViewportPosition[2];
+
+    for (i = 0; i < 4; i++) {
+        if (distance <= delta[0] * sViewportFrustumPlanes[i][0] +
+                        delta[1] * sViewportFrustumPlanes[i][1] +
+                        delta[2] * sViewportFrustumPlanes[i][2]) {
+            return false;
+        }
+    }
+
+    return true;
+}
+
+static bool modelRender_isActorDraw_demoSync(void) {
+    return
+        modelRenderCallback.pre_draw == (model_render_pre_draw_callback_f)actor_predrawMethod ||
+        modelRenderCallback.post_draw == (model_render_post_draw_callback_f)actor_postdrawMethod;
+}
+
+// Original Banjo whole-model sphere/frustum test.
+// Used only to preserve demo/playback actor logic while visual culling stays disabled.
+static bool modelRender_originalSphereInFrustum(f32 pos[3], f32 distance) {
+    f32 delta[3];
+    s32 i;
+
+    delta[0] = pos[0] - sViewportPosition[0];
+    delta[1] = pos[1] - sViewportPosition[1];
+    delta[2] = pos[2] - sViewportPosition[2];
+
+    for (i = 0; i < 4; i++) {
+        if (distance <= delta[0] * sViewportFrustumPlanes[i][0] +
+                        delta[1] * sViewportFrustumPlanes[i][1] +
+                        delta[2] * sViewportFrustumPlanes[i][2]) {
+            return false;
+        }
+    }
+
+    return true;
+}
+
+// Demo-only actor culling. World/geo culling stays disabled.
+static bool modelRender_demoActorSphereInFrustum(f32 pos[3], f32 distance) {
+    f32 delta[3];
+    s32 i;
+
+    delta[0] = pos[0] - sViewportPosition[0];
+    delta[1] = pos[1] - sViewportPosition[1];
+    delta[2] = pos[2] - sViewportPosition[2];
+
+    for (i = 0; i < 4; i++) {
+        if (distance <= delta[0] * sViewportFrustumPlanes[i][0] +
+                        delta[1] * sViewportFrustumPlanes[i][1] +
+                        delta[2] * sViewportFrustumPlanes[i][2]) {
+            return false;
+        }
+    }
+
+    return true;
+}
+
+static bool modelRender_isDemoActorDraw(void) {
+    if (getGameMode() != GAME_MODE_7_ATTRACT_DEMO) {
+        return false;
+    }
+
+    return
+        modelRenderCallback.pre_draw == (model_render_pre_draw_callback_f)actor_predrawMethod ||
+        modelRenderCallback.post_draw == (model_render_post_draw_callback_f)actor_postdrawMethod;
+}
 
 s32 modelRenderDynEnvColor[4];
 
@@ -959,7 +1048,7 @@ void modelRender_geoCmd_DRAWDIST(Gfx ** gfx, Mtx ** mtx, struct bk_geo_cmd_s *ar
         // [port] The N64 bounding boxes in CmdD_DRAW_DISTANCE are too conservative
         // for the port's viewport (292x216 -> 320x240 at 4:3). Extend to all aspect
         // ratios since the port always renders at a higher effective resolution.
-        if (EventSystem_Should(VB_DRAWDIST_BOX_CULL, true, sp2C, sp20)) {
+        if (port_shouldDisableCulling() || EventSystem_Should(VB_DRAWDIST_BOX_CULL, true, sp2C, sp20)) {
             modelRender_executeGeoCmds(gfx, mtx, (BKGeoCmd*)((u8*)cmd + cmd->unk14));
         }
     }
@@ -970,6 +1059,12 @@ void modelRender_geoCmd_UnkE(Gfx ** gfx, Mtx ** mtx, struct bk_geo_cmd_s *arg2){
     f32 sp34[3];
     f32 sp30;
     GeoCmdE * cmd = (GeoCmdE *)arg2;
+    if (port_shouldDisableCulling() && !lighthouse_cullV2_inPlaybackMode()) {
+        if (cmd->unk10) {
+            modelRender_executeGeoCmds(gfx, mtx, (BKGeoCmd*)((u8*)cmd + cmd->unk10));
+        }
+        return;
+    }
 
     if(cmd->unk12 == -1){
         s32 draw;
@@ -1015,6 +1110,12 @@ void modelRender_geoCmd_UnkE(Gfx ** gfx, Mtx ** mtx, struct bk_geo_cmd_s *arg2){
 //cmdF_??? (processes model_setup offset_0x20)
 void modelRender_geoCmd_CAMERA(Gfx ** gfx, Mtx ** mtx, struct bk_geo_cmd_s *arg2){
     GeoCmdF *cmd = (GeoCmdF *)arg2;
+    if (port_shouldDisableCulling() && !lighthouse_cullV2_inPlaybackMode()) {
+        if (cmd->unk8 != 0) {
+            modelRender_executeGeoCmds(gfx, mtx, (BKGeoCmd*)((u8*)cmd + cmd->unk8));
+        }
+        return;
+    }
     int tmp_v0 = cameraAreaList_searchForEntryInBounds(modelRenderCameraAreaList, cmd->unkC, cmd->unkA);
     int draw = (!tmp_v0 && (cmd->unkB & 1)) || (tmp_v0 && (cmd->unkB & 2));
     draw = port_geoCullDraw(OCCLUSION_CMD_CAMERA, cmd, modelRenderModelBin, draw, cmd->unkC, cmd->unkA, cmd->unkB, 0);
@@ -1055,6 +1156,8 @@ BKModelBin *modelRender_draw(Gfx **gfx, Mtx **mtx, f32 position[3], f32 rotation
     s32 alpha; 
     f32 tmp_f0;
     f32 padB8;
+
+    cur_model_would_have_been_culled_in_demo = false;
     
     if( (!model_bin && !sSecondaryModelData.model_id)
         || (model_bin && sSecondaryModelData.model_id)
@@ -1136,10 +1239,22 @@ BKModelBin *modelRender_draw(Gfx **gfx, Mtx **mtx, f32 position[3], f32 rotation
         return 0;
     }
 
-    D_80370990 = (D_80383704) ? viewport_func_8024DB50(object_position, spD0*scale) : 1;
-    if(D_80370990 == 0){
-        modelRender_reset();
-        return 0;
+    if (port_shouldDisableCulling()) {
+        if (lighthouse_cullV2_inPlaybackMode()) {
+            // Exact widescreen demo state: remember original visibility,
+            // but keep the visual model alive during the draw.
+            cur_model_would_have_been_culled_in_demo =
+                !((D_80383704) ? viewport_func_8024DB50(object_position, spD0 * scale) : 1);
+        } else {
+            cur_model_would_have_been_culled_in_demo = false;
+        }
+        D_80370990 = true;
+    } else {
+        D_80370990 = (D_80383704) ? viewport_func_8024DB50(object_position, spD0*scale) : 1;
+        if(D_80370990 == 0){
+            modelRender_reset();
+            return 0;
+        }
     }
 
     if(modelRenderCallback.pre_draw != NULL){
@@ -1328,7 +1443,13 @@ BKModelBin *modelRender_draw(Gfx **gfx, Mtx **mtx, f32 position[3], f32 rotation
 
     // [port] Mirror mode: counter-mirror text-bearing models so text reads correctly
     if (_mirror_excluded) gSPClearExtraGeometryMode((*gfx)++, G_EX_INVERT_CULLING);
+    if (port_shouldDisableCulling()) {
+        lighthouse_cullV2_setFrustumChecksEnabled(false);
+    }
     modelRender_executeGeoCmds(gfx, mtx, (BKGeoCmd *)((u8 *)model_bin + model_bin->geo_list_offset));
+    if (port_shouldDisableCulling()) {
+        lighthouse_cullV2_setFrustumChecksEnabled(true);
+    }
     // [port] Mirror mode: restore culling inversion
     if (_mirror_excluded) gSPSetExtraGeometryMode((*gfx)++, G_EX_INVERT_CULLING);
     gSPPopMatrix((*gfx)++, G_MTX_MODELVIEW);
@@ -1346,6 +1467,15 @@ BKModelBin *modelRender_draw(Gfx **gfx, Mtx **mtx, f32 position[3], f32 rotation
 
 
     modelRender_reset();
+    if (port_shouldDisableCulling()) {
+        if (lighthouse_cullV2_inPlaybackMode()) {
+            // Critical Recomp behavior: expose original visibility after draw.
+            D_80370990 = !cur_model_would_have_been_culled_in_demo;
+        } else {
+            D_80370990 = true;
+        }
+        cur_model_would_have_been_culled_in_demo = false;
+    }
     return model_bin;
 }
 

--- a/src/core2/model/modelRender.c
+++ b/src/core2/model/modelRender.c
@@ -12,6 +12,22 @@
 #include "port/Interpolation/FrameInterpolation.h"
 #include "port/Patches/GeoCull.h"
 
+extern s32 getGameMode(void);
+
+static s32 port_modelRenderInDemoPlayback(void) {
+    switch (getGameMode()) {
+        case GAME_MODE_2_UNKNOWN:
+        case GAME_MODE_6_FILE_PLAYBACK:
+        case GAME_MODE_7_ATTRACT_DEMO:
+        case GAME_MODE_8_BOTTLES_BONUS:
+        case GAME_MODE_9_BANJO_AND_KAZOOIE:
+        case GAME_MODE_A_SNS_PICTURE:
+            return TRUE;
+        default:
+            return FALSE;
+    }
+}
+
 #define ARRAYLEN(x) (sizeof(x) / sizeof((x)[0]))
 
 extern bool cameraAreaList_searchForEntryInBounds(BKCameraAreaList *this, u8 *id, u32 count);
@@ -1196,10 +1212,11 @@ BKModelBin *modelRender_draw(Gfx **gfx, Mtx **mtx, f32 position[3], f32 rotation
     camera_focus[1] = object_position[1] - modelRenderCameraPosition[1];
     camera_focus[2] = object_position[2] - modelRenderCameraPosition[2];
 
-    if( ((camera_focus[0] < -17000.0f) || (17000.0f < camera_focus[0]))
+    // [port] Disable Culling model distance gates V3.1
+    if ((!port_shouldDisableCulling() || port_modelRenderInDemoPlayback()) && ( ((camera_focus[0] < -17000.0f) || (17000.0f < camera_focus[0]))
         || ((camera_focus[1] < -17000.0f) || (17000.0f < camera_focus[1]))
         || ((camera_focus[2] < -17000.0f) || (17000.0f < camera_focus[2]))
-    ){
+    )) {
         modelRender_reset();
         return 0;
     }
@@ -1234,7 +1251,7 @@ BKModelBin *modelRender_draw(Gfx **gfx, Mtx **mtx, f32 position[3], f32 rotation
         D_80383708 = spD4*scale*D_8038370C*50.0f;
     }
 
-    if(D_80383708 <= camera_focus_distance){
+    if ((!port_shouldDisableCulling() || port_modelRenderInDemoPlayback()) && D_80383708 <= camera_focus_distance) {
         modelRender_reset();
         return 0;
     }
@@ -1270,7 +1287,7 @@ BKModelBin *modelRender_draw(Gfx **gfx, Mtx **mtx, f32 position[3], f32 rotation
     modelRendervertexList = modelRendervertexList ? modelRendervertexList : (BKVertexList *)((uintptr_t)modelRenderModelBin + (uintptr_t)(u32)modelRenderModelBin->vtx_list_offset);
     modelRenderCameraAreaList = (modelRenderModelBin->camera_area_list_offset == 0) ? NULL : (BKCameraAreaList *)((uintptr_t)model_bin + (uintptr_t)(u32)model_bin->camera_area_list_offset);
 
-    if(D_80383710){
+    if (D_80383710 && (!port_shouldDisableCulling() || port_modelRenderInDemoPlayback())) {
         tmp_f0 = D_80383708 - 500.0f;
         if(tmp_f0 < camera_focus_distance){
             alpha = (s32)((1.0f - (camera_focus_distance - tmp_f0)/500.0f)*255.0f);

--- a/src/core2/model/modelRender.c
+++ b/src/core2/model/modelRender.c
@@ -1120,7 +1120,7 @@ BKModelBin *modelRender_draw(Gfx **gfx, Mtx **mtx, f32 position[3], f32 rotation
     camera_focus[1] = object_position[1] - modelRenderCameraPosition[1];
     camera_focus[2] = object_position[2] - modelRenderCameraPosition[2];
 
-    // [port] Disable Culling model distance gates V3.1
+    // [port] Disable Culling model distance gates
     if ((!port_shouldDisableCulling() || port_isDemoPlayback()) && ( ((camera_focus[0] < -17000.0f) || (17000.0f < camera_focus[0]))
         || ((camera_focus[1] < -17000.0f) || (17000.0f < camera_focus[1]))
         || ((camera_focus[2] < -17000.0f) || (17000.0f < camera_focus[2]))
@@ -1398,7 +1398,7 @@ BKModelBin *modelRender_draw(Gfx **gfx, Mtx **mtx, f32 position[3], f32 rotation
     modelRender_reset();
     if (port_shouldDisableCulling()) {
         if (port_isDemoPlayback()) {
-            // Critical Recomp behavior: expose original visibility after draw.
+            // Preserve the original visibility result after the visual-only draw.
             D_80370990 = !cur_model_would_have_been_culled_in_demo;
         } else {
             D_80370990 = true;

--- a/src/port/Patches/GraphicsPatches.cpp
+++ b/src/port/Patches/GraphicsPatches.cpp
@@ -100,7 +100,6 @@ int port_shouldDisableLOD(void) {
     return sDisableLOD;
 }
 
-
 int port_shouldDisableCulling(void) {
     return sDisableCulling;
 }
@@ -127,7 +126,7 @@ int port_isDemoPlayback(void) {
 // Some distant level geometry is hidden by BK's camera-area portal culling rather than the
 // distance/LOD culls the prop draw-distance enhancement covers. Disabling that culling
 // wholesale floods the render buffer, so at the maxed draw-distance level we force just the
-// specific chunks known to suffer from it. Currently the only one is the Mumbo's Mountain
+// Disable Culling uses this listener for general render-only overrides. Draw Distance still only forces
 // stonehenge: a single "outside areas {1,2}" CAMERA command in the opaque map model.
 
 static void OnGeoCull_GraphicsEnhancements(IEvent* event) {

--- a/src/port/Patches/GraphicsPatches.cpp
+++ b/src/port/Patches/GraphicsPatches.cpp
@@ -12,6 +12,7 @@
 
 #define CVAR_DRAW_DISTANCE CVAR_ENHANCEMENT("Graphics.DrawDistance")
 #define CVAR_DISABLE_LOD CVAR_ENHANCEMENT("Graphics.DisableLOD")
+#define CVAR_DISABLE_CULLING CVAR_ENHANCEMENT("Graphics.DisableCulling")
 #define CVAR_FP_LOBBY_DOOR_TILE CVAR_ENHANCEMENT("Fixes.FPLobbyDoorTile")
 
 static const int kMaxDrawDistanceMul = 6;
@@ -21,6 +22,7 @@ static int sDrawDistanceCubeWidth(int mul) {
 
 static int sDrawDistanceLevel = 1;
 static int sDisableLOD = 0;
+static int sDisableCulling = 0;
 
 extern "C" {
 #include <ultra64.h>
@@ -97,6 +99,10 @@ int port_spriteSizeCulled(float depth, float size, float baseThreshold, int disa
 int port_shouldDisableLOD(void) {
     return sDisableLOD;
 }
+
+int port_shouldDisableCulling(void) {
+    return sDisableCulling;
+}
 }
 
 // ============================================================================
@@ -158,9 +164,10 @@ static void RefreshDrawDistanceCVars() {
     }
     sDrawDistanceLevel = mul;
     sDisableLOD = CVarGetInteger(CVAR_DISABLE_LOD, 0);
+    sDisableCulling = CVarGetInteger(CVAR_DISABLE_CULLING, 0);
 }
 
-static RegisterShipInitFunc drawDistanceCVarCache(RefreshDrawDistanceCVars, { CVAR_DRAW_DISTANCE, CVAR_DISABLE_LOD });
+static RegisterShipInitFunc drawDistanceCVarCache(RefreshDrawDistanceCVars, { CVAR_DRAW_DISTANCE, CVAR_DISABLE_LOD, CVAR_DISABLE_CULLING });
 
 // ============================================================================
 // STALE TILE DESCRIPTOR — Freezeezy Peak lobby door trim

--- a/src/port/Patches/GraphicsPatches.cpp
+++ b/src/port/Patches/GraphicsPatches.cpp
@@ -100,12 +100,6 @@ int port_shouldDisableLOD(void) {
     return sDisableLOD;
 }
 
-int port_shouldDisableCullingCubeRange(void) {
-    if (IsDemoMode() && getGameMode() != GAME_MODE_4_PAUSED) {
-        return 0;
-    }
-    return sDisableCulling;
-}
 
 int port_shouldDisableCulling(void) {
     return sDisableCulling;

--- a/src/port/Patches/GraphicsPatches.cpp
+++ b/src/port/Patches/GraphicsPatches.cpp
@@ -110,6 +110,20 @@ int port_shouldDisableCullingCubeRange(void) {
 int port_shouldDisableCulling(void) {
     return sDisableCulling;
 }
+
+int port_isDemoPlayback(void) {
+    switch (getGameMode()) {
+        case GAME_MODE_2_UNKNOWN:
+        case GAME_MODE_6_FILE_PLAYBACK:
+        case GAME_MODE_7_ATTRACT_DEMO:
+        case GAME_MODE_8_BOTTLES_BONUS:
+        case GAME_MODE_9_BANJO_AND_KAZOOIE:
+        case GAME_MODE_A_SNS_PICTURE:
+            return 1;
+        default:
+            return 0;
+    }
+}
 }
 
 // ============================================================================
@@ -122,11 +136,23 @@ int port_shouldDisableCulling(void) {
 // specific chunks known to suffer from it. Currently the only one is the Mumbo's Mountain
 // stonehenge: a single "outside areas {1,2}" CAMERA command in the opaque map model.
 
-static void OnGeoCull_LevelOcclusion(IEvent* event) {
+static void OnGeoCull_GraphicsEnhancements(IEvent* event) {
     auto* ev = reinterpret_cast<OnGeoCull*>(event);
-    if (ev->type != OCCLUSION_CMD_CAMERA) {
+
+    // Preserve the existing Disable Culling demo/playback behavior while routing the
+    // render-only override through Lighthouse's GeoCull event.
+    bool disableCulling = port_shouldDisableCulling() && !port_isDemoPlayback();
+    if (disableCulling && (ev->type == OCCLUSION_CMD_CAMERA || ev->type == OCCLUSION_CMD_UNKE)) {
+        *ev->forceDraw = true;
         return;
     }
+
+    // Keep the existing draw-distance exception gated exactly as before. The shared
+    // enhancement listener can also be active solely because Disable Culling is enabled.
+    if (port_getDrawDistanceSetting() < kMaxDrawDistanceMul || ev->type != OCCLUSION_CMD_CAMERA) {
+        return;
+    }
+
     // Offset into the opaque map model's geo command list (the "outside areas {1,2}" CAMERA
     // command). Read it off the Occlusion Debugger, which reports the same geo-relative key.
     if (gsworld_getMap() == MAP_2_MM_MUMBOS_MOUNTAIN && ev->offset == 0x2C98 &&
@@ -137,11 +163,14 @@ static void OnGeoCull_LevelOcclusion(IEvent* event) {
 
 void RegisterLevelOcclusion_Init() {
     bool maxed = CVarGetInteger(CVAR_DRAW_DISTANCE, 1) >= kMaxDrawDistanceMul;
-    GeoCull_SetConsumer(GEOCULL_CONSUMER_ENHANCEMENT, maxed);
-    COND_HOOK(OnGeoCull, EVENT_PRIORITY_NORMAL, maxed, OnGeoCull_LevelOcclusion);
+    bool disableCulling = CVarGetInteger(CVAR_DISABLE_CULLING, 0) != 0;
+    bool active = maxed || disableCulling;
+    GeoCull_SetConsumer(GEOCULL_CONSUMER_ENHANCEMENT, active);
+    COND_HOOK(OnGeoCull, EVENT_PRIORITY_NORMAL, active, OnGeoCull_GraphicsEnhancements);
 }
 
-static RegisterShipInitFunc sInitLevelOcclusion(RegisterLevelOcclusion_Init, { CVAR_DRAW_DISTANCE });
+static RegisterShipInitFunc sInitLevelOcclusion(RegisterLevelOcclusion_Init,
+                                                { CVAR_DRAW_DISTANCE, CVAR_DISABLE_CULLING });
 
 static void RegisterDrawDistanceGraphics_Init() {
     COND_HOOK(DrawDistanceCubeWidth, EVENT_PRIORITY_NORMAL, CVarGetInteger(CVAR_DRAW_DISTANCE, 1) > 1,

--- a/src/port/Patches/GraphicsPatches.cpp
+++ b/src/port/Patches/GraphicsPatches.cpp
@@ -104,7 +104,7 @@ int port_shouldDisableCullingCubeRange(void) {
     if (IsDemoMode() && getGameMode() != GAME_MODE_4_PAUSED) {
         return 0;
     }
-    return CVarGetInteger(CVAR_ENHANCEMENT("Graphics.DisableCulling"), 0) != 0;
+    return sDisableCulling;
 }
 
 int port_shouldDisableCulling(void) {

--- a/src/port/Patches/GraphicsPatches.cpp
+++ b/src/port/Patches/GraphicsPatches.cpp
@@ -100,6 +100,13 @@ int port_shouldDisableLOD(void) {
     return sDisableLOD;
 }
 
+int port_shouldDisableCullingCubeRange(void) {
+    if (IsDemoMode() && getGameMode() != GAME_MODE_4_PAUSED) {
+        return 0;
+    }
+    return CVarGetInteger(CVAR_ENHANCEMENT("Graphics.DisableCulling"), 0) != 0;
+}
+
 int port_shouldDisableCulling(void) {
     return sDisableCulling;
 }

--- a/src/port/Patches/GraphicsPatches.cpp
+++ b/src/port/Patches/GraphicsPatches.cpp
@@ -167,7 +167,8 @@ static void RefreshDrawDistanceCVars() {
     sDisableCulling = CVarGetInteger(CVAR_DISABLE_CULLING, 0);
 }
 
-static RegisterShipInitFunc drawDistanceCVarCache(RefreshDrawDistanceCVars, { CVAR_DRAW_DISTANCE, CVAR_DISABLE_LOD, CVAR_DISABLE_CULLING });
+static RegisterShipInitFunc drawDistanceCVarCache(RefreshDrawDistanceCVars,
+                                                  { CVAR_DRAW_DISTANCE, CVAR_DISABLE_LOD, CVAR_DISABLE_CULLING });
 
 // ============================================================================
 // STALE TILE DESCRIPTOR — Freezeezy Peak lobby door trim

--- a/src/port/Patches/Patches.h
+++ b/src/port/Patches/Patches.h
@@ -80,6 +80,7 @@ int port_getDrawDistanceLevel(void);   // render-time multiplier; clamped to 1x 
 int port_shouldDisableLOD(void);
 int port_shouldDisableCullingCubeRange(void);
 int port_shouldDisableCulling(void);
+int port_isDemoPlayback(void);
 float port_drawDistanceMul(void);
 void port_applyModelDrawDistanceCull(int* fadeFlag, float* cullMult, float* cullDist);
 int port_spriteSizeCulled(float depth, float size, float baseThreshold, int disableFlag);

--- a/src/port/Patches/Patches.h
+++ b/src/port/Patches/Patches.h
@@ -78,6 +78,7 @@ int port_scalePlayerDamage(int damage);
 int port_getDrawDistanceSetting(void); // configured multiplier; safe during map load
 int port_getDrawDistanceLevel(void);   // render-time multiplier; clamped to 1x outside normal gameplay
 int port_shouldDisableLOD(void);
+int port_shouldDisableCulling(void);
 float port_drawDistanceMul(void);
 void port_applyModelDrawDistanceCull(int* fadeFlag, float* cullMult, float* cullDist);
 int port_spriteSizeCulled(float depth, float size, float baseThreshold, int disableFlag);

--- a/src/port/Patches/Patches.h
+++ b/src/port/Patches/Patches.h
@@ -78,6 +78,7 @@ int port_scalePlayerDamage(int damage);
 int port_getDrawDistanceSetting(void); // configured multiplier; safe during map load
 int port_getDrawDistanceLevel(void);   // render-time multiplier; clamped to 1x outside normal gameplay
 int port_shouldDisableLOD(void);
+int port_shouldDisableCullingCubeRange(void);
 int port_shouldDisableCulling(void);
 float port_drawDistanceMul(void);
 void port_applyModelDrawDistanceCull(int* fadeFlag, float* cullMult, float* cullDist);

--- a/src/port/Patches/Patches.h
+++ b/src/port/Patches/Patches.h
@@ -78,7 +78,6 @@ int port_scalePlayerDamage(int damage);
 int port_getDrawDistanceSetting(void); // configured multiplier; safe during map load
 int port_getDrawDistanceLevel(void);   // render-time multiplier; clamped to 1x outside normal gameplay
 int port_shouldDisableLOD(void);
-int port_shouldDisableCullingCubeRange(void);
 int port_shouldDisableCulling(void);
 int port_isDemoPlayback(void);
 float port_drawDistanceMul(void);

--- a/src/port/UI/LighthouseMenuEnhancements.cpp
+++ b/src/port/UI/LighthouseMenuEnhancements.cpp
@@ -130,12 +130,13 @@ void LighthouseMenu::AddMenuEnhancements() {
         .RaceDisable(false)
         .Options(CheckboxOptions().Tooltip("Forces maximum model detail everywhere."));
     AddWidget(path, "Disable Culling", WIDGET_CVAR_CHECKBOX)
-.CVar(CVAR_ENHANCEMENT("Graphics.DisableCulling"))
-.RaceDisable(false)
-.Options(CheckboxOptions().Tooltip("Disables frustum/occlusion culling. "
- "LOD and real draw distance are unaffected." " May cost performance when enabled."));
+        .CVar(CVAR_ENHANCEMENT("Graphics.DisableCulling"))
+        .RaceDisable(false)
+        .Options(CheckboxOptions().Tooltip("Disables frustum/occlusion culling. "
+                                           "LOD and real draw distance are unaffected."
+                                           " May cost performance when enabled."));
 
- AddWidget(path, "Original Aspect Ratio In Cutscenes", WIDGET_CVAR_CHECKBOX)
+    AddWidget(path, "Original Aspect Ratio In Cutscenes", WIDGET_CVAR_CHECKBOX)
         .CVar(CVAR_ENHANCEMENT("Graphics.CutsceneAspect"))
         .Options(CheckboxOptions().Tooltip("Forces game to show original aspect ratio during cutscenes to avoid seeing "
                                            "unfinished edges of scene geometry."));

--- a/src/port/UI/LighthouseMenuEnhancements.cpp
+++ b/src/port/UI/LighthouseMenuEnhancements.cpp
@@ -129,8 +129,13 @@ void LighthouseMenu::AddMenuEnhancements() {
         .CVar(CVAR_ENHANCEMENT("Graphics.DisableLOD"))
         .RaceDisable(false)
         .Options(CheckboxOptions().Tooltip("Forces maximum model detail everywhere."));
+    AddWidget(path, "Disable Culling", WIDGET_CVAR_CHECKBOX)
+.CVar(CVAR_ENHANCEMENT("Graphics.DisableCulling"))
+.RaceDisable(false)
+.Options(CheckboxOptions().Tooltip("Disables frustum/occlusion culling. "
+ "LOD and real draw distance are unaffected." " May cost performance when enabled."));
 
-    AddWidget(path, "Original Aspect Ratio In Cutscenes", WIDGET_CVAR_CHECKBOX)
+ AddWidget(path, "Original Aspect Ratio In Cutscenes", WIDGET_CVAR_CHECKBOX)
         .CVar(CVAR_ENHANCEMENT("Graphics.CutsceneAspect"))
         .Options(CheckboxOptions().Tooltip("Forces game to show original aspect ratio during cutscenes to avoid seeing "
                                            "unfinished edges of scene geometry."));


### PR DESCRIPTION
## Summary

- Adds a "Disable Culling" graphics option.
- Disables viewport, model, and actor culling when the option is enabled.
- Preserves the required culling behavior during demo/playback sequences to prevent desynchronization.
- Includes a warning that disabling culling may affect performance.

## Credits

Parts of the demo/playback synchronization approach were adapted from BanjoRecomp.

## AI Use

AI was used in development, debugging, and build verification. I manually tested and published this PR.

<!--- section:artifacts:start -->
### Build Artifacts
  - [Lighthouse-windows.zip](https://nightly.link/HarbourMasters/Lighthouse/actions/artifacts/10115899344.zip)
  - [Lighthouse-mac.zip](https://nightly.link/HarbourMasters/Lighthouse/actions/artifacts/10115549473.zip)
  - [Lighthouse-linux.zip](https://nightly.link/HarbourMasters/Lighthouse/actions/artifacts/10115517111.zip)
<!--- section:artifacts:end -->