### PR TITLE
Fix a freeze when a second display list starts too early

### DIFF
--- a/src/core1/graphics_thread.c
+++ b/src/core1/graphics_thread.c
@@ -248,7 +248,7 @@ void thread5_handleSyncEvent(void) {
 extern u64 osClockRate;
 
 void thread5_handleDPEvent(void) {
-    if ((sUnkFlag2 << 1) < 0) {
+    if (sUnkFlag2_Saved & 0x40000000) {
         osDpSetStatus(DPC_SET_FREEZE);
         sCurrentFramebuffer = osViGetCurrentFramebuffer();
         viMgr_func_8024BFAC();

--- a/src/port/Game.cpp
+++ b/src/port/Game.cpp
@@ -149,16 +149,18 @@ void RenderTask(void* dlStart) {
     FrameInterpolation_ReleasePair(pair.prev, pair.curr);
 }
 
-// This thread plays the RCP: thread5 hands over a task,
-// we run it and raise SP then DP.
+// This thread plays the RCP: thread5 hands over a task, it runs and raises DP
+// then SP. Hardware raises SP first, but the list is fully drawn before either
+// goes out. DP has to lead: SP frees thread5 to start the next task, and starting
+// one overwrites the flags the frame's swap token gates on.
 int ServiceRcp() {
     OSTask* task = OS_SpTakePendingTask();
     if (task == nullptr) {
         return 0;
     }
     RenderTask(task->t.data_ptr);
-    OS_SendEventMesg(OS_EVENT_SP);
     OS_SendEventMesg(OS_EVENT_DP);
+    OS_SendEventMesg(OS_EVENT_SP);
     return 1;
 }
 


### PR DESCRIPTION
`ServiceRcp` raised SP then DP back to back into thread5's queue. SP frees thread5 to start the next display list, and starting one overwrites the flag `thread5_handleDPEvent` reads to send the frame's swap signal--so any frame with a second list queued behind it lost that signal, and the tick parked on `sMesgQueue2` forever. Hardware has a real gap between the two, since they come from separate chips. `RenderTask` draws the whole list in one call, so both are idle when it returns and the order is ours to pick. DP first.

All 108 watchdog snapshots agree: tick on `sMesgQueue2`, pipeline drained, `sUnkFlag2=0x2/saved=0x2`. The flag was reset, so DP ran. No signal was sent, and the only other writer is a list start. 7 freezes across 6 maps and 3 builds, one with no mod loaded.

Resolves #562

<!--- section:artifacts:start -->
### Build Artifacts
  - [Lighthouse-windows.zip](https://nightly.link/HarbourMasters/Lighthouse/actions/artifacts/9739111364.zip)
  - [Lighthouse-linux.zip](https://nightly.link/HarbourMasters/Lighthouse/actions/artifacts/9738950024.zip)
  - [Lighthouse-mac.zip](https://nightly.link/HarbourMasters/Lighthouse/actions/artifacts/9738772323.zip)
<!--- section:artifacts:end -->