### PR TITLE
Stop the Anchor receive thread from busy-spinning

### DIFF
--- a/src/port/Network/Network.cpp
+++ b/src/port/Network/Network.cpp
@@ -87,8 +87,8 @@ void Network::ReceiveFromServer() {
         // Listen to socket messages
         while (isConnected && networkSocket && isEnabled) {
             // Check for data first so TCP_Recv never blocks.
-            static constexpr int kPollTimeoutMs = 16;
-            int socketsReady = SDLNet_CheckSockets(socketSet, kPollTimeoutMs);
+            // Must be > 0 or thread returns immediately and spins forever.
+            int socketsReady = SDLNet_CheckSockets(socketSet, 16);
 
             if (socketsReady == -1) {
                 SPDLOG_ERROR("[Network] SDLNet_CheckSockets: {}", SDLNet_GetError());

--- a/src/port/Network/Network.cpp
+++ b/src/port/Network/Network.cpp
@@ -86,8 +86,9 @@ void Network::ReceiveFromServer() {
 
         // Listen to socket messages
         while (isConnected && networkSocket && isEnabled) {
-            // we check first if socket has data, to not block in the TCP_Recv
-            int socketsReady = SDLNet_CheckSockets(socketSet, 0);
+            // Check for data first so TCP_Recv never blocks.
+            static constexpr int kPollTimeoutMs = 16;
+            int socketsReady = SDLNet_CheckSockets(socketSet, kPollTimeoutMs);
 
             if (socketsReady == -1) {
                 SPDLOG_ERROR("[Network] SDLNet_CheckSockets: {}", SDLNet_GetError());


### PR DESCRIPTION
`ReceiveFromServer` polled `SDLNet_CheckSockets` with a zero timeout, which returns immediately. With no incoming data the loop hit continue and came straight back, so the receive thread pinned a core for the whole time Anchor was connected. Block with a 16 ms timeout instead. Outgoing packets are still processed every pass, so the only cost is up to one frame of added latency on sends.

Credit: D4ead3ye's Wii U fork, where the spin starved the main loop on a three-core console (commit bb27056a).

<!--- section:artifacts:start -->
### Build Artifacts
  - [Lighthouse-windows.zip](https://nightly.link/HarbourMasters/Lighthouse/actions/artifacts/10104853033.zip)
  - [Lighthouse-linux.zip](https://nightly.link/HarbourMasters/Lighthouse/actions/artifacts/10104334689.zip)
  - [Lighthouse-mac.zip](https://nightly.link/HarbourMasters/Lighthouse/actions/artifacts/10103843180.zip)
<!--- section:artifacts:end -->