### PR TITLE
Add Always Update Actors option

### DIFF
--- a/src/CCW/ch/snarebear.c
+++ b/src/CCW/ch/snarebear.c
@@ -2,6 +2,7 @@
 #include <ultra64.h>
 #include "functions.h"
 #include "variables.h"
+#include "port/Enhancements/Events/Hooks/Events.h"
 
 
 void chSnarebear_update(Actor *this);
@@ -64,7 +65,7 @@ void chSnarebear_update(Actor *this) {
 
     time_delta = time_getDelta();
 
-    if(!subaddie_playerIsWithinSphere(this, 3000)) return;
+    if (!EventSystem_Should(VB_ACTOR_UPDATE_DISTANCE, subaddie_playerIsWithinSphere(this, 3000))) return;
 
     if (!this->volatile_initialized) {
         this->volatile_initialized = true;

--- a/src/FP/ch/boggyraceflag1.c
+++ b/src/FP/ch/boggyraceflag1.c
@@ -2,6 +2,7 @@
 #include <ultra64.h>
 #include "functions.h"
 #include "variables.h"
+#include "port/Enhancements/Events/Hooks/Events.h"
 
 typedef struct {
     u8 unk0;
@@ -128,7 +129,9 @@ void func_803881AC(Actor *this){
         if(0.0f == this->velocity_x)
             return;
     }else{
-        if(!subaddie_playerIsWithinSphereAndActive(this, 2000) && !maSlolam_WithinRadiusOfBoggy(this->position, 2000))
+        if(!EventSystem_Should(VB_ACTOR_UPDATE_DISTANCE,
+                               subaddie_playerIsWithinSphereAndActive(this, 2000)
+                                   || maSlolam_WithinRadiusOfBoggy(this->position, 2000)))
             return;
         this->marker->collidable = true;
         this->unk124_6 = true;

--- a/src/FP/ch/boggyraceflag2.c
+++ b/src/FP/ch/boggyraceflag2.c
@@ -2,6 +2,7 @@
 #include <ultra64.h>
 #include "functions.h"
 #include "variables.h"
+#include "port/Enhancements/Events/Hooks/Events.h"
 
 extern void func_803289EC(Actor *, f32, s32);
 extern void func_8028E668(f32[3], f32, f32, f32);
@@ -71,7 +72,9 @@ void func_80388584(Actor *this){
         }
     }
     else{//L80388694
-        if(!subaddie_playerIsWithinSphereAndActive(this, 2000)&& !maSlolam_WithinRadiusOfBoggy(this->position, 2000))
+        if(!EventSystem_Should(VB_ACTOR_UPDATE_DISTANCE,
+                               subaddie_playerIsWithinSphereAndActive(this, 2000)
+                                   || maSlolam_WithinRadiusOfBoggy(this->position, 2000)))
             return;
         this->marker->collidable = true;
         this->unk124_6 = true;

--- a/src/FP/ch/twinklybox.c
+++ b/src/FP/ch/twinklybox.c
@@ -324,7 +324,11 @@ void chTwinklyBox_update(Actor *this){
     switch (this->state)
     {
     case 1: //L8038D89C
-        if(!subaddie_playerIsWithinSphereAndActive(this, 800))
+        // Doesn't restart idle animation when finishing the minigame.
+        if(EventSystem_Should(VB_ACTOR_UPDATE_DISTANCE, false) && this->velocity[1] != 0.0f)
+            break;
+
+        if(!EventSystem_Should(VB_ACTOR_UPDATE_DISTANCE, subaddie_playerIsWithinSphereAndActive(this, 800)))
             break;
 
         if(!(globalTimer_getTime() & 1))
@@ -389,6 +393,7 @@ void chTwinklyBox_update(Actor *this){
 
         func_8025AEA0(COMUSIC_68_TWINKLY_MINIGAME, (s32)this->unk1C[2]);
         if(item_getCount(ITEM_24_TWINKLY_SCORE) == 0){
+            this->velocity[1] = 1.0f;
             subaddie_set_state_with_direction(this, 1, 0.001f, 1);
             coMusicPlayer_playMusic(COMUSIC_2D_PUZZLE_SOLVED_FANFARE, 28000);
             func_8038D3D8();

--- a/src/FP/ch/wozzasjig.c
+++ b/src/FP/ch/wozzasjig.c
@@ -2,6 +2,7 @@
 #include <ultra64.h>
 #include "functions.h"
 #include "variables.h"
+#include "port/Enhancements/Events/Hooks/Events.h"
 
 Actor *chWozzaJiggy_draw(ActorMarker *marker, Gfx **gfx, Mtx **mtx, Vtx **vtx);
 void chWozzaJiggy_update(Actor *this);
@@ -44,7 +45,7 @@ void chWozzaJiggy_update(Actor *this){
     ParticleEmitter *sp3C;
 
     if( maSlalom_isActive() )               return;
-    if( !subaddie_playerIsWithinSphere(this, 4500) )    return;
+    if (!EventSystem_Should(VB_ACTOR_UPDATE_DISTANCE, subaddie_playerIsWithinSphere(this, 4500))) return;
 
     this->marker->propPtr->unk8_3 = false;
     actor_collisionOff(this);

--- a/src/GV/ch/grabba.c
+++ b/src/GV/ch/grabba.c
@@ -2,6 +2,7 @@
 #include <ultra64.h>
 #include "functions.h"
 #include "variables.h"
+#include "port/Enhancements/Events/Hooks/Events.h"
 
 extern void func_8025AE50(s32, f32);
 
@@ -188,7 +189,7 @@ void chGrabba_update(Actor *this){
         this->marker->propPtr->unk8_3 = false;
     }//L8038BFF4
 
-    if(subaddie_playerIsWithinSphere(this, 4000) || this->state == 5){
+    if(EventSystem_Should(VB_ACTOR_UPDATE_DISTANCE, subaddie_playerIsWithinSphere(this, 4000)) || this->state == 5){
         this->unk58_0 = true;
         this->marker->propPtr->unk8_3 = true;
         switch(this->state){

--- a/src/GV/ch/slappa.c
+++ b/src/GV/ch/slappa.c
@@ -2,6 +2,7 @@
 #include <ultra64.h>
 #include "functions.h"
 #include "variables.h"
+#include "port/Enhancements/Events/Hooks/Events.h"
 
 void chSlappa_update(Actor *this);
 
@@ -174,7 +175,7 @@ void chSlappa_update(Actor *this){
         }
     }//L8038B25C
 
-    if(!subaddie_playerIsWithinSphere(this, 4500)) return;
+    if (!EventSystem_Should(VB_ACTOR_UPDATE_DISTANCE, subaddie_playerIsWithinSphere(this, 4500))) return;
 
     this->unk58_0 = true;
     switch(this->state){

--- a/src/MM/ch/conga.c
+++ b/src/MM/ch/conga.c
@@ -3,6 +3,7 @@
 #include "rand.h"
 #include "functions.h"
 #include "variables.h"
+#include "port/Enhancements/Events/Hooks/Events.h"
 #include <math.h>
 
 #include "bk_math.h" // [port] SQ macro
@@ -218,6 +219,9 @@ void chConga_update(Actor *this) {
     f32 unused;
     NodeProp *node_prop;
     s32 sp3C;
+    bool playerWithinUpdateRadius;
+    bool shouldUpdateForDistance;
+    bool distanceOverrideActive;
 
     this->marker->propPtr->unk8_3 = timedFuncQueue_is_empty() ? 1 : 0; // [port] def takes no args
 
@@ -245,7 +249,12 @@ void chConga_update(Actor *this) {
 
     marker_setCollisionScripts(this->marker, NULL, NULL, func_80387168);
 
-    if (!subaddie_playerIsWithinSphereAndActive(this, 2100)
+    playerWithinUpdateRadius = subaddie_playerIsWithinSphereAndActive(this, 2100);
+    shouldUpdateForDistance = EventSystem_Should(VB_ACTOR_UPDATE_DISTANCE, playerWithinUpdateRadius);
+    distanceOverrideActive = shouldUpdateForDistance && !playerWithinUpdateRadius
+                             && this->state != 2 && this->state != 8;
+
+    if (!playerWithinUpdateRadius
         && this->state != 2
         && this->state != 8) {
 
@@ -254,7 +263,9 @@ void chConga_update(Actor *this) {
             subaddie_set_state_with_direction(this, 1, 0.76f, 1);
         }
 
-        return;
+        if (!shouldUpdateForDistance) {
+            return;
+        }
     }
 
     sp3C = subaddie_playerIsWithinSphereAndActive(this, 1000);
@@ -275,8 +286,10 @@ void chConga_update(Actor *this) {
     switch (this->state) {
         case CONGA_STATE_IDLE://80387990
             actor_loopAnimation(this);
-            func_80386FB0(this);
-            __chConga_playRandomNoise();
+            if (!distanceOverrideActive) {
+                func_80386FB0(this);
+                __chConga_playRandomNoise();
+            }
 
             if(actor_animationIsAt(this, 0.0f) || actor_animationIsAt(this, 0.45f)){
                 if(randf() < 0.2){
@@ -310,7 +323,9 @@ void chConga_update(Actor *this) {
         case CONGA_STATE_BEAT_CHEST_STOP: //L80387B24
             ((ActorLocal_Conga *)&this->local)->unkC = 1;
             actor_playAnimationOnce(this);
-            __chConga_playRandomNoise();
+            if (!distanceOverrideActive) {
+                __chConga_playRandomNoise();
+            }
 
             if (anctrl_isPlayedForwards(this->anctrl) == TRUE
                 && actor_animationIsAt(this, 0.0f)) {
@@ -326,25 +341,30 @@ void chConga_update(Actor *this) {
         case CONGA_STATE_BEAT_CHEST: //L80387BC0
             ((ActorLocal_Conga *)&this->local)->unkC = 1;
             actor_loopAnimation(this);
-            __chConga_playRandomNoise();
+            if (!distanceOverrideActive) {
+                __chConga_playRandomNoise();
+            }
 
             if (actor_animationIsAt(this, 0.99f)) {
                 subaddie_maybe_set_state_position_direction(this, CONGA_STATE_BEAT_CHEST_STOP, 0.999f, 0, sp3C ? 1.0 : 0.4);
             }//L80387C30
 
-            if (actor_animationIsAt(this, 0.9f)
-                || actor_animationIsAt(this, 0.4f)) {
+            if (!distanceOverrideActive
+                && (actor_animationIsAt(this, 0.9f)
+                    || actor_animationIsAt(this, 0.4f))) {
                 func_8030E6D4(SFX_3FB_UNKNOWN);
             }
 
             break;
 
         case CONGA_STATE_TARGET_GROUND: //L80387C74
-            if (actor_animationIsAt(this, 0.6f)) {
+            if (!distanceOverrideActive && actor_animationIsAt(this, 0.6f)) {
                 func_8030E58C(SFX_2_CLAW_SWIPE, 0.7f);
             }
 
-            func_80386FB0(this);
+            if (!distanceOverrideActive) {
+                func_80386FB0(this);
+            }
 
             if (!sp3C
                 || player_is_in_jiggy_jig()

--- a/src/MM/ch/conga.c
+++ b/src/MM/ch/conga.c
@@ -3,7 +3,6 @@
 #include "rand.h"
 #include "functions.h"
 #include "variables.h"
-#include "port/Enhancements/Events/Hooks/Events.h"
 #include <math.h>
 
 #include "bk_math.h" // [port] SQ macro
@@ -219,9 +218,6 @@ void chConga_update(Actor *this) {
     f32 unused;
     NodeProp *node_prop;
     s32 sp3C;
-    bool playerWithinUpdateRadius;
-    bool shouldUpdateForDistance;
-    bool distanceOverrideActive;
 
     this->marker->propPtr->unk8_3 = timedFuncQueue_is_empty() ? 1 : 0; // [port] def takes no args
 
@@ -249,12 +245,7 @@ void chConga_update(Actor *this) {
 
     marker_setCollisionScripts(this->marker, NULL, NULL, func_80387168);
 
-    playerWithinUpdateRadius = subaddie_playerIsWithinSphereAndActive(this, 2100);
-    shouldUpdateForDistance = EventSystem_Should(VB_ACTOR_UPDATE_DISTANCE, playerWithinUpdateRadius);
-    distanceOverrideActive = shouldUpdateForDistance && !playerWithinUpdateRadius
-                             && this->state != 2 && this->state != 8;
-
-    if (!playerWithinUpdateRadius
+    if (!subaddie_playerIsWithinSphereAndActive(this, 2100)
         && this->state != 2
         && this->state != 8) {
 
@@ -263,9 +254,7 @@ void chConga_update(Actor *this) {
             subaddie_set_state_with_direction(this, 1, 0.76f, 1);
         }
 
-        if (!shouldUpdateForDistance) {
-            return;
-        }
+        return;
     }
 
     sp3C = subaddie_playerIsWithinSphereAndActive(this, 1000);
@@ -286,10 +275,8 @@ void chConga_update(Actor *this) {
     switch (this->state) {
         case CONGA_STATE_IDLE://80387990
             actor_loopAnimation(this);
-            if (!distanceOverrideActive) {
-                func_80386FB0(this);
-                __chConga_playRandomNoise();
-            }
+            func_80386FB0(this);
+            __chConga_playRandomNoise();
 
             if(actor_animationIsAt(this, 0.0f) || actor_animationIsAt(this, 0.45f)){
                 if(randf() < 0.2){
@@ -323,9 +310,7 @@ void chConga_update(Actor *this) {
         case CONGA_STATE_BEAT_CHEST_STOP: //L80387B24
             ((ActorLocal_Conga *)&this->local)->unkC = 1;
             actor_playAnimationOnce(this);
-            if (!distanceOverrideActive) {
-                __chConga_playRandomNoise();
-            }
+            __chConga_playRandomNoise();
 
             if (anctrl_isPlayedForwards(this->anctrl) == TRUE
                 && actor_animationIsAt(this, 0.0f)) {
@@ -341,30 +326,25 @@ void chConga_update(Actor *this) {
         case CONGA_STATE_BEAT_CHEST: //L80387BC0
             ((ActorLocal_Conga *)&this->local)->unkC = 1;
             actor_loopAnimation(this);
-            if (!distanceOverrideActive) {
-                __chConga_playRandomNoise();
-            }
+            __chConga_playRandomNoise();
 
             if (actor_animationIsAt(this, 0.99f)) {
                 subaddie_maybe_set_state_position_direction(this, CONGA_STATE_BEAT_CHEST_STOP, 0.999f, 0, sp3C ? 1.0 : 0.4);
             }//L80387C30
 
-            if (!distanceOverrideActive
-                && (actor_animationIsAt(this, 0.9f)
-                    || actor_animationIsAt(this, 0.4f))) {
+            if (actor_animationIsAt(this, 0.9f)
+                || actor_animationIsAt(this, 0.4f)) {
                 func_8030E6D4(SFX_3FB_UNKNOWN);
             }
 
             break;
 
         case CONGA_STATE_TARGET_GROUND: //L80387C74
-            if (!distanceOverrideActive && actor_animationIsAt(this, 0.6f)) {
+            if (actor_animationIsAt(this, 0.6f)) {
                 func_8030E58C(SFX_2_CLAW_SWIPE, 0.7f);
             }
 
-            if (!distanceOverrideActive) {
-                func_80386FB0(this);
-            }
+            func_80386FB0(this);
 
             if (!sp3C
                 || player_is_in_jiggy_jig()

--- a/src/TTC/ch/blubber.c
+++ b/src/TTC/ch/blubber.c
@@ -2,6 +2,7 @@
 #include <ultra64.h>
 #include "functions.h"
 #include "variables.h"
+#include "port/Enhancements/Events/Hooks/Events.h"
 
 #include "port/Patches/Patches.h"
 #include "port/Enhancements/Retention/Retention.h"
@@ -175,7 +176,8 @@ static void __chBlubber_updateFunc(Actor *this){
         local->unk24 = 0;
     }
 
-    if(!mapSpecificFlags_get(TTC_SPECIFIC_FLAG_1_UNKNOWN) && !subaddie_playerIsWithinSphereAndActive(this, 2500))
+    if(!mapSpecificFlags_get(TTC_SPECIFIC_FLAG_1_UNKNOWN)
+       && !EventSystem_Should(VB_ACTOR_UPDATE_DISTANCE, subaddie_playerIsWithinSphereAndActive(this, 2500)))
         return;
     
     if(!this->volatile_initialized){

--- a/src/core2/actor_array.c
+++ b/src/core2/actor_array.c
@@ -3,6 +3,7 @@
 #include "core1/core1.h"
 #include "functions.h"
 #include "variables.h"
+#include "port/Enhancements/Events/Hooks/Events.h"
 #include "port/Patches/Patches.h"
 #include "actor.h"
 
@@ -584,7 +585,8 @@ void func_803268B4(void) {
                         if (anim_ctrl != NULL) {
                                 actor->sound_timer = anctrl_getAnimTimer(anim_ctrl);
                         }
-                    } else if (!temp_s1 || (temp_s1 && func_803296D8(actor, temp_s1))) {
+                    } else if (EventSystem_Should(VB_ACTOR_UPDATE_DISTANCE,
+                                                  !temp_s1 || func_803296D8(actor, temp_s1))) {
                         if ( marker->actorUpdateFunc != NULL) {
                              marker->actorUpdateFunc(actor);
                             actor = &suBaddieActorArray->data[temp_v1]; // [port] re-fetch: see above

--- a/src/core2/ch/beeswarm.c
+++ b/src/core2/ch/beeswarm.c
@@ -1,6 +1,7 @@
 #include <ultra64.h>
 #include "functions.h"
 #include "variables.h"
+#include "port/Enhancements/Events/Hooks/Events.h"
 #include "port/Interpolation/FrameInterpolation.h"
 
 extern void func_8030DBFC(u32, f32, f32, f32);
@@ -382,7 +383,7 @@ void chBeeSwarm_update(Actor *this) {
         this->unk38_0 = volatileFlag_get(VOLATILE_FLAG_1) | volatileFlag_get(VOLATILE_FLAG_1F_IN_CHARACTER_PARADE);
     }
 
-    if (!subaddie_playerIsWithinSphere(this, 0xFA0)) 
+    if (!EventSystem_Should(VB_ACTOR_UPDATE_DISTANCE, subaddie_playerIsWithinSphere(this, 0xFA0)))
         return;
     if (!subaddie_playerIsWithinSphere(this, 0x5DC)) {
         if ((u8)this->unk44_31 != 0) {

--- a/src/core2/ch/icecube.c
+++ b/src/core2/ch/icecube.c
@@ -1,6 +1,7 @@
 #include <ultra64.h>
 #include "functions.h"
 #include "variables.h"
+#include "port/Enhancements/Events/Hooks/Events.h"
 
 #define _HorzDist3v(v1, v2) ((v1[0]-v2[0])*(v1[0]-v2[0]) + (v1[2]-v2[2])*(v1[2]-v2[2]))
 extern void func_802D729C(Actor *, f32);
@@ -262,7 +263,7 @@ void chicecube_update(Actor *this){
         this->unk58_0 = true;
     }//L8035AAF4
     
-    if(!subaddie_playerIsWithinSphere(this, 3000))
+    if (!EventSystem_Should(VB_ACTOR_UPDATE_DISTANCE, subaddie_playerIsWithinSphere(this, 3000)))
         return;
 
     func_802D729C(this, 3.4 * this->scale);

--- a/src/core2/ch/snowman.c
+++ b/src/core2/ch/snowman.c
@@ -1,6 +1,7 @@
 #include <ultra64.h>
 #include "functions.h"
 #include "variables.h"
+#include "port/Enhancements/Events/Hooks/Events.h"
 
 #include "port/Patches/Patches.h"
 
@@ -210,6 +211,8 @@ int __chSnowman_CCW_playerInProtectedZone(void){
 void chSnowman_update(Actor *this){
     ActorLocal_chSirSlush *local = (ActorLocal_chSirSlush *) &this->local;
     f32 dt;
+    bool playerWithinActiveRadius;
+    bool shouldStayActive;
 
 
     dt = time_getDelta();
@@ -255,7 +258,7 @@ void chSnowman_update(Actor *this){
 
         }
     }//L802E223C
-    if(!subaddie_playerIsWithinSphere(this, 4000))
+    if (!EventSystem_Should(VB_ACTOR_UPDATE_DISTANCE, subaddie_playerIsWithinSphere(this, 4000)))
         return;
 
     if(!local->unkB && this->marker->unk14_21){
@@ -265,8 +268,12 @@ void chSnowman_update(Actor *this){
         case CHSNOWMAN_STATE_1_IDLE://L802E22B0
             local->unk9 = false;
             local->unkA = 1;
-            __chSnowman_setYawTarget(this, 6.0f);
-            if(!subaddie_playerIsWithinSphereAndActive(this, 3150)){
+            playerWithinActiveRadius = subaddie_playerIsWithinSphereAndActive(this, 3150);
+            shouldStayActive = EventSystem_Should(VB_ACTOR_UPDATE_DISTANCE, playerWithinActiveRadius);
+            if (playerWithinActiveRadius || !shouldStayActive) {
+                __chSnowman_setYawTarget(this, 6.0f);
+            }
+            if (!shouldStayActive) {
                 __chSnowman_enterDeath(this);
             }
             else if( 
@@ -294,7 +301,9 @@ void chSnowman_update(Actor *this){
             }
             break;
         case CHSNOWMAN_STATE_2_ATTACK://L802E23E8
-            if(!subaddie_playerIsWithinSphereAndActive(this, 3150)){
+            playerWithinActiveRadius = subaddie_playerIsWithinSphereAndActive(this, 3150);
+            shouldStayActive = EventSystem_Should(VB_ACTOR_UPDATE_DISTANCE, playerWithinActiveRadius);
+            if (!shouldStayActive) {
                 __chSnowman_enterDeath(this);
             }//L802E240C
             else if( 
@@ -334,7 +343,9 @@ void chSnowman_update(Actor *this){
             }
             break;
         case CHSNOWMAN_STATE_3_DIE://L802E2604
-            if(subaddie_playerIsWithinSphereAndActive(this, 3150)){
+            playerWithinActiveRadius = subaddie_playerIsWithinSphereAndActive(this, 3150);
+            shouldStayActive = EventSystem_Should(VB_ACTOR_UPDATE_DISTANCE, playerWithinActiveRadius);
+            if (shouldStayActive) {
                 __chSnowman_enterIdle(this);
             }
             break;

--- a/src/core2/ch/trainers.c
+++ b/src/core2/ch/trainers.c
@@ -1,6 +1,7 @@
 #include <ultra64.h>
 #include "functions.h"
 #include "variables.h"
+#include "port/Enhancements/Events/Hooks/Events.h"
 
 #include "core2/statetimer.h"
 extern f32 player_stateTimer_get(enum state_timer_e);
@@ -77,7 +78,7 @@ void chtrainers_update(Actor *this){
 
     switch(this->state){
         case 0://L802CA5A8
-            if(func_803296D8(this, 2000) || sp2C){
+            if(EventSystem_Should(VB_ACTOR_UPDATE_DISTANCE, func_803296D8(this, 2000)) || sp2C){
                 if( subaddie_playerIsWithinSphereAndActive(this, 0xfa)
                     && !volatileFlag_get(VOLATILE_FLAG_F_HAS_MEET_TURBO_SHOES)
                     && player_getTransformation() == TRANSFORM_1_BANJO

--- a/src/core2/collision/scarabbeetle.c
+++ b/src/core2/collision/scarabbeetle.c
@@ -2,6 +2,7 @@
 #include <ultra64.h>
 #include "functions.h"
 #include "variables.h"
+#include "port/Enhancements/Events/Hooks/Events.h"
 
 extern BKCollisionTriangle *func_80320DB0(f32[3], f32, f32[3], u32);
 
@@ -303,7 +304,7 @@ void chScarabBeetle_update(Actor *this) {
         func_80357F0C(this, 1);
     }
 
-    if (!subaddie_playerIsWithinSphere(this, 4000)) {
+    if (!EventSystem_Should(VB_ACTOR_UPDATE_DISTANCE, subaddie_playerIsWithinSphere(this, 4000))) {
         if (local->sfxsourceIdx != 0) {
             sfxsource_freeSfxsourceByIndex(local->sfxsourceIdx);
             local->sfxsourceIdx = 0U;

--- a/src/port/Enhancements/Events/Hooks/Events.h
+++ b/src/port/Enhancements/Events/Hooks/Events.h
@@ -45,6 +45,7 @@ typedef enum VBehaviorID {
 
     // Gameplay options and cheats
     VB_DISABLE_SNACKER,
+    VB_ACTOR_UPDATE_DISTANCE, // Proximity gate that skips an actor's normal update work.
     VB_SAVE_AND_EXIT,
     VB_MUMBO_DETRANSFORM,
 

--- a/src/port/Enhancements/Gameplay/AlwaysUpdateActors.cpp
+++ b/src/port/Enhancements/Gameplay/AlwaysUpdateActors.cpp
@@ -1,0 +1,26 @@
+#include <libultraship/bridge.h>
+
+#include "port/Enhancements/Events/Hooks/Events.h"
+#include "port/ShipInit.hpp"
+#include "port/UI/cvar_prefixes.h"
+
+extern "C" {
+#include "enums.h"
+#include "functions.h"
+}
+
+#define CVAR_ALWAYS_UPDATE_ACTORS CVAR_ENHANCEMENT("Graphics.AlwaysUpdateActors")
+
+static bool IsActorUpdatePlaybackMode() {
+    return getGameMode() == GAME_MODE_2_UNKNOWN || func_802E4A08();
+}
+
+static void RegisterAlwaysUpdateActors_Init() {
+    COND_VB_SHOULD(VB_ACTOR_UPDATE_DISTANCE, EVENT_PRIORITY_NORMAL, CVarGetInteger(CVAR_ALWAYS_UPDATE_ACTORS, 0), {
+        if (!IsActorUpdatePlaybackMode()) {
+            *should = true;
+        }
+    });
+}
+
+static RegisterShipInitFunc sInitAlwaysUpdateActors(RegisterAlwaysUpdateActors_Init, { CVAR_ALWAYS_UPDATE_ACTORS });

--- a/src/port/UI/LighthouseMenuEnhancements.cpp
+++ b/src/port/UI/LighthouseMenuEnhancements.cpp
@@ -130,6 +130,12 @@ void LighthouseMenu::AddMenuEnhancements() {
         .RaceDisable(false)
         .Options(CheckboxOptions().Tooltip("Forces maximum model detail everywhere."));
 
+    AddWidget(path, "Always Update Actors", WIDGET_CVAR_CHECKBOX)
+        .CVar(CVAR_ENHANCEMENT("Graphics.AlwaysUpdateActors"))
+        .Options(CheckboxOptions().Tooltip(
+            "Keeps supported loaded actors updating beyond their usual update distance without changing normal "
+            "interaction ranges. May cost performance when enabled."));
+
     AddWidget(path, "Original Aspect Ratio In Cutscenes", WIDGET_CVAR_CHECKBOX)
         .CVar(CVAR_ENHANCEMENT("Graphics.CutsceneAspect"))
         .Options(CheckboxOptions().Tooltip("Forces game to show original aspect ratio during cutscenes to avoid seeing "


### PR DESCRIPTION
### Summary

* Adds an **"Always Update Actors"** graphics option.
* Keeps supported loaded actors updating beyond their usual update-distance gates when the option is enabled.
* Keeps some specific gameplay checks unchanged and disables this option during a demo so they don't desync.
* Adds object-specific changes so they don't break when far away.
* Includes a warning that always updating more actors may affect performance.

### AI Use

AI was used in development, debugging, and build verification. I manually tested and published this PR.

<!--- section:artifacts:start -->
### Build Artifacts
  - [Lighthouse-windows.zip](https://nightly.link/HarbourMasters/Lighthouse/actions/artifacts/9774882744.zip)
  - [Lighthouse-linux.zip](https://nightly.link/HarbourMasters/Lighthouse/actions/artifacts/9774548853.zip)
  - [Lighthouse-mac.zip](https://nightly.link/HarbourMasters/Lighthouse/actions/artifacts/9774363319.zip)
<!--- section:artifacts:end -->