### PR TITLE
[RANDO] Add requeue for missed rando items

### DIFF
--- a/src/port/Rando/ItemQueue/ItemQueue.cpp
+++ b/src/port/Rando/ItemQueue/ItemQueue.cpp
@@ -82,7 +82,7 @@ void ItemQueue::Process() {
         ItemQueue::GiveItem(randoSaveCheck.randoItemId);
         ItemQueue::SendNotification(randoSaveCheck.randoItemId);
         Rando::StaticData::ModifyRandoInfFlagState(randoCheckId);
-        // RANDO_SAVE_CHECKS[randoCheckId].received = true;
+        RANDO_SAVE_CHECKS[randoCheckId].received = true;
     }
 
     itemQueue.pop();
@@ -337,10 +337,21 @@ void ItemQueue::AddCheck(RandoCheckId randoCheckId) {
     CheckTracker_AddToCheckCount((uint32_t)randoCheckId);
 }
 
+void ItemQueue::RequeueMissedItems() {
+    for (auto& check : RANDO_SAVE_CHECKS) {
+        if (check.eligible && !check.received) {
+            ItemQueue::AddCheck(check.randoCheckId);
+        }
+    }
+}
+
 void RegisterItemQueue() {
     COND_HOOK(GameFrameUpdate, EVENT_PRIORITY_NORMAL, IS_RANDO, [](IEvent* event) { ItemQueue::Process(); });
 
-    COND_HOOK(OnSetJiggyList, EVENT_PRIORITY_NORMAL, IS_RANDO, [](IEvent* event) { ItemQueue::Clear(); });
+    COND_HOOK(OnSetJiggyList, EVENT_PRIORITY_NORMAL, IS_RANDO, [](IEvent* event) {
+        ItemQueue::Clear();
+        ItemQueue::RequeueMissedItems();
+    });
 }
 
 static RegisterShipInitFunc initFunc(RegisterItemQueue, { "IS_RANDO" });

--- a/src/port/Rando/ItemQueue/ItemQueue.h
+++ b/src/port/Rando/ItemQueue/ItemQueue.h
@@ -7,4 +7,5 @@ public:
     static void GiveItem(RandoItemId randoItemId);
     static void SendNotification(RandoItemId randoItemId);
     static void AddCheck(RandoCheckId randoCheckId);
+    static void RequeueMissedItems();
 };


### PR DESCRIPTION
Resolves https://github.com/HarbourMasters/Lighthouse/issues/428

Putting that new .received property to use, it now requeues any item on map load if it was picked up but somehow never given out. Not super relevant right now but might become more relevant as we add more safeguards to the queue actually being able to give out items (don't give items in cutscenes, etc). So if the player resets their game when the queue wasn't done giving out any items, it would otherwise lose those items forever. Ship has this problem still, hence why I want to be ahead of the problem this time.

<!--- section:artifacts:start -->
### Build Artifacts
  - [Lighthouse-windows.zip](https://nightly.link/HarbourMasters/Lighthouse/actions/artifacts/9489584267.zip)
  - [Lighthouse-linux.zip](https://nightly.link/HarbourMasters/Lighthouse/actions/artifacts/9489449771.zip)
  - [Lighthouse-mac.zip](https://nightly.link/HarbourMasters/Lighthouse/actions/artifacts/9489287491.zip)
<!--- section:artifacts:end -->