### PR TITLE
Romhack work: Nostalgia 64

### DIFF
--- a/src/core2/nc/camera_fog.c
+++ b/src/core2/nc/camera_fog.c
@@ -40,8 +40,12 @@ Struct_core2_37E50_0 *func_802BEDE0(enum map_e map_id){
 
     phi_v1 = (u8 *)&D_80365D60;
     phi_v1_2 = (u8 *)&D_80365D60;
+    // [port] Let a romhack pick up another map's tint, including the unused first row.
+    s32 tintMap = map_id;
+    CALL_EVENT(MapUnderwaterTint, map_id, &tintMap);
     for(iPtr = D_80365D60; iPtr->map_id != 0; iPtr++){
-        if(map_id == iPtr->map_id){
+//      if(map_id == iPtr->map_id){
+        if(tintMap == iPtr->map_id){
             return iPtr;
         }
     }

--- a/src/port/Enhancements/Events/Hooks/List/EngineEvent.h
+++ b/src/port/Enhancements/Events/Hooks/List/EngineEvent.h
@@ -37,6 +37,7 @@ DEFINE_EVENT(MapModelXluScale, s32 map; f32 * scale;);
 DEFINE_EVENT(OnTransitionModelScale, Gfx** gfx; Mtx * *mtx; s32 uid; f32 * scale;);
 DEFINE_EVENT(OnTransitionStateUpdate, s32 modelId; s32 uid; s32 substate;);
 DEFINE_EVENT(DrawDistanceCubeWidth, int32_t mapWidth; int32_t * width;);
+DEFINE_EVENT(MapUnderwaterTint, s32 map; s32 * tintMap;);
 
 DEFINE_EVENT(OnActorTick, Actor* actor;);
 DEFINE_EVENT(OnPropTick, ActorMarker* marker; float* position;);

--- a/src/port/Enhancements/Events/PortEnhancements.cpp
+++ b/src/port/Enhancements/Events/PortEnhancements.cpp
@@ -32,6 +32,7 @@ void PortEnhancements_Register() {
     REGISTER_EVENT(OnTransitionModelScale);
     REGISTER_EVENT(OnTransitionStateUpdate);
     REGISTER_EVENT(DrawDistanceCubeWidth);
+    REGISTER_EVENT(MapUnderwaterTint);
     REGISTER_EVENT(OnActorTick);
     REGISTER_EVENT(OnPropTick);
     REGISTER_EVENT(OnSpritePropTick);

--- a/src/port/Romhack/Shared/HackShared.cpp
+++ b/src/port/Romhack/Shared/HackShared.cpp
@@ -30,6 +30,7 @@ void ApplyDialogSuppression();
 void ApplyForceAbilitiesUsed();
 
 int sNoteSignActorId = -1;
+bool sSuppressBottlesExplainer = false;
 const int* sSuppressedDialogs = nullptr;
 int sSuppressedDialogCount = 0;
 s32 sForcedUsedAbilities = 0;
@@ -37,7 +38,9 @@ s32 sForcedUsedAbilities = 0;
 // Romhacks that have note signs and Bottles explainers don't need them when
 // note saving is turned on. Suppress them.
 void ApplyNoteSignHooks() {
-    const bool active = sNoteSignActorId >= 0 && CVarGetInteger(CVAR_NOTE_RETENTION, 0);
+    const bool noteRetention = CVarGetInteger(CVAR_NOTE_RETENTION, 0);
+    const bool active = sNoteSignActorId >= 0 && noteRetention;
+    const bool suppressBottles = sSuppressBottlesExplainer && noteRetention;
 
     COND_HOOK(OnActorSpawn, EVENT_PRIORITY_NORMAL, active, [](IEvent* event) {
         auto* ev = reinterpret_cast<OnActorSpawn*>(event);
@@ -47,7 +50,7 @@ void ApplyNoteSignHooks() {
         }
     });
 
-    COND_HOOK(GameFrameUpdate, EVENT_PRIORITY_NORMAL, active, [](IEvent*) {
+    COND_HOOK(GameFrameUpdate, EVENT_PRIORITY_NORMAL, suppressBottles, [](IEvent*) {
         if (suBaddieActorArray == nullptr) {
             return;
         }
@@ -217,6 +220,11 @@ RegisterShipInitFunc noteDoorNumberInit(ApplyNoteDoorNumbers, { "BOOT" });
 
 void HackShared_EnableNoteSignSuppression(int signActorId) {
     sNoteSignActorId = signActorId;
+    ApplyNoteSignHooks();
+}
+
+void HackShared_EnableBottlesExplainerSuppression() {
+    sSuppressBottlesExplainer = true;
     ApplyNoteSignHooks();
 }
 

--- a/src/port/Romhack/Shared/HackShared.h
+++ b/src/port/Romhack/Shared/HackShared.h
@@ -14,6 +14,7 @@ constexpr ability_used kAllUsedAbilities[] = {
 };
 
 void HackShared_EnableNoteSignSuppression(int signActorId);
+void HackShared_EnableBottlesExplainerSuppression();
 void HackShared_EnableDialogSuppression(const int* dialogIds, int count);
 void HackShared_EnableForceAbilitiesUsed(const ability_used* moves, int count);
 

--- a/src/port/Romhack/Specific/JiggiesOfTime.cpp
+++ b/src/port/Romhack/Specific/JiggiesOfTime.cpp
@@ -28,4 +28,6 @@ void RegisterJiggiesOfTimePatches() {
     // JoT's note signs are repurposed Red Question Marks.
     // Source: https://github.com/Mr-Wiseguy/JiggiesOfTimeRecomp/blob/main/src/note_signs.c
     HackShared_EnableNoteSignSuppression(ACTOR_54_RED_QUESTION_MARK);
+    // JoT leaves the selector-8 Bottles as the note explainer, so drop it too.
+    HackShared_EnableBottlesExplainerSuppression();
 }

--- a/src/port/Romhack/Specific/Nostalgia64.cpp
+++ b/src/port/Romhack/Specific/Nostalgia64.cpp
@@ -87,4 +87,12 @@ void RegisterNostalgia64Patches() {
 
     // The N64 cube stands in for the note signs
     HackShared_EnableNoteSignSuppression(ACTOR_93_INTRO_N64_CUBE);
+
+    // Temple map gets the unused teal underwater tint
+    REGISTER_LISTENER(MapUnderwaterTint, EVENT_PRIORITY_NORMAL, [](IEvent* event) {
+        auto* ev = reinterpret_cast<MapUnderwaterTint*>(event);
+        if (ev->map == MAP_11_BGS_TIPTUP) {
+            *ev->tintMap = MAP_3_UNUSED;
+        }
+    });
 }


### PR DESCRIPTION
Resolves #549, the note suppression idea taken from banjo recomp was forcing the tutorial bottles molehill to despawn, disabling the dialog.

Adds the unused beta temple underwater tint to the temple map in Nostalgia 64.

<!--- section:artifacts:start -->
### Build Artifacts
  - [Lighthouse-windows.zip](https://nightly.link/HarbourMasters/Lighthouse/actions/artifacts/9739095575.zip)
  - [Lighthouse-linux.zip](https://nightly.link/HarbourMasters/Lighthouse/actions/artifacts/9738884385.zip)
  - [Lighthouse-mac.zip](https://nightly.link/HarbourMasters/Lighthouse/actions/artifacts/9738767946.zip)
<!--- section:artifacts:end -->