### PR TITLE
Simpler Egg Aim water fix

### DIFF
--- a/src/port/Enhancements/Backports/EggAim.cpp
+++ b/src/port/Enhancements/Backports/EggAim.cpp
@@ -18,8 +18,6 @@
 #include "core2/commonParticle.h"
 #include "core2/abilityprogress.h"
 
-extern "C" bool func_802A7588(void);
-
 #define CVAR_NAME CVAR_ENHANCEMENT("Backports.EggAim")
 
 namespace {
@@ -216,8 +214,7 @@ int sFiring = 0;
 int sOverlayShown = 0;
 
 bool canAimEggs() {
-    return can_egg() && player_getTransformation() == TRANSFORM_1_BANJO && !func_802A7588() &&
-           bs_getState() != BS_96_SWIM_DRONE;
+    return can_egg() && player_getTransformation() == TRANSFORM_1_BANJO && !player_inWater();
 }
 
 } // namespace


### PR DESCRIPTION
Follow-up to #556. @JeodC said:

> `player_inWater()` is also a thing and already in `functions.h`. Taken with the above, you could collapse both terms into one predicate.

And indeed, this is a much simpler fix and it's good to know that that function exists.