### PR TITLE
Send note and jinjo retention in Anchor team state

### DIFF
--- a/src/port/Enhancements/Retention/JinjoRetention.cpp
+++ b/src/port/Enhancements/Retention/JinjoRetention.cpp
@@ -187,6 +187,18 @@ static bool retentionActiveForLevel(int32_t level) {
     return true;
 }
 
+// Unlike the entry seed this also corrects downward: after a sync the bitfield is the team's truth.
+extern "C" void port_jinjoRetention_requestReseed(void) {
+    if (!systemActive() || !applyEnabled()) {
+        return;
+    }
+    const int32_t level = (int32_t)level_get();
+    if (!retentionActiveForLevel(level)) {
+        return;
+    }
+    item_adjustByDiffWithoutHud(ITEM_12_JINJOS, collectedBits(level) - item_getCount(ITEM_12_JINJOS));
+}
+
 void RegisterJinjoRetention_Init() {
     // Seed ITEM_12_JINJOS from saved bits on entry.
     COND_HOOK(OnSetJiggyList, EVENT_PRIORITY_NORMAL, CVAR_VALUE, [](IEvent* event) {

--- a/src/port/Enhancements/Retention/NoteRetention.cpp
+++ b/src/port/Enhancements/Retention/NoteRetention.cpp
@@ -241,6 +241,15 @@ extern "C" void port_noteRetention_onActorsFreed(void) {
     noteActorQueue.clear();
 }
 
+// Queue the same deferred reseed a level entry uses; it waits for normal play, so it can't fire
+// mid-transition or in the pause menu.
+extern "C" void port_noteRetention_requestReseed(void) {
+    if (!systemActive() || !applyEnabled()) {
+        return;
+    }
+    sPendingSeedLevel = (int32_t)level_get();
+}
+
 extern "C" void port_noteRetention_setForced(int32_t forced) {
     sForcedByAnchor = forced != 0;
     ShipInit::Init(CVAR_NOTE_RETENTION);

--- a/src/port/Enhancements/Retention/Retention.h
+++ b/src/port/Enhancements/Retention/Retention.h
@@ -17,6 +17,10 @@ void port_noteRetention_onActorsFreed(void);
 // Live slot's note-retention bytes for Anchor team-state sync (size 0 / null if no slot).
 void port_noteRetention_getSizeAndPtr(int32_t* size, uint8_t** addr);
 
+// Recompute the live note counter from the bitfield, deferred to normal play. Call after anything
+// overwrites the bitfield wholesale (team-state sync).
+void port_noteRetention_requestReseed(void);
+
 void port_noteRetention_applyRemoteCollect(int32_t mapId, int32_t noteIndex, int32_t sameMap);
 
 // Record + broadcast a local note pickup (marker is ActorMarker*, void* to avoid engine types).
@@ -29,6 +33,9 @@ void port_noteRetention_setForced(int32_t forced);
 
 // Live slot's jinjo-retention bytes for Anchor team-state sync (size 0 / null if no slot).
 void port_jinjoRetention_getSizeAndPtr(int32_t* size, uint8_t** addr);
+
+// Same as the note variant, for ITEM_12_JINJOS.
+void port_jinjoRetention_requestReseed(void);
 
 void port_jinjoRetention_applyRemoteCollect(int32_t map, int32_t bit, int32_t sameMap);
 

--- a/src/port/Network/Anchor/Packets/UpdateTeamState.cpp
+++ b/src/port/Network/Anchor/Packets/UpdateTeamState.cpp
@@ -67,6 +67,9 @@ void Anchor::SendPacket_UpdateTeamState() {
     timeScores_getSizeAndPtr(&tsSize, &tsAddr);
     payload["state"]["timeScores"] = std::vector<u8>((u8*)tsAddr, (u8*)tsAddr + tsSize);
     payload["state"]["volatileFlags"] = ScoreBytes(volatileFlag_getSizeAndPtr);
+    // Per-level retention bitfields; the receiver rebuilds its counters from these.
+    payload["state"]["noteRetention"] = ScoreBytes(port_noteRetention_getSizeAndPtr);
+    payload["state"]["jinjoRetention"] = ScoreBytes(port_jinjoRetention_getSizeAndPtr);
     // In-memory session sets (never saved).
     payload["state"]["brokenObjects"] = port_breakable_snapshotBroken();
     payload["state"]["carriedCollected"] = port_carriedSync_snapshotCollected();
@@ -143,12 +146,15 @@ void Anchor::HandlePacket_UpdateTeamState(nlohmann::json& payload) {
         if (state.contains("noteScores")) {
             ApplyTeamBytes(state["noteScores"], itemscore_noteScores_getSizeAndPtr);
         }
-        // Per-level retention sets; takes effect on next map load.
+        // Per-level retention sets. The live ITEM_C_NOTE / ITEM_12_JINJOS counters are derived from
+        // these and only seeded on level entry, so reseed them or a mid-level sync shows stale counts.
         if (state.contains("noteRetention")) {
             ApplyTeamBytes(state["noteRetention"], port_noteRetention_getSizeAndPtr);
+            port_noteRetention_requestReseed();
         }
         if (state.contains("jinjoRetention")) {
             ApplyTeamBytes(state["jinjoRetention"], port_jinjoRetention_getSizeAndPtr);
+            port_jinjoRetention_requestReseed();
         }
         if (state.contains("abilities")) {
             ApplyTeamBytes(state["abilities"], ability_getSizeAndPtr);


### PR DESCRIPTION
`HandlePacket_UpdateTeamState` applies `noteRetention` and `jinjoRetention` when they arrive, but `SendPacket_UpdateTeamState` never included them, so no client ever received the team's per-level note and jinjo bitfields.

Credit: found in D4ead3ye's Wii U fork (commits f40f1d44, 7193aa8d).

<!--- section:artifacts:start -->
### Build Artifacts
  - [Lighthouse-windows.zip](https://nightly.link/HarbourMasters/Lighthouse/actions/artifacts/10104726704.zip)
  - [Lighthouse-linux.zip](https://nightly.link/HarbourMasters/Lighthouse/actions/artifacts/10104233449.zip)
  - [Lighthouse-mac.zip](https://nightly.link/HarbourMasters/Lighthouse/actions/artifacts/10103661915.zip)
<!--- section:artifacts:end -->